### PR TITLE
fix(react_compiler): bail out on missing identifier nodes

### DIFF
--- a/crates/oxc_react_compiler/fixtures/preserve-memo-validation/error.bug-prune-non-escaping-scopes-named-function-expression-self-reference.tsx
+++ b/crates/oxc_react_compiler/fixtures/preserve-memo-validation/error.bug-prune-non-escaping-scopes-named-function-expression-self-reference.tsx
@@ -1,0 +1,49 @@
+// A named function expression can capture its own binding in a nested function.
+// PruneNonEscapingScopes does not create an identifier node for that binding, so
+// it must bail out with the same invariant as the TypeScript compiler instead of
+// continuing to PreserveManualMemo validation with inconsistent state.
+import { memo, useCallback } from 'react';
+
+type ObjectiveID = number;
+type LevelData = {
+  mapId: string;
+  next?: ReadonlyArray<LevelData | readonly [ObjectiveID, LevelData]>;
+};
+type Props = {
+  level: LevelData;
+  maps: ReadonlyMap<string, { name: string }>;
+  parentLevel?: LevelData;
+  updateLevel: (level: unknown) => void;
+};
+
+export default memo(function Level({ level, parentLevel, ...commonProps }: Props) {
+  const { maps, updateLevel } = commonProps;
+  const node = maps.get(level.mapId)!;
+
+  const updateObjective = useCallback(
+    (objectiveId: ObjectiveID | null) => {
+      if (parentLevel) {
+        updateLevel({
+          ...parentLevel,
+          next: [...(parentLevel.next || [])].map((entry) => {
+            const isArray = Array.isArray(entry);
+            const { mapId } = isArray ? entry[1] : entry;
+            // Only mutate if the level id matches.
+            if (mapId === level.mapId) {
+              return objectiveId != null ? [objectiveId, mapId] : mapId;
+            }
+            return isArray ? [entry[0], mapId] : mapId;
+          }),
+        });
+      }
+    },
+    [level.mapId, parentLevel, updateLevel],
+  );
+
+  return (
+    <>
+      {getMapName(node.name)}
+      {level.next?.map(() => <Level level={level} {...commonProps} />)}
+    </>
+  );
+});

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -356,6 +356,14 @@ pub fn invariant_expected_node_all_scopes() -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn invariant_expected_node_all_identifiers(id: usize) -> OxcDiagnostic {
+    diagnostic(
+        ErrorCategory::Invariant,
+        format!("Expected a node for all identifiers, none found for `{id}`"),
+    )
+}
+
+#[cold]
 pub fn invariant_there_should_at_least_one_operand() -> OxcDiagnostic {
     diagnostic(ErrorCategory::Invariant, "there should be at least one operand")
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -995,9 +995,7 @@ fn compute_memoized_identifiers(
         memoized: &mut FxHashSet<DeclarationId>,
     ) -> Result<bool, OxcDiagnostic> {
         let Some(&(level, _, _, _, seen)) = identifier_nodes.get(&id) else {
-            // Upstream raises an "Expected a node for all identifiers" invariant
-            // here; this port has always been lenient instead.
-            return Ok(false);
+            return Err(diagnostics::invariant_expected_node_all_identifiers(id.index()));
         };
         if seen {
             return Ok(identifier_nodes.get(&id).unwrap().1);

--- a/crates/oxc_react_compiler/tests/snapshots/preserve-memo-validation__error.bug-prune-non-escaping-scopes-named-function-expression-self-reference.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/preserve-memo-validation__error.bug-prune-non-escaping-scopes-named-function-expression-self-reference.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/preserve-memo-validation/error.bug-prune-non-escaping-scopes-named-function-expression-self-reference.tsx
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "Expected a node for all identifiers, none found for `0`", labels: [LabeledSpan { label: Some("Expected a node for all identifiers, none found for `0`"), span: Span { start: 681, end: 686 }, primary: true }], help: Some("Please report this internal React Compiler error to Oxc with a minimal reproduction"), note: Some("This is an internal React Compiler error; the component or hook was not optimized"), severity: Error, code: OxcCode { scope: Some("react-compiler"), number: Some("Invariant") }, url: Some("https://github.com/oxc-project/oxc/issues/new/choose") } }
+
+No changes.


### PR DESCRIPTION
Match upstream's catchable missing-identifier invariant in `PruneNonEscapingScopes`, preventing a later misleading `PreserveManualMemo` diagnostic.

AI-assisted and reviewed by the contributor.