### PR TITLE
fix(linter/eslint/no-use-before-define): run on JS, JSX files

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_use_before_define.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_use_before_define.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
-    context::{ContextHost, LintContext},
+    context::LintContext,
     rule::{DefaultRuleConfig, Rule},
 };
 
@@ -184,10 +184,6 @@ impl Rule for NoUseBeforeDefine {
             identifier.span,
             Some(ctx.scoping().symbol_span(symbol_id)),
         ));
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 
@@ -3050,4 +3046,16 @@ fn test_typescript_eslint() {
     Tester::new(NoUseBeforeDefine::NAME, NoUseBeforeDefine::PLUGIN, pass, fail)
         .with_snapshot_suffix("typescript-eslint")
         .test_and_snapshot();
+}
+
+#[test]
+fn test_javascript() {
+    use crate::tester::Tester;
+
+    let pass = vec!["const a = 1;"];
+    let fail = vec!["const a = b; const b = 1;"];
+
+    Tester::new(NoUseBeforeDefine::NAME, NoUseBeforeDefine::PLUGIN, pass, fail)
+        .change_rule_path_extension("js")
+        .test();
 }

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -140,7 +140,7 @@ eslint/no-unused-expressions                               |  24802
 eslint/no-unused-labels                                    |      7
 eslint/no-unused-private-class-members                     |      4
 eslint/no-unused-vars                                      |      7
-eslint/no-use-before-define                                | 104670
+eslint/no-use-before-define                                | 209565
 eslint/no-useless-assignment                               |      7
 eslint/no-useless-backreference                            |  64236
 eslint/no-useless-call                                     |  62606


### PR DESCRIPTION
Fixes #26113.

The rule was moved from the TypeScript plugin to the ESLint plugin in 79fc6d7e9f, but its TypeScript-only execution gate was retained. As a result, eslint/no-use-before-define never ran for JavaScript or JSX files.Remove the gate and add a JavaScript regression test for a temporal-dead-zone reference.