### PR TITLE
feat(codegen): handle print comment properly

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -69,7 +69,7 @@ function deserializeProgram(pos) {
       __proto__: NodeProto,
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       get comments() {
         comments === null && initComments();
         return comments;
@@ -83,8 +83,8 @@ function deserializeProgram(pos) {
       range: [0, end],
       parent: null,
     }),
-    body = (program.body = deserializeVecDirective(pos + 88));
-  body.push(...deserializeVecStatement(pos + 112));
+    body = (program.body = deserializeVecDirective(pos + 96));
+  body.push(...deserializeVecStatement(pos + 120));
   {
     let start;
     if (body.length > 0) {

--- a/apps/oxlint/src-js/generated/type_ids.ts
+++ b/apps/oxlint/src-js/generated/type_ids.ts
@@ -3,6 +3,7 @@
 
 /** Mapping from node type name to node type ID */
 export const NODE_TYPE_IDS_MAP = /* @__PURE__ */ new Map([
+  // Leaf nodes
   ["DebuggerStatement", 0],
   ["EmptyStatement", 1],
   ["Literal", 2],
@@ -30,6 +31,7 @@ export const NODE_TYPE_IDS_MAP = /* @__PURE__ */ new Map([
   ["TSUndefinedKeyword", 24],
   ["TSUnknownKeyword", 25],
   ["TSVoidKeyword", 26],
+  // Non-leaf nodes
   ["AccessorProperty", 27],
   ["ArrayExpression", 28],
   ["ArrayPattern", 29],
@@ -168,6 +170,7 @@ export const NODE_TYPE_IDS_MAP = /* @__PURE__ */ new Map([
   ["TSTypeQuery", 162],
   ["TSTypeReference", 163],
   ["TSUnionType", 164],
+  // CFG selectors
   ["onCodePathStart", 165],
   ["onCodePathEnd", 166],
   ["onCodePathSegmentStart", 167],

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -261,6 +261,7 @@ pub trait CompilerInterface {
         }
 
         builder
+            .with_build_comment_attachments(self.codegen_options().is_some())
             .with_check_syntax_error(self.check_semantic_error())
             .with_build_nodes(self.build_semantic_nodes())
             .build(program)

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -1,9 +1,12 @@
+use std::cell::Cell;
+
 use bitflags::bitflags;
 
-use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
+use oxc_allocator::{Allocator, Box, CloneIn, CloneInSemanticIds, Dummy, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, GetSpan, Span};
+use oxc_syntax::node::NodeId;
 
 /// Indicates a line or block comment.
 #[ast]
@@ -191,6 +194,122 @@ pub struct Comment {
     /// Content of the comment
     #[estree(skip)]
     pub content: CommentContent,
+}
+
+/// Position of a source comment relative to its semantic AST host.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub enum AttachedCommentPosition {
+    /// Print before the host node.
+    #[default]
+    Before = 0,
+    /// Print after the host node.
+    After = 1,
+    /// Print inside a childless host's delimiters.
+    Inside = 2,
+}
+
+/// A source comment assigned to an AST host by the semantic attachment pass.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct AttachedComment {
+    pub comment: Comment,
+    pub position: AttachedCommentPosition,
+    pub same_line: bool,
+    /// Whether ordinary node-boundary printing owns this comment.
+    pub node_owned: bool,
+    /// Whether the NodeId owner is exclusive, with no source-offset fallback.
+    pub node_exclusive: bool,
+}
+
+/// A compact range of comments owned by one AST host.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CommentAttachmentHost {
+    /// Semantic identity assigned before transforms mutate the AST.
+    pub node_id: NodeId,
+    /// Start of this host's range in the attachment comment buffer.
+    pub start: u32,
+    /// Number of comments in this host's range.
+    pub len: u32,
+}
+
+/// Post-parse comment ownership sidecar.
+#[derive(Debug)]
+pub struct CommentAttachments<'a> {
+    hosts: Vec<'a, Cell<CommentAttachmentHost>>,
+    comments: Vec<'a, Cell<AttachedComment>>,
+    host_len: Cell<u32>,
+}
+
+/// Optional arena-owned comment attachment table.
+#[derive(Debug, Default)]
+pub struct CommentAttachmentsStore<'a>(pub Option<Box<'a, CommentAttachments<'a>>>);
+
+/// Dummy type communicating [`CommentAttachmentsStore`] to `oxc_ast_tools`.
+#[ast(foreign = CommentAttachmentsStore)]
+#[expect(dead_code)]
+struct CommentAttachmentsStoreAlias<'a>(Option<Box<'a, u8>>);
+
+impl<'a> Dummy<'a> for CommentAttachmentsStore<'a> {
+    #[inline]
+    fn dummy(_: &'a Allocator) -> Self {
+        Self::default()
+    }
+}
+
+impl<'a> CommentAttachments<'a> {
+    #[inline]
+    pub fn new_in(allocator: &'a Allocator, capacity: usize) -> Self {
+        Self {
+            hosts: Vec::from_iter_in(
+                std::iter::repeat_with(Cell::default).take(capacity),
+                &allocator,
+            ),
+            comments: Vec::from_iter_in(
+                std::iter::repeat_with(Cell::default).take(capacity),
+                &allocator,
+            ),
+            host_len: Cell::new(0),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.host_len.get() == 0
+    }
+
+    #[inline]
+    pub fn host_len(&self) -> usize {
+        self.host_len.get() as usize
+    }
+
+    #[inline]
+    pub fn host(&self, index: usize) -> CommentAttachmentHost {
+        self.hosts[index].get()
+    }
+
+    #[inline]
+    pub fn comment(&self, index: usize) -> AttachedComment {
+        self.comments[index].get()
+    }
+
+    #[inline]
+    pub fn clear(&self) {
+        self.host_len.set(0);
+    }
+
+    #[inline]
+    pub fn set_comment(&self, index: usize, comment: AttachedComment) {
+        self.comments[index].set(comment);
+    }
+
+    #[inline]
+    /// # Panics
+    ///
+    /// Panics if the attachment pass produces more hosts than source comments.
+    pub fn push_host(&self, host: CommentAttachmentHost) {
+        let index = self.host_len();
+        self.hosts[index].set(host);
+        self.host_len.set(u32::try_from(index + 1).unwrap());
+    }
 }
 
 impl Comment {

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -62,6 +62,13 @@ pub struct Program<'a> {
     #[content_eq(skip)]
     #[estree(skip)]
     pub comments: Vec<'a, Comment>,
+    /// Post-parse source-comment ownership. This is intentionally not exposed
+    /// through ESTree and is rebuilt when cloning without semantic identity.
+    #[builder(default)]
+    #[clone_in(default)]
+    #[content_eq(skip)]
+    #[estree(skip)]
+    pub comment_attachments: CommentAttachmentsStore<'a>,
     pub hashbang: Option<Hashbang<'a>>,
     #[estree(prepend_to = body)]
     pub directives: Vec<'a, Directive<'a>>,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -10,17 +10,18 @@ use crate::ast::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 4 bytes
-    assert!(size_of::<Program>() == 144);
+    assert!(size_of::<Program>() == 152);
     assert!(align_of::<Program>() == 8);
     assert!(offset_of!(Program, span) == 0);
     assert!(offset_of!(Program, node_id) == 8);
     assert!(offset_of!(Program, scope_id) == 12);
     assert!(offset_of!(Program, source_text) == 16);
     assert!(offset_of!(Program, comments) == 32);
-    assert!(offset_of!(Program, hashbang) == 56);
-    assert!(offset_of!(Program, directives) == 88);
-    assert!(offset_of!(Program, body) == 112);
-    assert!(offset_of!(Program, source_type) == 136);
+    assert!(offset_of!(Program, comment_attachments) == 56);
+    assert!(offset_of!(Program, hashbang) == 64);
+    assert!(offset_of!(Program, directives) == 96);
+    assert!(offset_of!(Program, body) == 120);
+    assert!(offset_of!(Program, source_type) == 144);
 
     assert!(size_of::<Expression>() == 16);
     assert!(align_of::<Expression>() == 8);
@@ -1847,22 +1848,27 @@ const _: () = {
     assert!(offset_of!(Comment, position) == 13);
     assert!(offset_of!(Comment, newlines) == 14);
     assert!(offset_of!(Comment, content) == 15);
+
+    // Padding: 0 bytes
+    assert!(size_of::<CommentAttachmentsStore>() == 8);
+    assert!(align_of::<CommentAttachmentsStore>() == 8);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
-    assert!(size_of::<Program>() == 96);
+    assert!(size_of::<Program>() == 100);
     assert!(align_of::<Program>() == 4);
     assert!(offset_of!(Program, span) == 0);
     assert!(offset_of!(Program, node_id) == 8);
     assert!(offset_of!(Program, scope_id) == 12);
     assert!(offset_of!(Program, source_text) == 16);
     assert!(offset_of!(Program, comments) == 24);
-    assert!(offset_of!(Program, hashbang) == 40);
-    assert!(offset_of!(Program, directives) == 60);
-    assert!(offset_of!(Program, body) == 76);
-    assert!(offset_of!(Program, source_type) == 92);
+    assert!(offset_of!(Program, comment_attachments) == 40);
+    assert!(offset_of!(Program, hashbang) == 44);
+    assert!(offset_of!(Program, directives) == 64);
+    assert!(offset_of!(Program, body) == 80);
+    assert!(offset_of!(Program, source_type) == 96);
 
     assert!(size_of::<Expression>() == 8);
     assert!(align_of::<Expression>() == 4);
@@ -3689,6 +3695,10 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(Comment, position) == 13);
     assert!(offset_of!(Comment, newlines) == 14);
     assert!(offset_of!(Comment, content) == 15);
+
+    // Padding: 0 bytes
+    assert!(size_of::<CommentAttachmentsStore>() == 4);
+    assert!(align_of::<CommentAttachmentsStore>() == 4);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -53,6 +53,7 @@ impl<'a> Program<'a> {
             source_type,
             source_text,
             comments: comments.into_in(builder.allocator()),
+            comment_attachments: Default::default(),
             hashbang,
             directives: directives.into_in(builder.allocator()),
             body: body.into_in(builder.allocator()),
@@ -60,23 +61,25 @@ impl<'a> Program<'a> {
         }
     }
 
-    /// Build a [`Program`] with `scope_id`.
+    /// Build a [`Program`] with `comment_attachments` and `scope_id`.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `source_type`
     /// * `source_text`
     /// * `comments`: Sorted comments
+    /// * `comment_attachments`: Post-parse source-comment ownership. This is intentionally not exposed
     /// * `hashbang`
     /// * `directives`
     /// * `body`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id(
+    pub fn new_with_comment_attachments_and_scope_id(
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
         comments: impl IntoIn<'a, ArenaVec<'a, Comment>>,
+        comment_attachments: CommentAttachmentsStore<'a>,
         hashbang: Option<Hashbang<'a>>,
         directives: impl IntoIn<'a, ArenaVec<'a, Directive<'a>>>,
         body: impl IntoIn<'a, ArenaVec<'a, Statement<'a>>>,
@@ -90,6 +93,7 @@ impl<'a> Program<'a> {
             source_type,
             source_text,
             comments: comments.into_in(builder.allocator()),
+            comment_attachments,
             hashbang,
             directives: directives.into_in(builder.allocator()),
             body: body.into_in(builder.allocator()),

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -27,6 +27,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
             source_type: CloneIn::clone_in_impl(&self.source_type, with_semantic_ids, allocator),
             source_text: CloneIn::clone_in_impl(&self.source_text, with_semantic_ids, allocator),
             comments: CloneIn::clone_in_impl(&self.comments, with_semantic_ids, allocator),
+            comment_attachments: Default::default(),
             hashbang: CloneIn::clone_in_impl(&self.hashbang, with_semantic_ids, allocator),
             directives: CloneIn::clone_in_impl(&self.directives, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -23,6 +23,7 @@ impl<'a> Dummy<'a> for Program<'a> {
             source_type: Dummy::dummy(allocator),
             source_text: Dummy::dummy(allocator),
             comments: Dummy::dummy(allocator),
+            comment_attachments: Dummy::dummy(allocator),
             hashbang: Dummy::dummy(allocator),
             directives: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),

--- a/crates/oxc_ast/src/generated/get_id.rs
+++ b/crates/oxc_ast/src/generated/get_id.rs
@@ -5,7 +5,7 @@
 #![expect(clippy::match_same_arms)]
 use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
-use crate::ast::*;
+use crate::{GetNodeId, ast::*};
 
 impl Program<'_> {
     /// Get [`NodeId`] of [`Program`].
@@ -39,6 +39,12 @@ impl Program<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for Program<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl IdentifierName<'_> {
     /// Get [`NodeId`] of [`IdentifierName`].
@@ -53,6 +59,12 @@ impl IdentifierName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for IdentifierName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -88,6 +100,12 @@ impl IdentifierReference<'_> {
         self.reference_id.set(Some(reference_id));
     }
 }
+impl GetNodeId for IdentifierReference<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl BindingIdentifier<'_> {
     /// Get [`NodeId`] of [`BindingIdentifier`].
@@ -121,6 +139,12 @@ impl BindingIdentifier<'_> {
         self.symbol_id.set(Some(symbol_id));
     }
 }
+impl GetNodeId for BindingIdentifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl LabelIdentifier<'_> {
     /// Get [`NodeId`] of [`LabelIdentifier`].
@@ -135,6 +159,12 @@ impl LabelIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for LabelIdentifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -153,6 +183,12 @@ impl ThisExpression {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ThisExpression {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ArrayExpression<'_> {
     /// Get [`NodeId`] of [`ArrayExpression`].
@@ -167,6 +203,12 @@ impl ArrayExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ArrayExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -185,6 +227,12 @@ impl Elision {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for Elision {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ObjectExpression<'_> {
     /// Get [`NodeId`] of [`ObjectExpression`].
@@ -199,6 +247,12 @@ impl ObjectExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ObjectExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -217,6 +271,12 @@ impl ObjectProperty<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ObjectProperty<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TemplateLiteral<'_> {
     /// Get [`NodeId`] of [`TemplateLiteral`].
@@ -231,6 +291,12 @@ impl TemplateLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TemplateLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -249,6 +315,12 @@ impl TaggedTemplateExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TaggedTemplateExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TemplateElement<'_> {
     /// Get [`NodeId`] of [`TemplateElement`].
@@ -263,6 +335,12 @@ impl TemplateElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TemplateElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -281,6 +359,12 @@ impl ComputedMemberExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ComputedMemberExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl StaticMemberExpression<'_> {
     /// Get [`NodeId`] of [`StaticMemberExpression`].
@@ -295,6 +379,12 @@ impl StaticMemberExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for StaticMemberExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -313,6 +403,12 @@ impl PrivateFieldExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for PrivateFieldExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl CallExpression<'_> {
     /// Get [`NodeId`] of [`CallExpression`].
@@ -327,6 +423,12 @@ impl CallExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for CallExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -345,6 +447,12 @@ impl NewExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for NewExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ImportMeta {
     /// Get [`NodeId`] of [`ImportMeta`].
@@ -359,6 +467,12 @@ impl ImportMeta {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ImportMeta {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -377,6 +491,12 @@ impl NewTarget {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for NewTarget {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl SpreadElement<'_> {
     /// Get [`NodeId`] of [`SpreadElement`].
@@ -391,6 +511,12 @@ impl SpreadElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for SpreadElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -409,6 +535,12 @@ impl UpdateExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for UpdateExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl UnaryExpression<'_> {
     /// Get [`NodeId`] of [`UnaryExpression`].
@@ -423,6 +555,12 @@ impl UnaryExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for UnaryExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -441,6 +579,12 @@ impl BinaryExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for BinaryExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl PrivateInExpression<'_> {
     /// Get [`NodeId`] of [`PrivateInExpression`].
@@ -455,6 +599,12 @@ impl PrivateInExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for PrivateInExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -473,6 +623,12 @@ impl LogicalExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for LogicalExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ConditionalExpression<'_> {
     /// Get [`NodeId`] of [`ConditionalExpression`].
@@ -487,6 +643,12 @@ impl ConditionalExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ConditionalExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -505,6 +667,12 @@ impl AssignmentExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for AssignmentExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ArrayAssignmentTarget<'_> {
     /// Get [`NodeId`] of [`ArrayAssignmentTarget`].
@@ -519,6 +687,12 @@ impl ArrayAssignmentTarget<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ArrayAssignmentTarget<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -537,6 +711,12 @@ impl ObjectAssignmentTarget<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ObjectAssignmentTarget<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentTargetRest<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetRest`].
@@ -551,6 +731,12 @@ impl AssignmentTargetRest<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for AssignmentTargetRest<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -569,6 +755,12 @@ impl AssignmentTargetWithDefault<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for AssignmentTargetWithDefault<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentTargetPropertyIdentifier<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetPropertyIdentifier`].
@@ -583,6 +775,12 @@ impl AssignmentTargetPropertyIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for AssignmentTargetPropertyIdentifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -601,6 +799,12 @@ impl AssignmentTargetPropertyProperty<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for AssignmentTargetPropertyProperty<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl SequenceExpression<'_> {
     /// Get [`NodeId`] of [`SequenceExpression`].
@@ -615,6 +819,12 @@ impl SequenceExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for SequenceExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -633,6 +843,12 @@ impl Super {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for Super {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AwaitExpression<'_> {
     /// Get [`NodeId`] of [`AwaitExpression`].
@@ -647,6 +863,12 @@ impl AwaitExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for AwaitExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -665,6 +887,12 @@ impl ChainExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ChainExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ParenthesizedExpression<'_> {
     /// Get [`NodeId`] of [`ParenthesizedExpression`].
@@ -679,6 +907,12 @@ impl ParenthesizedExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ParenthesizedExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -697,6 +931,12 @@ impl Directive<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for Directive<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl Hashbang<'_> {
     /// Get [`NodeId`] of [`Hashbang`].
@@ -711,6 +951,12 @@ impl Hashbang<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for Hashbang<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -746,6 +992,12 @@ impl BlockStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for BlockStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl VariableDeclaration<'_> {
     /// Get [`NodeId`] of [`VariableDeclaration`].
@@ -760,6 +1012,12 @@ impl VariableDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for VariableDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -778,6 +1036,12 @@ impl VariableDeclarator<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for VariableDeclarator<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl EmptyStatement {
     /// Get [`NodeId`] of [`EmptyStatement`].
@@ -792,6 +1056,12 @@ impl EmptyStatement {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for EmptyStatement {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -810,6 +1080,12 @@ impl ExpressionStatement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ExpressionStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl IfStatement<'_> {
     /// Get [`NodeId`] of [`IfStatement`].
@@ -824,6 +1100,12 @@ impl IfStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for IfStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -842,6 +1124,12 @@ impl DoWhileStatement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for DoWhileStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl WhileStatement<'_> {
     /// Get [`NodeId`] of [`WhileStatement`].
@@ -856,6 +1144,12 @@ impl WhileStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for WhileStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -891,6 +1185,12 @@ impl ForStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for ForStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ForInStatement<'_> {
     /// Get [`NodeId`] of [`ForInStatement`].
@@ -922,6 +1222,12 @@ impl ForInStatement<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
+    }
+}
+impl GetNodeId for ForInStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -957,6 +1263,12 @@ impl ForOfStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for ForOfStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ContinueStatement<'_> {
     /// Get [`NodeId`] of [`ContinueStatement`].
@@ -971,6 +1283,12 @@ impl ContinueStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ContinueStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -989,6 +1307,12 @@ impl BreakStatement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for BreakStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ReturnStatement<'_> {
     /// Get [`NodeId`] of [`ReturnStatement`].
@@ -1003,6 +1327,12 @@ impl ReturnStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ReturnStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1038,6 +1368,12 @@ impl WithStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for WithStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl SwitchStatement<'_> {
     /// Get [`NodeId`] of [`SwitchStatement`].
@@ -1071,6 +1407,12 @@ impl SwitchStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for SwitchStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl SwitchCase<'_> {
     /// Get [`NodeId`] of [`SwitchCase`].
@@ -1085,6 +1427,12 @@ impl SwitchCase<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for SwitchCase<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1103,6 +1451,12 @@ impl LabeledStatement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for LabeledStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ThrowStatement<'_> {
     /// Get [`NodeId`] of [`ThrowStatement`].
@@ -1119,6 +1473,12 @@ impl ThrowStatement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ThrowStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TryStatement<'_> {
     /// Get [`NodeId`] of [`TryStatement`].
@@ -1133,6 +1493,12 @@ impl TryStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TryStatement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1168,6 +1534,12 @@ impl CatchClause<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for CatchClause<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl CatchParameter<'_> {
     /// Get [`NodeId`] of [`CatchParameter`].
@@ -1182,6 +1554,12 @@ impl CatchParameter<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for CatchParameter<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1200,6 +1578,12 @@ impl DebuggerStatement {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for DebuggerStatement {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentPattern<'_> {
     /// Get [`NodeId`] of [`AssignmentPattern`].
@@ -1214,6 +1598,12 @@ impl AssignmentPattern<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for AssignmentPattern<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1232,6 +1622,12 @@ impl ObjectPattern<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ObjectPattern<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl BindingProperty<'_> {
     /// Get [`NodeId`] of [`BindingProperty`].
@@ -1246,6 +1642,12 @@ impl BindingProperty<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for BindingProperty<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1264,6 +1666,12 @@ impl ArrayPattern<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ArrayPattern<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl BindingRestElement<'_> {
     /// Get [`NodeId`] of [`BindingRestElement`].
@@ -1278,6 +1686,12 @@ impl BindingRestElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for BindingRestElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1313,6 +1727,12 @@ impl Function<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for Function<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl FormalParameters<'_> {
     /// Get [`NodeId`] of [`FormalParameters`].
@@ -1327,6 +1747,12 @@ impl FormalParameters<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for FormalParameters<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1345,6 +1771,12 @@ impl FormalParameter<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for FormalParameter<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl FormalParameterRest<'_> {
     /// Get [`NodeId`] of [`FormalParameterRest`].
@@ -1361,6 +1793,12 @@ impl FormalParameterRest<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for FormalParameterRest<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl FunctionBody<'_> {
     /// Get [`NodeId`] of [`FunctionBody`].
@@ -1375,6 +1813,12 @@ impl FunctionBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for FunctionBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1410,6 +1854,12 @@ impl ArrowFunctionExpression<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for ArrowFunctionExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl YieldExpression<'_> {
     /// Get [`NodeId`] of [`YieldExpression`].
@@ -1424,6 +1874,12 @@ impl YieldExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for YieldExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1459,6 +1915,12 @@ impl Class<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for Class<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ClassBody<'_> {
     /// Get [`NodeId`] of [`ClassBody`].
@@ -1473,6 +1935,12 @@ impl ClassBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ClassBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1491,6 +1959,12 @@ impl MethodDefinition<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for MethodDefinition<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl PropertyDefinition<'_> {
     /// Get [`NodeId`] of [`PropertyDefinition`].
@@ -1507,6 +1981,12 @@ impl PropertyDefinition<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for PropertyDefinition<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl PrivateIdentifier<'_> {
     /// Get [`NodeId`] of [`PrivateIdentifier`].
@@ -1521,6 +2001,12 @@ impl PrivateIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for PrivateIdentifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1556,6 +2042,12 @@ impl StaticBlock<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for StaticBlock<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AccessorProperty<'_> {
     /// Get [`NodeId`] of [`AccessorProperty`].
@@ -1570,6 +2062,12 @@ impl AccessorProperty<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for AccessorProperty<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1588,6 +2086,12 @@ impl ImportExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ImportExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ImportDeclaration<'_> {
     /// Get [`NodeId`] of [`ImportDeclaration`].
@@ -1602,6 +2106,12 @@ impl ImportDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ImportDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1620,6 +2130,12 @@ impl ImportSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ImportSpecifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ImportDefaultSpecifier<'_> {
     /// Get [`NodeId`] of [`ImportDefaultSpecifier`].
@@ -1634,6 +2150,12 @@ impl ImportDefaultSpecifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ImportDefaultSpecifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1652,6 +2174,12 @@ impl ImportNamespaceSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ImportNamespaceSpecifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl WithClause<'_> {
     /// Get [`NodeId`] of [`WithClause`].
@@ -1666,6 +2194,12 @@ impl WithClause<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for WithClause<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1684,6 +2218,12 @@ impl ImportAttribute<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ImportAttribute<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ExportDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportDeclaration`].
@@ -1698,6 +2238,12 @@ impl ExportDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ExportDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1716,6 +2262,12 @@ impl ExportNamedDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ExportNamedDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ExportFromDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportFromDeclaration`].
@@ -1730,6 +2282,12 @@ impl ExportFromDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ExportFromDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1748,6 +2306,12 @@ impl ExportDefaultDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ExportDefaultDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ExportAllDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportAllDeclaration`].
@@ -1762,6 +2326,12 @@ impl ExportAllDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for ExportAllDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1780,6 +2350,12 @@ impl ExportSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for ExportSpecifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl V8IntrinsicExpression<'_> {
     /// Get [`NodeId`] of [`V8IntrinsicExpression`].
@@ -1794,6 +2370,12 @@ impl V8IntrinsicExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for V8IntrinsicExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1812,6 +2394,12 @@ impl BooleanLiteral {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for BooleanLiteral {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl NullLiteral {
     /// Get [`NodeId`] of [`NullLiteral`].
@@ -1826,6 +2414,12 @@ impl NullLiteral {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for NullLiteral {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1844,6 +2438,12 @@ impl NumericLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for NumericLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl StringLiteral<'_> {
     /// Get [`NodeId`] of [`StringLiteral`].
@@ -1858,6 +2458,12 @@ impl StringLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for StringLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1876,6 +2482,12 @@ impl BigIntLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for BigIntLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl RegExpLiteral<'_> {
     /// Get [`NodeId`] of [`RegExpLiteral`].
@@ -1890,6 +2502,12 @@ impl RegExpLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for RegExpLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1908,6 +2526,12 @@ impl JSXElement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXOpeningElement<'_> {
     /// Get [`NodeId`] of [`JSXOpeningElement`].
@@ -1922,6 +2546,12 @@ impl JSXOpeningElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXOpeningElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1940,6 +2570,12 @@ impl JSXClosingElement<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXClosingElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXFragment<'_> {
     /// Get [`NodeId`] of [`JSXFragment`].
@@ -1954,6 +2590,12 @@ impl JSXFragment<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXFragment<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -1972,6 +2614,12 @@ impl JSXOpeningFragment {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXOpeningFragment {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXClosingFragment {
     /// Get [`NodeId`] of [`JSXClosingFragment`].
@@ -1986,6 +2634,12 @@ impl JSXClosingFragment {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXClosingFragment {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2004,6 +2658,12 @@ impl JSXNamespacedName<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXNamespacedName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXMemberExpression<'_> {
     /// Get [`NodeId`] of [`JSXMemberExpression`].
@@ -2018,6 +2678,12 @@ impl JSXMemberExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXMemberExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2036,6 +2702,12 @@ impl JSXExpressionContainer<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXExpressionContainer<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXEmptyExpression {
     /// Get [`NodeId`] of [`JSXEmptyExpression`].
@@ -2050,6 +2722,12 @@ impl JSXEmptyExpression {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXEmptyExpression {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2068,6 +2746,12 @@ impl JSXAttribute<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXAttribute<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXSpreadAttribute<'_> {
     /// Get [`NodeId`] of [`JSXSpreadAttribute`].
@@ -2082,6 +2766,12 @@ impl JSXSpreadAttribute<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXSpreadAttribute<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2100,6 +2790,12 @@ impl JSXIdentifier<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXIdentifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXSpreadChild<'_> {
     /// Get [`NodeId`] of [`JSXSpreadChild`].
@@ -2114,6 +2810,12 @@ impl JSXSpreadChild<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSXSpreadChild<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2132,6 +2834,12 @@ impl JSXText<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSXText<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSThisParameter<'_> {
     /// Get [`NodeId`] of [`TSThisParameter`].
@@ -2148,6 +2856,12 @@ impl TSThisParameter<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSThisParameter<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSEnumDeclaration<'_> {
     /// Get [`NodeId`] of [`TSEnumDeclaration`].
@@ -2162,6 +2876,12 @@ impl TSEnumDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSEnumDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2197,6 +2917,12 @@ impl TSEnumBody<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSEnumBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSEnumMember<'_> {
     /// Get [`NodeId`] of [`TSEnumMember`].
@@ -2211,6 +2937,12 @@ impl TSEnumMember<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSEnumMember<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2229,6 +2961,12 @@ impl TSTypeAnnotation<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeAnnotation<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSLiteralType<'_> {
     /// Get [`NodeId`] of [`TSLiteralType`].
@@ -2243,6 +2981,12 @@ impl TSLiteralType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSLiteralType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2278,6 +3022,12 @@ impl TSConditionalType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSConditionalType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSUnionType<'_> {
     /// Get [`NodeId`] of [`TSUnionType`].
@@ -2292,6 +3042,12 @@ impl TSUnionType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSUnionType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2310,6 +3066,12 @@ impl TSIntersectionType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSIntersectionType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSParenthesizedType<'_> {
     /// Get [`NodeId`] of [`TSParenthesizedType`].
@@ -2324,6 +3086,12 @@ impl TSParenthesizedType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSParenthesizedType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2342,6 +3110,12 @@ impl TSTypeOperator<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeOperator<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSArrayType<'_> {
     /// Get [`NodeId`] of [`TSArrayType`].
@@ -2356,6 +3130,12 @@ impl TSArrayType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSArrayType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2374,6 +3154,12 @@ impl TSIndexedAccessType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSIndexedAccessType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTupleType<'_> {
     /// Get [`NodeId`] of [`TSTupleType`].
@@ -2388,6 +3174,12 @@ impl TSTupleType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTupleType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2406,6 +3198,12 @@ impl TSNamedTupleMember<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSNamedTupleMember<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSOptionalType<'_> {
     /// Get [`NodeId`] of [`TSOptionalType`].
@@ -2420,6 +3218,12 @@ impl TSOptionalType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSOptionalType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2438,6 +3242,12 @@ impl TSRestType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSRestType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSAnyKeyword {
     /// Get [`NodeId`] of [`TSAnyKeyword`].
@@ -2452,6 +3262,12 @@ impl TSAnyKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSAnyKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2470,6 +3286,12 @@ impl TSStringKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSStringKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSBooleanKeyword {
     /// Get [`NodeId`] of [`TSBooleanKeyword`].
@@ -2484,6 +3306,12 @@ impl TSBooleanKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSBooleanKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2502,6 +3330,12 @@ impl TSNumberKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSNumberKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSNeverKeyword {
     /// Get [`NodeId`] of [`TSNeverKeyword`].
@@ -2516,6 +3350,12 @@ impl TSNeverKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSNeverKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2534,6 +3374,12 @@ impl TSIntrinsicKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSIntrinsicKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSUnknownKeyword {
     /// Get [`NodeId`] of [`TSUnknownKeyword`].
@@ -2548,6 +3394,12 @@ impl TSUnknownKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSUnknownKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2566,6 +3418,12 @@ impl TSNullKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSNullKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSUndefinedKeyword {
     /// Get [`NodeId`] of [`TSUndefinedKeyword`].
@@ -2580,6 +3438,12 @@ impl TSUndefinedKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSUndefinedKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2598,6 +3462,12 @@ impl TSVoidKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSVoidKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSSymbolKeyword {
     /// Get [`NodeId`] of [`TSSymbolKeyword`].
@@ -2612,6 +3482,12 @@ impl TSSymbolKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSSymbolKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2630,6 +3506,12 @@ impl TSThisType {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSThisType {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSObjectKeyword {
     /// Get [`NodeId`] of [`TSObjectKeyword`].
@@ -2644,6 +3526,12 @@ impl TSObjectKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSObjectKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2662,6 +3550,12 @@ impl TSBigIntKeyword {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSBigIntKeyword {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypeReference<'_> {
     /// Get [`NodeId`] of [`TSTypeReference`].
@@ -2676,6 +3570,12 @@ impl TSTypeReference<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTypeReference<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2694,6 +3594,12 @@ impl TSQualifiedName<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSQualifiedName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypeParameterInstantiation<'_> {
     /// Get [`NodeId`] of [`TSTypeParameterInstantiation`].
@@ -2708,6 +3614,12 @@ impl TSTypeParameterInstantiation<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTypeParameterInstantiation<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2726,6 +3638,12 @@ impl TSTypeParameter<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeParameter<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypeParameterDeclaration<'_> {
     /// Get [`NodeId`] of [`TSTypeParameterDeclaration`].
@@ -2740,6 +3658,12 @@ impl TSTypeParameterDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTypeParameterDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2775,6 +3699,12 @@ impl TSTypeAliasDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSTypeAliasDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSClassImplements<'_> {
     /// Get [`NodeId`] of [`TSClassImplements`].
@@ -2789,6 +3719,12 @@ impl TSClassImplements<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSClassImplements<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2824,6 +3760,12 @@ impl TSInterfaceDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSInterfaceDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSInterfaceBody<'_> {
     /// Get [`NodeId`] of [`TSInterfaceBody`].
@@ -2838,6 +3780,12 @@ impl TSInterfaceBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSInterfaceBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2856,6 +3804,12 @@ impl TSPropertySignature<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSPropertySignature<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSIndexSignature<'_> {
     /// Get [`NodeId`] of [`TSIndexSignature`].
@@ -2870,6 +3824,12 @@ impl TSIndexSignature<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSIndexSignature<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2905,6 +3865,12 @@ impl TSCallSignatureDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSCallSignatureDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSMethodSignature<'_> {
     /// Get [`NodeId`] of [`TSMethodSignature`].
@@ -2936,6 +3902,12 @@ impl TSMethodSignature<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
+    }
+}
+impl GetNodeId for TSMethodSignature<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -2971,6 +3943,12 @@ impl TSConstructSignatureDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSConstructSignatureDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSIndexSignatureName<'_> {
     /// Get [`NodeId`] of [`TSIndexSignatureName`].
@@ -2985,6 +3963,12 @@ impl TSIndexSignatureName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSIndexSignatureName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3003,6 +3987,12 @@ impl TSInterfaceHeritage<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSInterfaceHeritage<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypePredicate<'_> {
     /// Get [`NodeId`] of [`TSTypePredicate`].
@@ -3017,6 +4007,12 @@ impl TSTypePredicate<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTypePredicate<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3052,6 +4048,12 @@ impl TSExternalModuleDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSExternalModuleDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSNamespaceDeclaration<'_> {
     /// Get [`NodeId`] of [`TSNamespaceDeclaration`].
@@ -3083,6 +4085,12 @@ impl TSNamespaceDeclaration<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
+    }
+}
+impl GetNodeId for TSNamespaceDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3118,6 +4126,12 @@ impl TSGlobalDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSGlobalDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSModuleBlock<'_> {
     /// Get [`NodeId`] of [`TSModuleBlock`].
@@ -3132,6 +4146,12 @@ impl TSModuleBlock<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSModuleBlock<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3150,6 +4170,12 @@ impl TSTypeLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSInferType<'_> {
     /// Get [`NodeId`] of [`TSInferType`].
@@ -3164,6 +4190,12 @@ impl TSInferType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSInferType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3182,6 +4214,12 @@ impl TSTypeQuery<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeQuery<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSImportType<'_> {
     /// Get [`NodeId`] of [`TSImportType`].
@@ -3198,6 +4236,12 @@ impl TSImportType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSImportType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSImportTypeQualifiedName<'_> {
     /// Get [`NodeId`] of [`TSImportTypeQualifiedName`].
@@ -3212,6 +4256,12 @@ impl TSImportTypeQualifiedName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSImportTypeQualifiedName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3247,6 +4297,12 @@ impl TSFunctionType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSFunctionType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSConstructorType<'_> {
     /// Get [`NodeId`] of [`TSConstructorType`].
@@ -3278,6 +4334,12 @@ impl TSConstructorType<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
+    }
+}
+impl GetNodeId for TSConstructorType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3313,6 +4375,12 @@ impl TSMappedType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
+impl GetNodeId for TSMappedType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTemplateLiteralType<'_> {
     /// Get [`NodeId`] of [`TSTemplateLiteralType`].
@@ -3327,6 +4395,12 @@ impl TSTemplateLiteralType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSTemplateLiteralType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3345,6 +4419,12 @@ impl TSAsExpression<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSAsExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSSatisfiesExpression<'_> {
     /// Get [`NodeId`] of [`TSSatisfiesExpression`].
@@ -3359,6 +4439,12 @@ impl TSSatisfiesExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSSatisfiesExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3377,6 +4463,12 @@ impl TSTypeAssertion<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSTypeAssertion<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSImportEqualsDeclaration<'_> {
     /// Get [`NodeId`] of [`TSImportEqualsDeclaration`].
@@ -3391,6 +4483,12 @@ impl TSImportEqualsDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSImportEqualsDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3409,6 +4507,12 @@ impl TSExternalModuleReference<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSExternalModuleReference<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSNonNullExpression<'_> {
     /// Get [`NodeId`] of [`TSNonNullExpression`].
@@ -3423,6 +4527,12 @@ impl TSNonNullExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSNonNullExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3441,6 +4551,12 @@ impl Decorator<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for Decorator<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSExportAssignment<'_> {
     /// Get [`NodeId`] of [`TSExportAssignment`].
@@ -3455,6 +4571,12 @@ impl TSExportAssignment<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSExportAssignment<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3473,6 +4595,12 @@ impl TSNamespaceExportDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for TSNamespaceExportDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSInstantiationExpression<'_> {
     /// Get [`NodeId`] of [`TSInstantiationExpression`].
@@ -3487,6 +4615,12 @@ impl TSInstantiationExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for TSInstantiationExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3505,6 +4639,12 @@ impl JSDocNullableType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSDocNullableType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSDocNonNullableType<'_> {
     /// Get [`NodeId`] of [`JSDocNonNullableType`].
@@ -3521,6 +4661,12 @@ impl JSDocNonNullableType<'_> {
         self.node_id.set(node_id);
     }
 }
+impl GetNodeId for JSDocNonNullableType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSDocUnknownType {
     /// Get [`NodeId`] of [`JSDocUnknownType`].
@@ -3535,6 +4681,12 @@ impl JSDocUnknownType {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+impl GetNodeId for JSDocUnknownType {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3589,6 +4741,12 @@ impl Expression<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for Expression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3647,6 +4805,12 @@ impl ArrayExpressionElement<'_> {
         }
     }
 }
+impl GetNodeId for ArrayExpressionElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ObjectPropertyKind<'_> {
     /// Get [`NodeId`] of [`ObjectPropertyKind`].
@@ -3657,6 +4821,12 @@ impl ObjectPropertyKind<'_> {
             Self::ObjectProperty(it) => it.node_id(),
             Self::SpreadProperty(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for ObjectPropertyKind<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3715,6 +4885,12 @@ impl PropertyKey<'_> {
         }
     }
 }
+impl GetNodeId for PropertyKey<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl MemberExpression<'_> {
     /// Get [`NodeId`] of [`MemberExpression`].
@@ -3726,6 +4902,12 @@ impl MemberExpression<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for MemberExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3783,6 +4965,12 @@ impl Argument<'_> {
         }
     }
 }
+impl GetNodeId for Argument<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentTarget<'_> {
     /// Get [`NodeId`] of [`AssignmentTarget`].
@@ -3803,6 +4991,12 @@ impl AssignmentTarget<'_> {
         }
     }
 }
+impl GetNodeId for AssignmentTarget<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl SimpleAssignmentTarget<'_> {
     /// Get [`NodeId`] of [`SimpleAssignmentTarget`].
@@ -3821,6 +5015,12 @@ impl SimpleAssignmentTarget<'_> {
         }
     }
 }
+impl GetNodeId for SimpleAssignmentTarget<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentTargetPattern<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetPattern`].
@@ -3831,6 +5031,12 @@ impl AssignmentTargetPattern<'_> {
             Self::ArrayAssignmentTarget(it) => it.node_id(),
             Self::ObjectAssignmentTarget(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for AssignmentTargetPattern<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3854,6 +5060,12 @@ impl AssignmentTargetMaybeDefault<'_> {
         }
     }
 }
+impl GetNodeId for AssignmentTargetMaybeDefault<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl AssignmentTargetProperty<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetProperty`].
@@ -3864,6 +5076,12 @@ impl AssignmentTargetProperty<'_> {
             Self::AssignmentTargetPropertyIdentifier(it) => it.node_id(),
             Self::AssignmentTargetPropertyProperty(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for AssignmentTargetProperty<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3879,6 +5097,12 @@ impl ChainElement<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for ChainElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -3927,6 +5151,12 @@ impl Statement<'_> {
         }
     }
 }
+impl GetNodeId for Statement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl Declaration<'_> {
     /// Get [`NodeId`] of [`Declaration`].
@@ -3945,6 +5175,12 @@ impl Declaration<'_> {
             Self::TSGlobalDeclaration(it) => it.node_id(),
             Self::TSImportEqualsDeclaration(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for Declaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4002,6 +5238,12 @@ impl ForStatementInit<'_> {
         }
     }
 }
+impl GetNodeId for ForStatementInit<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ForStatementLeft<'_> {
     /// Get [`NodeId`] of [`ForStatementLeft`].
@@ -4023,6 +5265,12 @@ impl ForStatementLeft<'_> {
         }
     }
 }
+impl GetNodeId for ForStatementLeft<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl BindingPattern<'_> {
     /// Get [`NodeId`] of [`BindingPattern`].
@@ -4035,6 +5283,12 @@ impl BindingPattern<'_> {
             Self::ArrayPattern(it) => it.node_id(),
             Self::AssignmentPattern(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for BindingPattern<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4092,6 +5346,12 @@ impl ArrowFunctionBody<'_> {
         }
     }
 }
+impl GetNodeId for ArrowFunctionBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ClassElement<'_> {
     /// Get [`NodeId`] of [`ClassElement`].
@@ -4105,6 +5365,12 @@ impl ClassElement<'_> {
             Self::AccessorProperty(it) => it.node_id(),
             Self::TSIndexSignature(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for ClassElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4125,6 +5391,12 @@ impl ModuleDeclaration<'_> {
         }
     }
 }
+impl GetNodeId for ModuleDeclaration<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ImportDeclarationSpecifier<'_> {
     /// Get [`NodeId`] of [`ImportDeclarationSpecifier`].
@@ -4138,6 +5410,12 @@ impl ImportDeclarationSpecifier<'_> {
         }
     }
 }
+impl GetNodeId for ImportDeclarationSpecifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ImportAttributeKey<'_> {
     /// Get [`NodeId`] of [`ImportAttributeKey`].
@@ -4148,6 +5426,12 @@ impl ImportAttributeKey<'_> {
             Self::Identifier(it) => it.node_id(),
             Self::StringLiteral(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for ImportAttributeKey<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4207,6 +5491,12 @@ impl ExportDefaultDeclarationKind<'_> {
         }
     }
 }
+impl GetNodeId for ExportDefaultDeclarationKind<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl ModuleExportName<'_> {
     /// Get [`NodeId`] of [`ModuleExportName`].
@@ -4218,6 +5508,12 @@ impl ModuleExportName<'_> {
             Self::IdentifierReference(it) => it.node_id(),
             Self::StringLiteral(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for ModuleExportName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4235,6 +5531,12 @@ impl JSXElementName<'_> {
         }
     }
 }
+impl GetNodeId for JSXElementName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXMemberExpressionObject<'_> {
     /// Get [`NodeId`] of [`JSXMemberExpressionObject`].
@@ -4246,6 +5548,12 @@ impl JSXMemberExpressionObject<'_> {
             Self::MemberExpression(it) => it.node_id(),
             Self::ThisExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for JSXMemberExpressionObject<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4303,6 +5611,12 @@ impl JSXExpression<'_> {
         }
     }
 }
+impl GetNodeId for JSXExpression<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXAttributeItem<'_> {
     /// Get [`NodeId`] of [`JSXAttributeItem`].
@@ -4313,6 +5627,12 @@ impl JSXAttributeItem<'_> {
             Self::Attribute(it) => it.node_id(),
             Self::SpreadAttribute(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for JSXAttributeItem<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4327,6 +5647,12 @@ impl JSXAttributeName<'_> {
         }
     }
 }
+impl GetNodeId for JSXAttributeName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl JSXAttributeValue<'_> {
     /// Get [`NodeId`] of [`JSXAttributeValue`].
@@ -4339,6 +5665,12 @@ impl JSXAttributeValue<'_> {
             Self::Element(it) => it.node_id(),
             Self::Fragment(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for JSXAttributeValue<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4356,6 +5688,12 @@ impl JSXChild<'_> {
         }
     }
 }
+impl GetNodeId for JSXChild<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSEnumMemberName<'_> {
     /// Get [`NodeId`] of [`TSEnumMemberName`].
@@ -4368,6 +5706,12 @@ impl TSEnumMemberName<'_> {
             Self::ComputedString(it) => it.node_id(),
             Self::ComputedTemplateString(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSEnumMemberName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4384,6 +5728,12 @@ impl TSLiteral<'_> {
             Self::TemplateLiteral(it) => it.node_id(),
             Self::UnaryExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSLiteral<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4431,6 +5781,12 @@ impl TSType<'_> {
             Self::JSDocNonNullableType(it) => it.node_id(),
             Self::JSDocUnknownType(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSType<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4482,6 +5838,12 @@ impl TSTupleElement<'_> {
         }
     }
 }
+impl GetNodeId for TSTupleElement<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypeName<'_> {
     /// Get [`NodeId`] of [`TSTypeName`].
@@ -4493,6 +5855,12 @@ impl TSTypeName<'_> {
             Self::QualifiedName(it) => it.node_id(),
             Self::ThisExpression(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSTypeName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4510,6 +5878,12 @@ impl TSSignature<'_> {
         }
     }
 }
+impl GetNodeId for TSSignature<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSTypePredicateName<'_> {
     /// Get [`NodeId`] of [`TSTypePredicateName`].
@@ -4522,6 +5896,12 @@ impl TSTypePredicateName<'_> {
         }
     }
 }
+impl GetNodeId for TSTypePredicateName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSNamespaceDeclarationBody<'_> {
     /// Get [`NodeId`] of [`TSNamespaceDeclarationBody`].
@@ -4532,6 +5912,12 @@ impl TSNamespaceDeclarationBody<'_> {
             Self::TSNamespaceDeclaration(it) => it.node_id(),
             Self::TSModuleBlock(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSNamespaceDeclarationBody<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4548,6 +5934,12 @@ impl TSTypeQueryExprName<'_> {
         }
     }
 }
+impl GetNodeId for TSTypeQueryExprName<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
+    }
+}
 
 impl TSImportTypeQualifier<'_> {
     /// Get [`NodeId`] of [`TSImportTypeQualifier`].
@@ -4558,6 +5950,12 @@ impl TSImportTypeQualifier<'_> {
             Self::Identifier(it) => it.node_id(),
             Self::QualifiedName(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSImportTypeQualifier<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }
 
@@ -4571,5 +5969,11 @@ impl TSModuleReference<'_> {
             Self::IdentifierReference(it) => it.node_id(),
             Self::QualifiedName(it) => it.node_id(),
         }
+    }
+}
+impl GetNodeId for TSModuleReference<'_> {
+    #[inline]
+    fn get_node_id(&self) -> NodeId {
+        self.node_id()
     }
 }

--- a/crates/oxc_ast/src/generated/get_id.rs
+++ b/crates/oxc_ast/src/generated/get_id.rs
@@ -5,7 +5,7 @@
 #![expect(clippy::match_same_arms)]
 use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
-use crate::{GetNodeId, ast::*};
+use crate::ast::*;
 
 impl Program<'_> {
     /// Get [`NodeId`] of [`Program`].
@@ -39,12 +39,6 @@ impl Program<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for Program<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl IdentifierName<'_> {
     /// Get [`NodeId`] of [`IdentifierName`].
@@ -59,12 +53,6 @@ impl IdentifierName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for IdentifierName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -100,12 +88,6 @@ impl IdentifierReference<'_> {
         self.reference_id.set(Some(reference_id));
     }
 }
-impl GetNodeId for IdentifierReference<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl BindingIdentifier<'_> {
     /// Get [`NodeId`] of [`BindingIdentifier`].
@@ -139,12 +121,6 @@ impl BindingIdentifier<'_> {
         self.symbol_id.set(Some(symbol_id));
     }
 }
-impl GetNodeId for BindingIdentifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl LabelIdentifier<'_> {
     /// Get [`NodeId`] of [`LabelIdentifier`].
@@ -159,12 +135,6 @@ impl LabelIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for LabelIdentifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -183,12 +153,6 @@ impl ThisExpression {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ThisExpression {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ArrayExpression<'_> {
     /// Get [`NodeId`] of [`ArrayExpression`].
@@ -203,12 +167,6 @@ impl ArrayExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ArrayExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -227,12 +185,6 @@ impl Elision {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for Elision {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ObjectExpression<'_> {
     /// Get [`NodeId`] of [`ObjectExpression`].
@@ -247,12 +199,6 @@ impl ObjectExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ObjectExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -271,12 +217,6 @@ impl ObjectProperty<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ObjectProperty<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TemplateLiteral<'_> {
     /// Get [`NodeId`] of [`TemplateLiteral`].
@@ -291,12 +231,6 @@ impl TemplateLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TemplateLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -315,12 +249,6 @@ impl TaggedTemplateExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TaggedTemplateExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TemplateElement<'_> {
     /// Get [`NodeId`] of [`TemplateElement`].
@@ -335,12 +263,6 @@ impl TemplateElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TemplateElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -359,12 +281,6 @@ impl ComputedMemberExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ComputedMemberExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl StaticMemberExpression<'_> {
     /// Get [`NodeId`] of [`StaticMemberExpression`].
@@ -379,12 +295,6 @@ impl StaticMemberExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for StaticMemberExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -403,12 +313,6 @@ impl PrivateFieldExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for PrivateFieldExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl CallExpression<'_> {
     /// Get [`NodeId`] of [`CallExpression`].
@@ -423,12 +327,6 @@ impl CallExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for CallExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -447,12 +345,6 @@ impl NewExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for NewExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ImportMeta {
     /// Get [`NodeId`] of [`ImportMeta`].
@@ -467,12 +359,6 @@ impl ImportMeta {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ImportMeta {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -491,12 +377,6 @@ impl NewTarget {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for NewTarget {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl SpreadElement<'_> {
     /// Get [`NodeId`] of [`SpreadElement`].
@@ -511,12 +391,6 @@ impl SpreadElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for SpreadElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -535,12 +409,6 @@ impl UpdateExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for UpdateExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl UnaryExpression<'_> {
     /// Get [`NodeId`] of [`UnaryExpression`].
@@ -555,12 +423,6 @@ impl UnaryExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for UnaryExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -579,12 +441,6 @@ impl BinaryExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for BinaryExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl PrivateInExpression<'_> {
     /// Get [`NodeId`] of [`PrivateInExpression`].
@@ -599,12 +455,6 @@ impl PrivateInExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for PrivateInExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -623,12 +473,6 @@ impl LogicalExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for LogicalExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ConditionalExpression<'_> {
     /// Get [`NodeId`] of [`ConditionalExpression`].
@@ -643,12 +487,6 @@ impl ConditionalExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ConditionalExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -667,12 +505,6 @@ impl AssignmentExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for AssignmentExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ArrayAssignmentTarget<'_> {
     /// Get [`NodeId`] of [`ArrayAssignmentTarget`].
@@ -687,12 +519,6 @@ impl ArrayAssignmentTarget<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ArrayAssignmentTarget<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -711,12 +537,6 @@ impl ObjectAssignmentTarget<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ObjectAssignmentTarget<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentTargetRest<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetRest`].
@@ -731,12 +551,6 @@ impl AssignmentTargetRest<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for AssignmentTargetRest<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -755,12 +569,6 @@ impl AssignmentTargetWithDefault<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for AssignmentTargetWithDefault<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentTargetPropertyIdentifier<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetPropertyIdentifier`].
@@ -775,12 +583,6 @@ impl AssignmentTargetPropertyIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for AssignmentTargetPropertyIdentifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -799,12 +601,6 @@ impl AssignmentTargetPropertyProperty<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for AssignmentTargetPropertyProperty<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl SequenceExpression<'_> {
     /// Get [`NodeId`] of [`SequenceExpression`].
@@ -819,12 +615,6 @@ impl SequenceExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for SequenceExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -843,12 +633,6 @@ impl Super {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for Super {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AwaitExpression<'_> {
     /// Get [`NodeId`] of [`AwaitExpression`].
@@ -863,12 +647,6 @@ impl AwaitExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for AwaitExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -887,12 +665,6 @@ impl ChainExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ChainExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ParenthesizedExpression<'_> {
     /// Get [`NodeId`] of [`ParenthesizedExpression`].
@@ -907,12 +679,6 @@ impl ParenthesizedExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ParenthesizedExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -931,12 +697,6 @@ impl Directive<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for Directive<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl Hashbang<'_> {
     /// Get [`NodeId`] of [`Hashbang`].
@@ -951,12 +711,6 @@ impl Hashbang<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for Hashbang<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -992,12 +746,6 @@ impl BlockStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for BlockStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl VariableDeclaration<'_> {
     /// Get [`NodeId`] of [`VariableDeclaration`].
@@ -1012,12 +760,6 @@ impl VariableDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for VariableDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1036,12 +778,6 @@ impl VariableDeclarator<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for VariableDeclarator<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl EmptyStatement {
     /// Get [`NodeId`] of [`EmptyStatement`].
@@ -1056,12 +792,6 @@ impl EmptyStatement {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for EmptyStatement {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1080,12 +810,6 @@ impl ExpressionStatement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ExpressionStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl IfStatement<'_> {
     /// Get [`NodeId`] of [`IfStatement`].
@@ -1100,12 +824,6 @@ impl IfStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for IfStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1124,12 +842,6 @@ impl DoWhileStatement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for DoWhileStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl WhileStatement<'_> {
     /// Get [`NodeId`] of [`WhileStatement`].
@@ -1144,12 +856,6 @@ impl WhileStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for WhileStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1185,12 +891,6 @@ impl ForStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for ForStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ForInStatement<'_> {
     /// Get [`NodeId`] of [`ForInStatement`].
@@ -1222,12 +922,6 @@ impl ForInStatement<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
-    }
-}
-impl GetNodeId for ForInStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1263,12 +957,6 @@ impl ForOfStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for ForOfStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ContinueStatement<'_> {
     /// Get [`NodeId`] of [`ContinueStatement`].
@@ -1283,12 +971,6 @@ impl ContinueStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ContinueStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1307,12 +989,6 @@ impl BreakStatement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for BreakStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ReturnStatement<'_> {
     /// Get [`NodeId`] of [`ReturnStatement`].
@@ -1327,12 +1003,6 @@ impl ReturnStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ReturnStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1368,12 +1038,6 @@ impl WithStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for WithStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl SwitchStatement<'_> {
     /// Get [`NodeId`] of [`SwitchStatement`].
@@ -1407,12 +1071,6 @@ impl SwitchStatement<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for SwitchStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl SwitchCase<'_> {
     /// Get [`NodeId`] of [`SwitchCase`].
@@ -1427,12 +1085,6 @@ impl SwitchCase<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for SwitchCase<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1451,12 +1103,6 @@ impl LabeledStatement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for LabeledStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ThrowStatement<'_> {
     /// Get [`NodeId`] of [`ThrowStatement`].
@@ -1473,12 +1119,6 @@ impl ThrowStatement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ThrowStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TryStatement<'_> {
     /// Get [`NodeId`] of [`TryStatement`].
@@ -1493,12 +1133,6 @@ impl TryStatement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TryStatement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1534,12 +1168,6 @@ impl CatchClause<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for CatchClause<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl CatchParameter<'_> {
     /// Get [`NodeId`] of [`CatchParameter`].
@@ -1554,12 +1182,6 @@ impl CatchParameter<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for CatchParameter<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1578,12 +1200,6 @@ impl DebuggerStatement {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for DebuggerStatement {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentPattern<'_> {
     /// Get [`NodeId`] of [`AssignmentPattern`].
@@ -1598,12 +1214,6 @@ impl AssignmentPattern<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for AssignmentPattern<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1622,12 +1232,6 @@ impl ObjectPattern<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ObjectPattern<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl BindingProperty<'_> {
     /// Get [`NodeId`] of [`BindingProperty`].
@@ -1642,12 +1246,6 @@ impl BindingProperty<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for BindingProperty<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1666,12 +1264,6 @@ impl ArrayPattern<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ArrayPattern<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl BindingRestElement<'_> {
     /// Get [`NodeId`] of [`BindingRestElement`].
@@ -1686,12 +1278,6 @@ impl BindingRestElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for BindingRestElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1727,12 +1313,6 @@ impl Function<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for Function<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl FormalParameters<'_> {
     /// Get [`NodeId`] of [`FormalParameters`].
@@ -1747,12 +1327,6 @@ impl FormalParameters<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for FormalParameters<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1771,12 +1345,6 @@ impl FormalParameter<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for FormalParameter<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl FormalParameterRest<'_> {
     /// Get [`NodeId`] of [`FormalParameterRest`].
@@ -1793,12 +1361,6 @@ impl FormalParameterRest<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for FormalParameterRest<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl FunctionBody<'_> {
     /// Get [`NodeId`] of [`FunctionBody`].
@@ -1813,12 +1375,6 @@ impl FunctionBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for FunctionBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1854,12 +1410,6 @@ impl ArrowFunctionExpression<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for ArrowFunctionExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl YieldExpression<'_> {
     /// Get [`NodeId`] of [`YieldExpression`].
@@ -1874,12 +1424,6 @@ impl YieldExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for YieldExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1915,12 +1459,6 @@ impl Class<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for Class<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ClassBody<'_> {
     /// Get [`NodeId`] of [`ClassBody`].
@@ -1935,12 +1473,6 @@ impl ClassBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ClassBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -1959,12 +1491,6 @@ impl MethodDefinition<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for MethodDefinition<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl PropertyDefinition<'_> {
     /// Get [`NodeId`] of [`PropertyDefinition`].
@@ -1981,12 +1507,6 @@ impl PropertyDefinition<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for PropertyDefinition<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl PrivateIdentifier<'_> {
     /// Get [`NodeId`] of [`PrivateIdentifier`].
@@ -2001,12 +1521,6 @@ impl PrivateIdentifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for PrivateIdentifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2042,12 +1556,6 @@ impl StaticBlock<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for StaticBlock<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AccessorProperty<'_> {
     /// Get [`NodeId`] of [`AccessorProperty`].
@@ -2062,12 +1570,6 @@ impl AccessorProperty<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for AccessorProperty<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2086,12 +1588,6 @@ impl ImportExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ImportExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ImportDeclaration<'_> {
     /// Get [`NodeId`] of [`ImportDeclaration`].
@@ -2106,12 +1602,6 @@ impl ImportDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ImportDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2130,12 +1620,6 @@ impl ImportSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ImportSpecifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ImportDefaultSpecifier<'_> {
     /// Get [`NodeId`] of [`ImportDefaultSpecifier`].
@@ -2150,12 +1634,6 @@ impl ImportDefaultSpecifier<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ImportDefaultSpecifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2174,12 +1652,6 @@ impl ImportNamespaceSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ImportNamespaceSpecifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl WithClause<'_> {
     /// Get [`NodeId`] of [`WithClause`].
@@ -2194,12 +1666,6 @@ impl WithClause<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for WithClause<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2218,12 +1684,6 @@ impl ImportAttribute<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ImportAttribute<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ExportDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportDeclaration`].
@@ -2238,12 +1698,6 @@ impl ExportDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ExportDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2262,12 +1716,6 @@ impl ExportNamedDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ExportNamedDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ExportFromDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportFromDeclaration`].
@@ -2282,12 +1730,6 @@ impl ExportFromDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ExportFromDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2306,12 +1748,6 @@ impl ExportDefaultDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ExportDefaultDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ExportAllDeclaration<'_> {
     /// Get [`NodeId`] of [`ExportAllDeclaration`].
@@ -2326,12 +1762,6 @@ impl ExportAllDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for ExportAllDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2350,12 +1780,6 @@ impl ExportSpecifier<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for ExportSpecifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl V8IntrinsicExpression<'_> {
     /// Get [`NodeId`] of [`V8IntrinsicExpression`].
@@ -2370,12 +1794,6 @@ impl V8IntrinsicExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for V8IntrinsicExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2394,12 +1812,6 @@ impl BooleanLiteral {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for BooleanLiteral {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl NullLiteral {
     /// Get [`NodeId`] of [`NullLiteral`].
@@ -2414,12 +1826,6 @@ impl NullLiteral {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for NullLiteral {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2438,12 +1844,6 @@ impl NumericLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for NumericLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl StringLiteral<'_> {
     /// Get [`NodeId`] of [`StringLiteral`].
@@ -2458,12 +1858,6 @@ impl StringLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for StringLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2482,12 +1876,6 @@ impl BigIntLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for BigIntLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl RegExpLiteral<'_> {
     /// Get [`NodeId`] of [`RegExpLiteral`].
@@ -2502,12 +1890,6 @@ impl RegExpLiteral<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for RegExpLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2526,12 +1908,6 @@ impl JSXElement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXOpeningElement<'_> {
     /// Get [`NodeId`] of [`JSXOpeningElement`].
@@ -2546,12 +1922,6 @@ impl JSXOpeningElement<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXOpeningElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2570,12 +1940,6 @@ impl JSXClosingElement<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXClosingElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXFragment<'_> {
     /// Get [`NodeId`] of [`JSXFragment`].
@@ -2590,12 +1954,6 @@ impl JSXFragment<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXFragment<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2614,12 +1972,6 @@ impl JSXOpeningFragment {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXOpeningFragment {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXClosingFragment {
     /// Get [`NodeId`] of [`JSXClosingFragment`].
@@ -2634,12 +1986,6 @@ impl JSXClosingFragment {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXClosingFragment {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2658,12 +2004,6 @@ impl JSXNamespacedName<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXNamespacedName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXMemberExpression<'_> {
     /// Get [`NodeId`] of [`JSXMemberExpression`].
@@ -2678,12 +2018,6 @@ impl JSXMemberExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXMemberExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2702,12 +2036,6 @@ impl JSXExpressionContainer<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXExpressionContainer<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXEmptyExpression {
     /// Get [`NodeId`] of [`JSXEmptyExpression`].
@@ -2722,12 +2050,6 @@ impl JSXEmptyExpression {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXEmptyExpression {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2746,12 +2068,6 @@ impl JSXAttribute<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXAttribute<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXSpreadAttribute<'_> {
     /// Get [`NodeId`] of [`JSXSpreadAttribute`].
@@ -2766,12 +2082,6 @@ impl JSXSpreadAttribute<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXSpreadAttribute<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2790,12 +2100,6 @@ impl JSXIdentifier<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXIdentifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXSpreadChild<'_> {
     /// Get [`NodeId`] of [`JSXSpreadChild`].
@@ -2810,12 +2114,6 @@ impl JSXSpreadChild<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSXSpreadChild<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2834,12 +2132,6 @@ impl JSXText<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSXText<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSThisParameter<'_> {
     /// Get [`NodeId`] of [`TSThisParameter`].
@@ -2856,12 +2148,6 @@ impl TSThisParameter<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSThisParameter<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSEnumDeclaration<'_> {
     /// Get [`NodeId`] of [`TSEnumDeclaration`].
@@ -2876,12 +2162,6 @@ impl TSEnumDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSEnumDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2917,12 +2197,6 @@ impl TSEnumBody<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSEnumBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSEnumMember<'_> {
     /// Get [`NodeId`] of [`TSEnumMember`].
@@ -2937,12 +2211,6 @@ impl TSEnumMember<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSEnumMember<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -2961,12 +2229,6 @@ impl TSTypeAnnotation<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeAnnotation<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSLiteralType<'_> {
     /// Get [`NodeId`] of [`TSLiteralType`].
@@ -2981,12 +2243,6 @@ impl TSLiteralType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSLiteralType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3022,12 +2278,6 @@ impl TSConditionalType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSConditionalType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSUnionType<'_> {
     /// Get [`NodeId`] of [`TSUnionType`].
@@ -3042,12 +2292,6 @@ impl TSUnionType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSUnionType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3066,12 +2310,6 @@ impl TSIntersectionType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSIntersectionType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSParenthesizedType<'_> {
     /// Get [`NodeId`] of [`TSParenthesizedType`].
@@ -3086,12 +2324,6 @@ impl TSParenthesizedType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSParenthesizedType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3110,12 +2342,6 @@ impl TSTypeOperator<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeOperator<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSArrayType<'_> {
     /// Get [`NodeId`] of [`TSArrayType`].
@@ -3130,12 +2356,6 @@ impl TSArrayType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSArrayType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3154,12 +2374,6 @@ impl TSIndexedAccessType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSIndexedAccessType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTupleType<'_> {
     /// Get [`NodeId`] of [`TSTupleType`].
@@ -3174,12 +2388,6 @@ impl TSTupleType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTupleType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3198,12 +2406,6 @@ impl TSNamedTupleMember<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSNamedTupleMember<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSOptionalType<'_> {
     /// Get [`NodeId`] of [`TSOptionalType`].
@@ -3218,12 +2420,6 @@ impl TSOptionalType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSOptionalType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3242,12 +2438,6 @@ impl TSRestType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSRestType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSAnyKeyword {
     /// Get [`NodeId`] of [`TSAnyKeyword`].
@@ -3262,12 +2452,6 @@ impl TSAnyKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSAnyKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3286,12 +2470,6 @@ impl TSStringKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSStringKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSBooleanKeyword {
     /// Get [`NodeId`] of [`TSBooleanKeyword`].
@@ -3306,12 +2484,6 @@ impl TSBooleanKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSBooleanKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3330,12 +2502,6 @@ impl TSNumberKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSNumberKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSNeverKeyword {
     /// Get [`NodeId`] of [`TSNeverKeyword`].
@@ -3350,12 +2516,6 @@ impl TSNeverKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSNeverKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3374,12 +2534,6 @@ impl TSIntrinsicKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSIntrinsicKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSUnknownKeyword {
     /// Get [`NodeId`] of [`TSUnknownKeyword`].
@@ -3394,12 +2548,6 @@ impl TSUnknownKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSUnknownKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3418,12 +2566,6 @@ impl TSNullKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSNullKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSUndefinedKeyword {
     /// Get [`NodeId`] of [`TSUndefinedKeyword`].
@@ -3438,12 +2580,6 @@ impl TSUndefinedKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSUndefinedKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3462,12 +2598,6 @@ impl TSVoidKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSVoidKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSSymbolKeyword {
     /// Get [`NodeId`] of [`TSSymbolKeyword`].
@@ -3482,12 +2612,6 @@ impl TSSymbolKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSSymbolKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3506,12 +2630,6 @@ impl TSThisType {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSThisType {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSObjectKeyword {
     /// Get [`NodeId`] of [`TSObjectKeyword`].
@@ -3526,12 +2644,6 @@ impl TSObjectKeyword {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSObjectKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3550,12 +2662,6 @@ impl TSBigIntKeyword {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSBigIntKeyword {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypeReference<'_> {
     /// Get [`NodeId`] of [`TSTypeReference`].
@@ -3570,12 +2676,6 @@ impl TSTypeReference<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTypeReference<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3594,12 +2694,6 @@ impl TSQualifiedName<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSQualifiedName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypeParameterInstantiation<'_> {
     /// Get [`NodeId`] of [`TSTypeParameterInstantiation`].
@@ -3614,12 +2708,6 @@ impl TSTypeParameterInstantiation<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTypeParameterInstantiation<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3638,12 +2726,6 @@ impl TSTypeParameter<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeParameter<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypeParameterDeclaration<'_> {
     /// Get [`NodeId`] of [`TSTypeParameterDeclaration`].
@@ -3658,12 +2740,6 @@ impl TSTypeParameterDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTypeParameterDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3699,12 +2775,6 @@ impl TSTypeAliasDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSTypeAliasDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSClassImplements<'_> {
     /// Get [`NodeId`] of [`TSClassImplements`].
@@ -3719,12 +2789,6 @@ impl TSClassImplements<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSClassImplements<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3760,12 +2824,6 @@ impl TSInterfaceDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSInterfaceDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSInterfaceBody<'_> {
     /// Get [`NodeId`] of [`TSInterfaceBody`].
@@ -3780,12 +2838,6 @@ impl TSInterfaceBody<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSInterfaceBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3804,12 +2856,6 @@ impl TSPropertySignature<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSPropertySignature<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSIndexSignature<'_> {
     /// Get [`NodeId`] of [`TSIndexSignature`].
@@ -3824,12 +2870,6 @@ impl TSIndexSignature<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSIndexSignature<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3865,12 +2905,6 @@ impl TSCallSignatureDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSCallSignatureDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSMethodSignature<'_> {
     /// Get [`NodeId`] of [`TSMethodSignature`].
@@ -3902,12 +2936,6 @@ impl TSMethodSignature<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
-    }
-}
-impl GetNodeId for TSMethodSignature<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3943,12 +2971,6 @@ impl TSConstructSignatureDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSConstructSignatureDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSIndexSignatureName<'_> {
     /// Get [`NodeId`] of [`TSIndexSignatureName`].
@@ -3963,12 +2985,6 @@ impl TSIndexSignatureName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSIndexSignatureName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -3987,12 +3003,6 @@ impl TSInterfaceHeritage<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSInterfaceHeritage<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypePredicate<'_> {
     /// Get [`NodeId`] of [`TSTypePredicate`].
@@ -4007,12 +3017,6 @@ impl TSTypePredicate<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTypePredicate<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4048,12 +3052,6 @@ impl TSExternalModuleDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSExternalModuleDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSNamespaceDeclaration<'_> {
     /// Get [`NodeId`] of [`TSNamespaceDeclaration`].
@@ -4085,12 +3083,6 @@ impl TSNamespaceDeclaration<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
-    }
-}
-impl GetNodeId for TSNamespaceDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4126,12 +3118,6 @@ impl TSGlobalDeclaration<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSGlobalDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSModuleBlock<'_> {
     /// Get [`NodeId`] of [`TSModuleBlock`].
@@ -4146,12 +3132,6 @@ impl TSModuleBlock<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSModuleBlock<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4170,12 +3150,6 @@ impl TSTypeLiteral<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSInferType<'_> {
     /// Get [`NodeId`] of [`TSInferType`].
@@ -4190,12 +3164,6 @@ impl TSInferType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSInferType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4214,12 +3182,6 @@ impl TSTypeQuery<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeQuery<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSImportType<'_> {
     /// Get [`NodeId`] of [`TSImportType`].
@@ -4236,12 +3198,6 @@ impl TSImportType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSImportType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSImportTypeQualifiedName<'_> {
     /// Get [`NodeId`] of [`TSImportTypeQualifiedName`].
@@ -4256,12 +3212,6 @@ impl TSImportTypeQualifiedName<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSImportTypeQualifiedName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4297,12 +3247,6 @@ impl TSFunctionType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSFunctionType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSConstructorType<'_> {
     /// Get [`NodeId`] of [`TSConstructorType`].
@@ -4334,12 +3278,6 @@ impl TSConstructorType<'_> {
     #[inline]
     pub fn set_scope_id(&self, scope_id: ScopeId) {
         self.scope_id.set(Some(scope_id));
-    }
-}
-impl GetNodeId for TSConstructorType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4375,12 +3313,6 @@ impl TSMappedType<'_> {
         self.scope_id.set(Some(scope_id));
     }
 }
-impl GetNodeId for TSMappedType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTemplateLiteralType<'_> {
     /// Get [`NodeId`] of [`TSTemplateLiteralType`].
@@ -4395,12 +3327,6 @@ impl TSTemplateLiteralType<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSTemplateLiteralType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4419,12 +3345,6 @@ impl TSAsExpression<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSAsExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSSatisfiesExpression<'_> {
     /// Get [`NodeId`] of [`TSSatisfiesExpression`].
@@ -4439,12 +3359,6 @@ impl TSSatisfiesExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSSatisfiesExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4463,12 +3377,6 @@ impl TSTypeAssertion<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSTypeAssertion<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSImportEqualsDeclaration<'_> {
     /// Get [`NodeId`] of [`TSImportEqualsDeclaration`].
@@ -4483,12 +3391,6 @@ impl TSImportEqualsDeclaration<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSImportEqualsDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4507,12 +3409,6 @@ impl TSExternalModuleReference<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSExternalModuleReference<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSNonNullExpression<'_> {
     /// Get [`NodeId`] of [`TSNonNullExpression`].
@@ -4527,12 +3423,6 @@ impl TSNonNullExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSNonNullExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4551,12 +3441,6 @@ impl Decorator<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for Decorator<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSExportAssignment<'_> {
     /// Get [`NodeId`] of [`TSExportAssignment`].
@@ -4571,12 +3455,6 @@ impl TSExportAssignment<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSExportAssignment<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4595,12 +3473,6 @@ impl TSNamespaceExportDeclaration<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for TSNamespaceExportDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSInstantiationExpression<'_> {
     /// Get [`NodeId`] of [`TSInstantiationExpression`].
@@ -4615,12 +3487,6 @@ impl TSInstantiationExpression<'_> {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for TSInstantiationExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4639,12 +3505,6 @@ impl JSDocNullableType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSDocNullableType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSDocNonNullableType<'_> {
     /// Get [`NodeId`] of [`JSDocNonNullableType`].
@@ -4661,12 +3521,6 @@ impl JSDocNonNullableType<'_> {
         self.node_id.set(node_id);
     }
 }
-impl GetNodeId for JSDocNonNullableType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSDocUnknownType {
     /// Get [`NodeId`] of [`JSDocUnknownType`].
@@ -4681,12 +3535,6 @@ impl JSDocUnknownType {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
-    }
-}
-impl GetNodeId for JSDocUnknownType {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4741,12 +3589,6 @@ impl Expression<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for Expression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4805,12 +3647,6 @@ impl ArrayExpressionElement<'_> {
         }
     }
 }
-impl GetNodeId for ArrayExpressionElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ObjectPropertyKind<'_> {
     /// Get [`NodeId`] of [`ObjectPropertyKind`].
@@ -4821,12 +3657,6 @@ impl ObjectPropertyKind<'_> {
             Self::ObjectProperty(it) => it.node_id(),
             Self::SpreadProperty(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for ObjectPropertyKind<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4885,12 +3715,6 @@ impl PropertyKey<'_> {
         }
     }
 }
-impl GetNodeId for PropertyKey<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl MemberExpression<'_> {
     /// Get [`NodeId`] of [`MemberExpression`].
@@ -4902,12 +3726,6 @@ impl MemberExpression<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for MemberExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -4965,12 +3783,6 @@ impl Argument<'_> {
         }
     }
 }
-impl GetNodeId for Argument<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentTarget<'_> {
     /// Get [`NodeId`] of [`AssignmentTarget`].
@@ -4991,12 +3803,6 @@ impl AssignmentTarget<'_> {
         }
     }
 }
-impl GetNodeId for AssignmentTarget<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl SimpleAssignmentTarget<'_> {
     /// Get [`NodeId`] of [`SimpleAssignmentTarget`].
@@ -5015,12 +3821,6 @@ impl SimpleAssignmentTarget<'_> {
         }
     }
 }
-impl GetNodeId for SimpleAssignmentTarget<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentTargetPattern<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetPattern`].
@@ -5031,12 +3831,6 @@ impl AssignmentTargetPattern<'_> {
             Self::ArrayAssignmentTarget(it) => it.node_id(),
             Self::ObjectAssignmentTarget(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for AssignmentTargetPattern<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5060,12 +3854,6 @@ impl AssignmentTargetMaybeDefault<'_> {
         }
     }
 }
-impl GetNodeId for AssignmentTargetMaybeDefault<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl AssignmentTargetProperty<'_> {
     /// Get [`NodeId`] of [`AssignmentTargetProperty`].
@@ -5076,12 +3864,6 @@ impl AssignmentTargetProperty<'_> {
             Self::AssignmentTargetPropertyIdentifier(it) => it.node_id(),
             Self::AssignmentTargetPropertyProperty(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for AssignmentTargetProperty<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5097,12 +3879,6 @@ impl ChainElement<'_> {
             Self::StaticMemberExpression(it) => it.node_id(),
             Self::PrivateFieldExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for ChainElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5151,12 +3927,6 @@ impl Statement<'_> {
         }
     }
 }
-impl GetNodeId for Statement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl Declaration<'_> {
     /// Get [`NodeId`] of [`Declaration`].
@@ -5175,12 +3945,6 @@ impl Declaration<'_> {
             Self::TSGlobalDeclaration(it) => it.node_id(),
             Self::TSImportEqualsDeclaration(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for Declaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5238,12 +4002,6 @@ impl ForStatementInit<'_> {
         }
     }
 }
-impl GetNodeId for ForStatementInit<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ForStatementLeft<'_> {
     /// Get [`NodeId`] of [`ForStatementLeft`].
@@ -5265,12 +4023,6 @@ impl ForStatementLeft<'_> {
         }
     }
 }
-impl GetNodeId for ForStatementLeft<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl BindingPattern<'_> {
     /// Get [`NodeId`] of [`BindingPattern`].
@@ -5283,12 +4035,6 @@ impl BindingPattern<'_> {
             Self::ArrayPattern(it) => it.node_id(),
             Self::AssignmentPattern(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for BindingPattern<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5346,12 +4092,6 @@ impl ArrowFunctionBody<'_> {
         }
     }
 }
-impl GetNodeId for ArrowFunctionBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ClassElement<'_> {
     /// Get [`NodeId`] of [`ClassElement`].
@@ -5365,12 +4105,6 @@ impl ClassElement<'_> {
             Self::AccessorProperty(it) => it.node_id(),
             Self::TSIndexSignature(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for ClassElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5391,12 +4125,6 @@ impl ModuleDeclaration<'_> {
         }
     }
 }
-impl GetNodeId for ModuleDeclaration<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ImportDeclarationSpecifier<'_> {
     /// Get [`NodeId`] of [`ImportDeclarationSpecifier`].
@@ -5410,12 +4138,6 @@ impl ImportDeclarationSpecifier<'_> {
         }
     }
 }
-impl GetNodeId for ImportDeclarationSpecifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ImportAttributeKey<'_> {
     /// Get [`NodeId`] of [`ImportAttributeKey`].
@@ -5426,12 +4148,6 @@ impl ImportAttributeKey<'_> {
             Self::Identifier(it) => it.node_id(),
             Self::StringLiteral(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for ImportAttributeKey<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5491,12 +4207,6 @@ impl ExportDefaultDeclarationKind<'_> {
         }
     }
 }
-impl GetNodeId for ExportDefaultDeclarationKind<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl ModuleExportName<'_> {
     /// Get [`NodeId`] of [`ModuleExportName`].
@@ -5508,12 +4218,6 @@ impl ModuleExportName<'_> {
             Self::IdentifierReference(it) => it.node_id(),
             Self::StringLiteral(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for ModuleExportName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5531,12 +4235,6 @@ impl JSXElementName<'_> {
         }
     }
 }
-impl GetNodeId for JSXElementName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXMemberExpressionObject<'_> {
     /// Get [`NodeId`] of [`JSXMemberExpressionObject`].
@@ -5548,12 +4246,6 @@ impl JSXMemberExpressionObject<'_> {
             Self::MemberExpression(it) => it.node_id(),
             Self::ThisExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for JSXMemberExpressionObject<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5611,12 +4303,6 @@ impl JSXExpression<'_> {
         }
     }
 }
-impl GetNodeId for JSXExpression<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXAttributeItem<'_> {
     /// Get [`NodeId`] of [`JSXAttributeItem`].
@@ -5627,12 +4313,6 @@ impl JSXAttributeItem<'_> {
             Self::Attribute(it) => it.node_id(),
             Self::SpreadAttribute(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for JSXAttributeItem<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5647,12 +4327,6 @@ impl JSXAttributeName<'_> {
         }
     }
 }
-impl GetNodeId for JSXAttributeName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl JSXAttributeValue<'_> {
     /// Get [`NodeId`] of [`JSXAttributeValue`].
@@ -5665,12 +4339,6 @@ impl JSXAttributeValue<'_> {
             Self::Element(it) => it.node_id(),
             Self::Fragment(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for JSXAttributeValue<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5688,12 +4356,6 @@ impl JSXChild<'_> {
         }
     }
 }
-impl GetNodeId for JSXChild<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSEnumMemberName<'_> {
     /// Get [`NodeId`] of [`TSEnumMemberName`].
@@ -5706,12 +4368,6 @@ impl TSEnumMemberName<'_> {
             Self::ComputedString(it) => it.node_id(),
             Self::ComputedTemplateString(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSEnumMemberName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5728,12 +4384,6 @@ impl TSLiteral<'_> {
             Self::TemplateLiteral(it) => it.node_id(),
             Self::UnaryExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSLiteral<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5781,12 +4431,6 @@ impl TSType<'_> {
             Self::JSDocNonNullableType(it) => it.node_id(),
             Self::JSDocUnknownType(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSType<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5838,12 +4482,6 @@ impl TSTupleElement<'_> {
         }
     }
 }
-impl GetNodeId for TSTupleElement<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypeName<'_> {
     /// Get [`NodeId`] of [`TSTypeName`].
@@ -5855,12 +4493,6 @@ impl TSTypeName<'_> {
             Self::QualifiedName(it) => it.node_id(),
             Self::ThisExpression(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSTypeName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5878,12 +4510,6 @@ impl TSSignature<'_> {
         }
     }
 }
-impl GetNodeId for TSSignature<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSTypePredicateName<'_> {
     /// Get [`NodeId`] of [`TSTypePredicateName`].
@@ -5896,12 +4522,6 @@ impl TSTypePredicateName<'_> {
         }
     }
 }
-impl GetNodeId for TSTypePredicateName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSNamespaceDeclarationBody<'_> {
     /// Get [`NodeId`] of [`TSNamespaceDeclarationBody`].
@@ -5912,12 +4532,6 @@ impl TSNamespaceDeclarationBody<'_> {
             Self::TSNamespaceDeclaration(it) => it.node_id(),
             Self::TSModuleBlock(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSNamespaceDeclarationBody<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5934,12 +4548,6 @@ impl TSTypeQueryExprName<'_> {
         }
     }
 }
-impl GetNodeId for TSTypeQueryExprName<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
-    }
-}
 
 impl TSImportTypeQualifier<'_> {
     /// Get [`NodeId`] of [`TSImportTypeQualifier`].
@@ -5950,12 +4558,6 @@ impl TSImportTypeQualifier<'_> {
             Self::Identifier(it) => it.node_id(),
             Self::QualifiedName(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSImportTypeQualifier<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }
 
@@ -5969,11 +4571,5 @@ impl TSModuleReference<'_> {
             Self::IdentifierReference(it) => it.node_id(),
             Self::QualifiedName(it) => it.node_id(),
         }
-    }
-}
-impl GetNodeId for TSModuleReference<'_> {
-    #[inline]
-    fn get_node_id(&self) -> NodeId {
-        self.node_id()
     }
 }

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -84,14 +84,6 @@ pub use trivia::{
     CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,
 };
 
-/// Uniform access to an AST node's semantic identity.
-///
-/// Returns [`oxc_syntax::node::NodeId::DUMMY`] for AST helper types without
-/// their own node identity.
-pub trait GetNodeId {
-    fn get_node_id(&self) -> oxc_syntax::node::NodeId;
-}
-
 // After experimenting with two types of boxed enum variants:
 //   1.
 //   ```

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -74,12 +74,23 @@ mod generated {
 }
 pub use generated::ast_kind;
 
-pub use ast::comment::{Comment, CommentContent, CommentKind, CommentPosition};
+pub use ast::comment::{
+    AttachedComment, AttachedCommentPosition, Comment, CommentAttachmentHost, CommentAttachments,
+    CommentAttachmentsStore, CommentContent, CommentKind, CommentPosition,
+};
 pub use ast_kind::{AstKind, AstType};
 pub use ast_kind_impl::{MemberExpressionKind, ModuleDeclarationKind};
 pub use trivia::{
     CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,
 };
+
+/// Uniform access to an AST node's semantic identity.
+///
+/// Returns [`oxc_syntax::node::NodeId::DUMMY`] for AST helper types without
+/// their own node identity.
+pub trait GetNodeId {
+    fn get_node_id(&self) -> oxc_syntax::node::NodeId;
+}
 
 // After experimenting with two types of boxed enum variants:
 //   1.

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -8,425 +8,92 @@ use crate::ast::StructDetails;
 pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
     key: 16287231350648472473,
     disps: &[
-        (0, 6),
-        (0, 19),
-        (0, 5),
+        (0, 11),
         (0, 1),
-        (0, 1),
-        (0, 3),
-        (0, 41),
-        (0, 37),
-        (0, 13),
-        (0, 14),
-        (0, 70),
-        (0, 1),
-        (0, 31),
-        (0, 34),
-        (0, 70),
-        (0, 6),
-        (0, 1),
-        (0, 5),
-        (0, 92),
-        (0, 141),
+        (0, 0),
+        (0, 12),
+        (0, 0),
+        (0, 2),
         (0, 7),
-        (0, 54),
-        (0, 9),
-        (0, 29),
-        (0, 28),
-        (0, 79),
-        (0, 99),
-        (0, 81),
-        (0, 4),
-        (0, 0),
-        (0, 25),
-        (0, 0),
-        (0, 1),
-        (0, 8),
-        (0, 0),
-        (0, 2),
-        (0, 38),
-        (0, 145),
-        (0, 122),
-        (0, 19),
-        (0, 77),
-        (0, 102),
-        (0, 6),
-        (0, 28),
-        (0, 9),
-        (0, 21),
-        (0, 192),
-        (0, 39),
-        (0, 143),
-        (0, 4),
-        (0, 2),
-        (0, 0),
-        (0, 1),
-        (0, 30),
-        (0, 37),
-        (0, 26),
-        (0, 97),
-        (0, 145),
-        (0, 32),
         (0, 3),
-        (0, 3),
+        (0, 0),
+        (0, 9),
         (0, 4),
-        (0, 0),
-        (0, 173),
-        (0, 0),
-        (0, 76),
-        (0, 186),
         (0, 27),
-        (0, 63),
-        (0, 2),
-        (0, 13),
-        (0, 27),
-        (0, 16),
+        (0, 17),
         (0, 115),
-        (0, 28),
-        (0, 185),
+        (0, 17),
+        (0, 79),
+        (0, 71),
+        (0, 4),
+        (0, 3),
+        (0, 100),
+        (0, 0),
+        (0, 22),
+        (0, 3),
+        (0, 9),
+        (0, 17),
+        (0, 1),
+        (0, 19),
+        (0, 0),
+        (0, 73),
+        (0, 2),
+        (0, 15),
+        (0, 89),
+        (0, 1),
+        (0, 1),
+        (0, 126),
+        (0, 21),
+        (0, 48),
+        (0, 0),
+        (0, 4),
+        (0, 0),
+        (0, 20),
+        (0, 3),
+        (0, 3),
+        (0, 26),
+        (1, 0),
+        (0, 37),
+        (0, 0),
+        (0, 61),
+        (0, 13),
+        (0, 67),
+        (0, 1),
+        (0, 13),
+        (0, 0),
+        (0, 39),
         (0, 36),
-        (0, 27),
-        (0, 54),
-        (1, 177),
+        (0, 1),
+        (0, 29),
+        (0, 35),
+        (0, 45),
+        (0, 13),
+        (0, 31),
+        (0, 214),
+        (0, 3),
+        (0, 0),
+        (0, 15),
+        (0, 29),
+        (0, 0),
+        (0, 157),
+        (0, 22),
+        (0, 38),
+        (0, 122),
+        (0, 29),
+        (0, 80),
+        (0, 33),
+        (0, 0),
+        (0, 12),
+        (0, 18),
+        (1, 50),
+        (0, 96),
+        (0, 64),
+        (1, 116),
     ],
     entries: &[
         (
-            "TSIndexSignature",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 5, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSEnumDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 5, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "CallExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 5, 6, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSModuleBlock",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "DebuggerStatement",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "RegExpPattern",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "IdentifierName",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "LabeledStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "BinaryExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ArrowFunctionExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 7, 3, 4, 5, 6, 2, 8, 9]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ThisExpression",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "EcmaScriptModule",
-            StructDetails {
-                field_order: Some(&[4, 0, 1, 2, 3]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "StaticMemberExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ClassHeritage",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "TSAsExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ClassString",
-            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
-        ),
-        (
-            "FixedSizeAllocatorMetadata",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "ExpressionStatement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSOptionalType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSThisType",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "Character",
-            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
-        ),
-        (
-            "TSConditionalType",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "YieldExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
             "TSNamespaceExportDeclaration",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSNumberKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTypeAliasDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Decorator",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSBooleanKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        ("RegExpFlags", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "TSTypeParameterInstantiation",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSNullKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSXNamespacedName",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ContinueStatement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "SequenceExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ClassBody",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSQualifiedName",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "LabelIdentifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        ("Pattern", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "UnicodePropertyEscape",
-            StructDetails {
-                field_order: Some(&[0, 3, 4, 1, 2]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ObjectAssignmentTarget",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSIntersectionType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "SwitchStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TemplateElementValue",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "TSClassImplements",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ReturnStatement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "CharacterClassEscape",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "TSSymbolKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "RegExpLiteral",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "JSXExpressionContainer",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSInterfaceBody",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "AssignmentTargetRest",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSImportTypeQualifiedName",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "BindingProperty",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 5, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ObjectPattern",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSImportType",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4, 5]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ConditionalExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TaggedTemplateExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "IndexedReference",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "StringLiteral",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
         ),
         (
             "FunctionBody",
@@ -437,97 +104,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TSInstantiationExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSParenthesizedType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "Program",
-            StructDetails {
-                field_order: Some(&[1, 0, 8, 3, 4, 5, 6, 7, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "BreakStatement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTupleType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTypeOperator",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSImportEqualsDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSNonNullExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSExportAssignment",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        ("ReferenceId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "JSDocNonNullableType",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "NewTarget",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        ("SourceType", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "ForStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "AssignmentPattern",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSTypeAssertion",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSExternalModuleDeclaration",
+            "ExportAllDeclaration",
             StructDetails {
                 field_order: Some(&[1, 0, 3, 4, 5, 2]),
                 is_node: true,
@@ -535,29 +112,13 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "StaticExport",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
+            "Character",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
         ),
         (
-            "NamedReference",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "ArrayExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "VariableDeclaration",
+            "TSNamespaceDeclaration",
             StructDetails {
-                field_order: Some(&[1, 0, 2, 4, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ExportNamedDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
                 is_node: true,
                 is_transparent: false,
             },
@@ -571,6 +132,60 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
+            "NameSpan",
+            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "BoundaryAssertion",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        ("Modifiers", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "Error",
+            StructDetails {
+                field_order: Some(&[4, 0, 1, 2, 3]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ObjectAssignmentTarget",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSParenthesizedType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "CharacterClassEscape",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSOptionalType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "LabeledStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Span",
+            StructDetails { field_order: Some(&[1, 2, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "LookAroundAssertion",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        ("IgnoreGroup", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
             "PrivateInExpression",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
@@ -579,7 +194,19 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "CatchParameter",
+            "TSTypeLiteral",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXFragment",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TemplateLiteral",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
@@ -587,9 +214,13 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TSEnumBody",
+            "NullLiteral",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "YieldExpression",
             StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
+                field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
                 is_transparent: false,
             },
@@ -603,609 +234,43 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TSMethodSignature",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 8, 9, 10, 4, 5, 6, 7, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("I32Dummy", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "FormalParameters",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSTypeLiteral",
+            "JSXClosingElement",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
         (
-            "JSXSpreadChild",
+            "ExpressionStatement",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ImportSpecifier",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("Modifiers", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "TSTemplateLiteralType",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSVoidKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "WhileStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("Modifier", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "TSStringKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ChainExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ErrorLabel",
-            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
-        ),
-        (
-            "ForOfStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ImportDefaultSpecifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "NewExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "CommentNewlines",
-            StructDetails { field_order: None, is_node: false, is_transparent: true },
-        ),
-        (
-            "Error",
-            StructDetails {
-                field_order: Some(&[4, 0, 1, 2, 3]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSUndefinedKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "NullLiteral",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSDocNullableType",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ComputedMemberExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSPropertySignature",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ArrayAssignmentTarget",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "MethodDefinition",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("ScopeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "JSXOpeningFragment",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTypeReference",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "JSXSpreadAttribute",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "NumericLiteral",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSAnyKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTypeQuery",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "AssignmentTargetPropertyProperty",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSInferType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "DoWhileStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSConstructorType",
-            StructDetails {
-                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSConstructSignatureDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "PrivateFieldExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "CatchClause",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSObjectKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSTypeParameter",
-            StructDetails {
-                field_order: Some(&[1, 0, 5, 6, 7, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "AssignmentTargetPropertyIdentifier",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "RawTransferData",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "ExportSpecifier",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Elision",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        ("NonMaxU32", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "RawTransferMetadata",
-            StructDetails {
-                field_order: Some(&[0, 3, 4, 5, 1, 2]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TryStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "BlockStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Quantifier",
-            StructDetails {
-                field_order: Some(&[0, 1, 2, 4, 3]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSInterfaceDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSIndexedAccessType",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("NodeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "JSXEmptyExpression",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "Span",
-            StructDetails { field_order: Some(&[1, 2, 0]), is_node: false, is_transparent: false },
-        ),
-        (
-            "TSRestType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "Hashbang",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSXText",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "WithClause",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "WithStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSBigIntKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "VariableDeclarator",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "LookAroundAssertion",
-            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
-        ),
-        (
-            "ExportDefaultDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSXAttribute",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
         ),
         (
             "TSTypeAnnotation",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
         (
-            "TSThisParameter",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSIndexSignatureName",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSCallSignatureDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ForInStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "JSXElement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "IfStatement",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Directive",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Class",
-            StructDetails {
-                field_order: Some(&[1, 0, 9, 3, 4, 5, 6, 7, 8, 10, 11, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "CapturingGroup",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "SpreadElement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "RawTransferMetadata2",
-            StructDetails {
-                field_order: Some(&[0, 3, 4, 5, 1, 2]),
-                is_node: false,
-                is_transparent: false,
-            },
-        ),
-        (
-            "PropertyDefinition",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11, 12, 13, 14]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "CharacterClassRange",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "DynamicImport",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        ("SymbolId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "ImportDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 4, 5, 2, 6, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("IgnoreGroup", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "TSLiteralType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "V8IntrinsicExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("Dot", StructDetails { field_order: None, is_node: false, is_transparent: true }),
-        (
-            "ImportExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        ("RegExp", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "AssignmentTargetWithDefault",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSNamedTupleMember",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "IdentifierReference",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "TSNamespaceDeclaration",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "JSXFragment",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "PrivateIdentifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ClassStringDisjunction",
-            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
-        ),
-        (
-            "TSNeverKeyword",
+            "TSObjectKeyword",
             StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
         ),
         (
-            "BoundaryAssertion",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "JSXMemberExpression",
+            "FormalParameter",
             StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
+                field_order: Some(&[1, 0, 6, 7, 8, 9, 2, 3, 4, 5]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
         (
-            "EmptyStatement",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+            "ObjectPattern",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "BooleanLiteral",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
         (
-            "StaticImport",
-            StructDetails { field_order: None, is_node: false, is_transparent: false },
-        ),
-        (
-            "ThrowStatement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "UpdateExpression",
+            "JSXOpeningElement",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3, 4]),
                 is_node: true,
@@ -1221,16 +286,11 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "BindingIdentifier",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
+            "TSBigIntKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
         ),
-        ("Comment", StructDetails { field_order: None, is_node: false, is_transparent: false }),
         (
-            "TSEnumMember",
+            "AssignmentTargetPropertyIdentifier",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
@@ -1238,29 +298,37 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TSTypeParameterDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+            "DynamicImport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
         ),
+        ("Pattern", StructDetails { field_order: None, is_node: false, is_transparent: false }),
         (
-            "TSFunctionType",
+            "JSXElement",
             StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                field_order: Some(&[1, 0, 2, 3, 4]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
-        ("ImportEntry", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        ("Disjunction", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        ("SourceType", StructDetails { field_order: None, is_node: false, is_transparent: false }),
         (
-            "TSUnionType",
+            "CapturingGroup",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "NumericLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Hashbang",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
         (
-            "JSDocUnknownType",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "FormalParameterRest",
+            "UpdateExpression",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3, 4]),
                 is_node: true,
@@ -1268,110 +336,61 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TemplateElement",
+            "TSIntersectionType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TryStatement",
             StructDetails {
-                field_order: Some(&[1, 0, 4, 2, 3]),
+                field_order: Some(&[1, 0, 2, 3, 4]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
         (
-            "TSArrayType",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+            "TSImportEqualsDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AssignmentPattern",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "EmptyStatement",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "DoWhileStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "ParenthesizedExpression",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
         (
-            "ObjectExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSInterfaceHeritage",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "AccessorProperty",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "ExportDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        ("Alternative", StructDetails { field_order: None, is_node: false, is_transparent: false }),
-        (
-            "JSXClosingFragment",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TemplateLiteral",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "LogicalExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2, 4]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "NameSpan",
-            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
-        ),
-        (
-            "TSUnknownKeyword",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "TSMappedType",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 8, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "AwaitExpression",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "BindingRestElement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSXIdentifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "StaticBlock",
-            StructDetails {
-                field_order: Some(&[1, 0, 3, 2]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "Super",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "JSXOpeningElement",
+            "TaggedTemplateExpression",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ExportFromDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2, 5]),
                 is_node: true,
                 is_transparent: false,
             },
@@ -1385,7 +404,90 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "ExportAllDeclaration",
+            "TSIndexedAccessType",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "PropertyDefinition",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11, 12, 13, 14]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("I32Dummy", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        ("ImportEntry", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        ("Dot", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "ClassStringDisjunction",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        (
+            "ExportEntry",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNonNullExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "Program",
+            StructDetails {
+                field_order: Some(&[1, 0, 9, 3, 4, 5, 6, 7, 8, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSBooleanKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSUndefinedKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ArrayExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXSpreadChild",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSLiteralType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "SwitchStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXOpeningFragment",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSModuleBlock",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSConstructSignatureDeclaration",
             StructDetails {
                 field_order: Some(&[1, 0, 3, 4, 5, 2]),
                 is_node: true,
@@ -1393,10 +495,287 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "ExportEntry",
+            "Class",
             StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
+                field_order: Some(&[1, 0, 9, 3, 4, 5, 6, 7, 8, 10, 11, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "CharacterClassRange",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "ForOfStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSMappedType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 8, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSImportTypeQualifiedName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AssignmentExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ArrowFunctionExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 7, 3, 4, 5, 6, 2, 8, 9]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "CatchClause",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TemplateElement",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ExportDeclaration",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSSatisfiesExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXSpreadAttribute",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "VariableDeclarator",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("NodeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        ("Disjunction", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "TSExternalModuleReference",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSThisType",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ImportDefaultSpecifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "NewExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ObjectProperty",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 6, 7, 3, 4, 5]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ComputedMemberExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSInstantiationExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSArrayType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ForStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "FormalParameterRest",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Function",
+            StructDetails {
+                field_order: Some(&[1, 0, 9, 3, 10, 11, 12, 4, 5, 6, 7, 8, 2, 13, 14]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ArrayAssignmentTarget",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TemplateElementValue",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "ImportExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSMethodSignature",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 8, 9, 10, 4, 5, 6, 7, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "SequenceExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "NewTarget",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ClassString",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        ("SymbolId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "TSTypeParameterInstantiation",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ReturnStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "WhileStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSVoidKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "AssignmentTargetWithDefault",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSSymbolKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSEnumBody",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("Alternative", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "CatchParameter",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "RawTransferMetadata2",
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 5, 1, 2]),
                 is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSStringKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        ("ReferenceId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "StaticMemberExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSImportType",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4, 5]),
+                is_node: true,
                 is_transparent: false,
             },
         ),
@@ -1409,7 +788,51 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "TSSatisfiesExpression",
+            "TSIndexSignature",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "FixedSizeAllocatorMetadata",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "CallExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 6, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "IdentifierReference",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BlockStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSEnumDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSClassImplements",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
@@ -1417,7 +840,157 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
+            "TSExportAssignment",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXMemberExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "VariableDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 4, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSInterfaceDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSConditionalType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ImportNamespaceSpecifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "RawTransferMetadata",
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 5, 1, 2]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
             "SwitchCase",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ChainExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ContinueStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ThisExpression",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "DebuggerStatement",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "WithStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BindingProperty",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXNamespacedName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("RegExp", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        ("ScopeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "TSInterfaceHeritage",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AwaitExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ConditionalExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Decorator",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXAttribute",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "MethodDefinition",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ObjectExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "V8IntrinsicExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Directive",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
@@ -1433,7 +1006,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "ImportAttribute",
+            "TSTypeQuery",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
@@ -1441,54 +1014,38 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             },
         ),
         (
-            "ObjectProperty",
+            "ImportSpecifier",
             StructDetails {
-                field_order: Some(&[1, 0, 2, 6, 7, 3, 4, 5]),
+                field_order: Some(&[1, 0, 3, 4, 2]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
         (
-            "FormalParameter",
+            "ErrorLabel",
+            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "RegExpLiteral",
             StructDetails {
-                field_order: Some(&[1, 0, 6, 7, 8, 9, 2, 3, 4, 5]),
+                field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
         (
-            "ImportNamespaceSpecifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ExportFromDeclaration",
+            "TSPropertySignature",
             StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2, 5]),
+                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
                 is_node: true,
                 is_transparent: false,
             },
         ),
         (
-            "Function",
+            "Quantifier",
             StructDetails {
-                field_order: Some(&[1, 0, 9, 3, 10, 11, 12, 4, 5, 6, 7, 8, 2, 13, 14]),
-                is_node: true,
-                is_transparent: false,
-            },
-        ),
-        (
-            "JSXClosingElement",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
-        ),
-        (
-            "ImportMeta",
-            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
-        ),
-        (
-            "AssignmentExpression",
-            StructDetails {
-                field_order: Some(&[1, 0, 2, 3, 4]),
-                is_node: true,
+                field_order: Some(&[0, 1, 2, 4, 3]),
+                is_node: false,
                 is_transparent: false,
             },
         ),
@@ -1497,8 +1054,456 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
             StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
         ),
         (
-            "TSExternalModuleReference",
+            "LabelIdentifier",
             StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "BinaryExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "StaticExport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "JSXEmptyExpression",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ImportAttribute",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BindingIdentifier",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXText",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSTypeAssertion",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "StaticBlock",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSRestType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSThisParameter",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BindingRestElement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXClosingFragment",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSEnumMember",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "CommentAttachmentsStore",
+            StructDetails { field_order: None, is_node: false, is_transparent: true },
+        ),
+        (
+            "TSConstructorType",
+            StructDetails {
+                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "IdentifierName",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "RawTransferData",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSInferType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSTypeParameterDeclaration",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "IndexedReference",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "ThrowStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSTupleType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ForInStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSTypeParameter",
+            StructDetails {
+                field_order: Some(&[1, 0, 5, 6, 7, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSExternalModuleDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSTypeReference",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNumberKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "Elision",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSUnknownKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSCallSignatureDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSDocNonNullableType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ClassHeritage",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "PrivateIdentifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ExportDefaultDeclaration",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("RegExpFlags", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "RegExpPattern",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSTypeOperator",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSIndexSignatureName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "IfStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Super",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSAsExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ClassBody",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("NonMaxU32", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "CommentNewlines",
+            StructDetails { field_order: None, is_node: false, is_transparent: true },
+        ),
+        (
+            "ImportMeta",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSDocUnknownType",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSTypeAliasDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "SpreadElement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "WithClause",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSInterfaceBody",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSDocNullableType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AccessorProperty",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNullKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ImportDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 6, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "PrivateFieldExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BreakStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("Modifier", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "StaticImport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSTemplateLiteralType",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "LogicalExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AssignmentTargetRest",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXExpressionContainer",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSQualifiedName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("Comment", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "ExportNamedDeclaration",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "UnicodePropertyEscape",
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 1, 2]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "StringLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSUnionType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSAnyKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "AssignmentTargetPropertyProperty",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "FormalParameters",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "NamedReference",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "EcmaScriptModule",
+            StructDetails {
+                field_order: Some(&[4, 0, 1, 2, 3]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNeverKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXIdentifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ExportSpecifier",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSFunctionType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNamedTupleMember",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
     ],
 };

--- a/crates/oxc_ast_visit/src/comments.rs
+++ b/crates/oxc_ast_visit/src/comments.rs
@@ -1,0 +1,396 @@
+//! Semantic source-comment attachment.
+
+use std::cmp::Reverse;
+
+use oxc_ast::{
+    AstKind, AstType, AttachedComment, AttachedCommentPosition, CommentAttachmentHost,
+    CommentAttachments, CommentContent, ast::*,
+};
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::{line_terminator::is_line_terminator, node::NodeId, scope::ScopeFlags};
+
+use crate::Visit;
+
+const NO_NODE: u32 = u32::MAX;
+
+#[derive(Debug)]
+struct NodeRecord {
+    node_id: NodeId,
+    kind: AstType,
+    parent: u32,
+    span: Span,
+    depth: u32,
+    first_child: u32,
+    next_sibling: u32,
+}
+
+pub struct CommentAttachmentCollector<'c> {
+    comments: &'c [oxc_ast::Comment],
+    anchors: std::vec::Vec<u32>,
+    nodes: std::vec::Vec<NodeRecord>,
+    stack: std::vec::Vec<u32>,
+}
+
+macro_rules! comment_pruning_visit_method {
+    ($visit:ident, $walk:ident, $kind:ident, $ty:ty $(, $arg:ident: $arg_ty:ty)*) => {
+        #[inline]
+        fn $visit(&mut self, it: &$ty $(, $arg: $arg_ty)*) {
+            let kind = AstKind::$kind(self.alloc(it));
+            if self.intersects_comment(kind.span()) {
+                crate::walk::$walk(self, it $(, $arg)*);
+            } else {
+                self.enter_node(kind);
+                self.leave_node(kind);
+            }
+        }
+    };
+}
+
+impl<'c> CommentAttachmentCollector<'c> {
+    pub fn new(comments: &'c [oxc_ast::Comment]) -> Self {
+        let mut anchors =
+            comments.iter().map(|comment| comment.attached_to).collect::<std::vec::Vec<_>>();
+        anchors.sort_unstable();
+        anchors.dedup();
+        Self { comments, anchors, nodes: std::vec::Vec::new(), stack: std::vec::Vec::new() }
+    }
+
+    fn intersects_comment(&self, span: Span) -> bool {
+        let comment_index =
+            self.comments.partition_point(|comment| comment.span.start < span.start);
+        if self.comments.get(comment_index).is_some_and(|comment| comment.span.start < span.end) {
+            return true;
+        }
+        let anchor_index = self.anchors.partition_point(|&anchor| anchor < span.start);
+        self.anchors.get(anchor_index).is_some_and(|&anchor| anchor <= span.end)
+    }
+}
+
+impl<'a> Visit<'a> for CommentAttachmentCollector<'_> {
+    crate::generate_comment_pruning_visit_methods!();
+
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        let index = u32::try_from(self.nodes.len()).unwrap();
+        let parent = self.stack.last().copied().unwrap_or(NO_NODE);
+        let next_sibling = if parent == NO_NODE {
+            NO_NODE
+        } else {
+            let parent_index = parent as usize;
+            let first_child = self.nodes[parent_index].first_child;
+            self.nodes[parent_index].first_child = index;
+            first_child
+        };
+        self.nodes.push(NodeRecord {
+            node_id: kind.node_id(),
+            kind: kind.ty(),
+            parent,
+            span: kind.span(),
+            depth: u32::try_from(self.stack.len()).unwrap(),
+            first_child: NO_NODE,
+            next_sibling,
+        });
+        self.stack.push(index);
+    }
+
+    fn leave_node(&mut self, _kind: AstKind<'a>) {
+        self.stack.pop();
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Assignment {
+    host: u32,
+    position: AttachedCommentPosition,
+    same_line: bool,
+    force_newline_after: bool,
+}
+
+impl Assignment {
+    const UNASSIGNED: Self = Self {
+        host: NO_NODE,
+        position: AttachedCommentPosition::Before,
+        same_line: false,
+        force_newline_after: false,
+    };
+}
+
+struct Attacher<'a> {
+    source_text: &'a str,
+    nodes: &'a [NodeRecord],
+    comments: &'a [oxc_ast::Comment],
+    assignments: std::vec::Vec<Assignment>,
+    scratch: std::vec::Vec<usize>,
+    cursor: usize,
+}
+
+impl<'a> Attacher<'a> {
+    fn new(
+        source_text: &'a str,
+        nodes: &'a [NodeRecord],
+        comments: &'a [oxc_ast::Comment],
+    ) -> Self {
+        Self {
+            source_text,
+            nodes,
+            comments,
+            assignments: vec![Assignment::UNASSIGNED; comments.len()],
+            scratch: std::vec::Vec::with_capacity(32),
+            cursor: 0,
+        }
+    }
+
+    fn attach(mut self) -> std::vec::Vec<Assignment> {
+        self.attach_pure_not_applied();
+        if !self.nodes.is_empty() {
+            self.walk_at(0);
+        }
+        while self.cursor < self.comments.len() {
+            if self.assignments[self.cursor].host == NO_NODE {
+                self.assignments[self.cursor] = Assignment {
+                    host: 0,
+                    position: AttachedCommentPosition::Inside,
+                    same_line: false,
+                    force_newline_after: false,
+                };
+            }
+            self.cursor += 1;
+        }
+        self.assignments
+    }
+
+    /// `PureNotApplied` is the one deliberate parser-attachment override. It
+    /// remains trailing on the deepest node ending at the parser's token
+    /// boundary, e.g. `foo /* PURE */ = call()`.
+    fn attach_pure_not_applied(&mut self) {
+        for (comment_index, comment) in self.comments.iter().enumerate() {
+            if comment.content != CommentContent::PureNotApplied {
+                continue;
+            }
+            let host = self
+                .nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, node)| node.span.end == comment.attached_to)
+                .max_by_key(|(_, node)| (node.depth, Reverse(node.span.size())))
+                .map_or(0, |(index, _)| index);
+            self.assignments[comment_index] = Assignment {
+                host: u32::try_from(host).unwrap(),
+                position: AttachedCommentPosition::After,
+                same_line: self.same_line(self.nodes[host].span.end, comment.span.start),
+                force_newline_after: false,
+            };
+        }
+    }
+
+    fn walk_at(&mut self, node_index: usize) {
+        if self.cursor >= self.comments.len() {
+            return;
+        }
+        let node_span = self.nodes[node_index].span;
+        if self.comments[self.cursor].span.start >= node_span.end {
+            return;
+        }
+
+        let checkpoint = self.scratch.len();
+        let mut child = self.nodes[node_index].first_child;
+        while child != NO_NODE {
+            self.scratch.push(child as usize);
+            child = self.nodes[child as usize].next_sibling;
+        }
+        // Children are linked by prepending during the visitor walk. Restore
+        // visitation order so the insertion sort below sees the overwhelmingly
+        // common already-source-ordered case instead of its quadratic worst case.
+        self.scratch[checkpoint..].reverse();
+        self.sort_scratch_children(checkpoint);
+
+        let mut previous = None;
+        let mut previous_end = node_span.start;
+        let child_count = self.scratch.len() - checkpoint;
+        for offset in 0..child_count {
+            let child = self.scratch[checkpoint + offset];
+            let child_start = self.nodes[child].span.start;
+            self.consume_between(node_index, previous, previous_end, Some(child), child_start);
+            self.walk_at(child);
+            previous = Some(child);
+            previous_end = self.nodes[child].span.end;
+        }
+        self.consume_between(node_index, previous, previous_end, None, node_span.end);
+        self.scratch.truncate(checkpoint);
+    }
+
+    fn consume_between(
+        &mut self,
+        host: usize,
+        previous: Option<usize>,
+        previous_end: u32,
+        next: Option<usize>,
+        next_start: u32,
+    ) {
+        while self.cursor < self.comments.len() {
+            if self.assignments[self.cursor].host != NO_NODE {
+                self.cursor += 1;
+                continue;
+            }
+            let comment = self.comments[self.cursor];
+            if comment.span.start >= next_start {
+                return;
+            }
+
+            let assignment = match (previous, next) {
+                (Some(previous), Some(next)) => {
+                    if self.same_line(comment.span.end, next_start) {
+                        Assignment {
+                            host: u32::try_from(next).unwrap(),
+                            position: AttachedCommentPosition::Before,
+                            same_line: true,
+                            force_newline_after: false,
+                        }
+                    } else if self.same_line(previous_end, comment.span.start) {
+                        Assignment {
+                            host: u32::try_from(previous).unwrap(),
+                            position: AttachedCommentPosition::After,
+                            same_line: true,
+                            force_newline_after: true,
+                        }
+                    } else {
+                        Assignment {
+                            host: u32::try_from(next).unwrap(),
+                            position: AttachedCommentPosition::Before,
+                            same_line: false,
+                            force_newline_after: false,
+                        }
+                    }
+                }
+                (None, Some(next)) => Assignment {
+                    host: u32::try_from(next).unwrap(),
+                    position: AttachedCommentPosition::Before,
+                    same_line: self.same_line(comment.span.end, next_start),
+                    force_newline_after: false,
+                },
+                (Some(previous), None) => Assignment {
+                    host: u32::try_from(previous).unwrap(),
+                    position: AttachedCommentPosition::After,
+                    same_line: self.same_line(previous_end, comment.span.start),
+                    force_newline_after: false,
+                },
+                (None, None) => Assignment {
+                    host: u32::try_from(host).unwrap(),
+                    position: AttachedCommentPosition::Inside,
+                    same_line: false,
+                    force_newline_after: false,
+                },
+            };
+            self.assignments[self.cursor] = assignment;
+            self.cursor += 1;
+        }
+    }
+
+    fn same_line(&self, a: u32, b: u32) -> bool {
+        let (start, end) = if a <= b { (a, b) } else { (b, a) };
+        let Ok(start) = usize::try_from(start) else { return false };
+        let Ok(end) = usize::try_from(end) else { return false };
+        self.source_text.get(start..end).is_some_and(|text| !text.chars().any(is_line_terminator))
+    }
+
+    fn sort_scratch_children(&mut self, start: usize) {
+        for index in start + 1..self.scratch.len() {
+            let child = self.scratch[index];
+            let child_span = self.nodes[child].span;
+            let mut insertion = index;
+            while insertion > start {
+                let previous = self.scratch[insertion - 1];
+                let previous_span = self.nodes[previous].span;
+                if (previous_span.start, previous_span.end, previous)
+                    <= (child_span.start, child_span.end, child)
+                {
+                    break;
+                }
+                self.scratch[insertion] = previous;
+                insertion -= 1;
+            }
+            self.scratch[insertion] = child;
+        }
+    }
+}
+
+/// Assign every parser comment to an AST host after semantic NodeIds are available.
+impl CommentAttachmentCollector<'_> {
+    /// # Panics
+    ///
+    /// Panics if comment or node counts exceed the sidecar's `u32` indices.
+    pub fn attach<'a>(self, program: &Program<'a>, attachments: &CommentAttachments<'a>) {
+        attachments.clear();
+        if program.comments.is_empty() {
+            return;
+        }
+
+        let assignments =
+            Attacher::new(program.source_text, &self.nodes, &program.comments).attach();
+
+        let mut offsets = vec![0_u32; self.nodes.len() + 1];
+        for assignment in &assignments {
+            offsets[assignment.host as usize + 1] += 1;
+        }
+        for index in 0..self.nodes.len() {
+            offsets[index + 1] += offsets[index];
+        }
+        let mut write_offsets = offsets[..self.nodes.len()].to_vec();
+        let mut sorted = vec![AttachedComment::default(); program.comments.len()];
+        let mut source_only_hosts = vec![false; self.nodes.len()];
+        for (comment, assignment) in program.comments.iter().zip(&assignments) {
+            if comment.is_line() || assignment.position == AttachedCommentPosition::Inside {
+                source_only_hosts[assignment.host as usize] = true;
+            }
+        }
+        for (mut comment, assignment) in program.comments.iter().copied().zip(assignments) {
+            if assignment.force_newline_after {
+                comment.set_followed_by_newline(true);
+            }
+            let host = assignment.host as usize;
+            let node = &self.nodes[host];
+            let exact_leading = comment.is_leading() && comment.attached_to == node.span.start;
+            let owned_composite_gap = node.kind == AstType::FormalParameters
+                || (node.kind == AstType::Function
+                    && node.parent != NO_NODE
+                    && matches!(
+                        self.nodes[node.parent as usize].kind,
+                        AstType::ObjectProperty | AstType::MethodDefinition
+                    ));
+            let owned_position = match assignment.position {
+                AttachedCommentPosition::Before => exact_leading || owned_composite_gap,
+                AttachedCommentPosition::After => {
+                    comment.is_block()
+                        && matches!(node.kind, AstType::FormalParameter | AstType::ObjectExpression)
+                }
+                AttachedCommentPosition::Inside => false,
+            };
+            let target = write_offsets[host];
+            let attached = AttachedComment {
+                comment,
+                position: assignment.position,
+                same_line: assignment.same_line,
+                node_owned: !source_only_hosts[host] && owned_position,
+                node_exclusive: !source_only_hosts[host]
+                    && owned_position
+                    && (!exact_leading || assignment.position != AttachedCommentPosition::Before),
+            };
+            sorted[target as usize] = attached;
+            write_offsets[host] += 1;
+        }
+
+        for (index, node) in self.nodes.iter().enumerate() {
+            let len = offsets[index + 1] - offsets[index];
+            if len == 0 {
+                continue;
+            }
+            attachments.push_host(CommentAttachmentHost {
+                node_id: node.node_id,
+                start: offsets[index],
+                len,
+            });
+        }
+        for (index, comment) in sorted.into_iter().enumerate() {
+            attachments.set_comment(index, comment);
+        }
+    }
+}

--- a/crates/oxc_ast_visit/src/comments.rs
+++ b/crates/oxc_ast_visit/src/comments.rs
@@ -324,8 +324,35 @@ impl CommentAttachmentCollector<'_> {
             return;
         }
 
-        let assignments =
+        let mut assignments =
             Attacher::new(program.source_text, &self.nodes, &program.comments).attach();
+        let mut function_header_comments = vec![false; program.comments.len()];
+        for function in &self.nodes {
+            if function.kind != AstType::Function {
+                continue;
+            }
+            let mut child = function.first_child;
+            let mut params = None;
+            while child != NO_NODE {
+                if self.nodes[child as usize].kind == AstType::FormalParameters {
+                    params = Some(child);
+                    break;
+                }
+                child = self.nodes[child as usize].next_sibling;
+            }
+            let Some(params) = params else { continue };
+            let params_start = self.nodes[params as usize].span.start;
+            let first = program
+                .comments
+                .partition_point(|comment| comment.span.start < function.span.start);
+            let last =
+                program.comments.partition_point(|comment| comment.span.start < params_start);
+            for comment_index in first..last {
+                assignments[comment_index].host = params;
+                assignments[comment_index].position = AttachedCommentPosition::Before;
+                function_header_comments[comment_index] = true;
+            }
+        }
 
         let mut offsets = vec![0_u32; self.nodes.len() + 1];
         for assignment in &assignments {
@@ -342,7 +369,9 @@ impl CommentAttachmentCollector<'_> {
                 source_only_hosts[assignment.host as usize] = true;
             }
         }
-        for (mut comment, assignment) in program.comments.iter().copied().zip(assignments) {
+        for (comment_index, (mut comment, assignment)) in
+            program.comments.iter().copied().zip(assignments).enumerate()
+        {
             if assignment.force_newline_after {
                 comment.set_followed_by_newline(true);
             }
@@ -369,10 +398,13 @@ impl CommentAttachmentCollector<'_> {
                 comment,
                 position: assignment.position,
                 same_line: assignment.same_line,
-                node_owned: !source_only_hosts[host] && owned_position,
-                node_exclusive: !source_only_hosts[host]
-                    && owned_position
-                    && (!exact_leading || assignment.position != AttachedCommentPosition::Before),
+                node_owned: function_header_comments[comment_index]
+                    || (!source_only_hosts[host] && owned_position),
+                node_exclusive: function_header_comments[comment_index]
+                    || (!source_only_hosts[host]
+                        && owned_position
+                        && (!exact_leading
+                            || assignment.position != AttachedCommentPosition::Before)),
             };
             sorted[target as usize] = attached;
             write_offsets[host] += 1;

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4570,3 +4570,386 @@ pub mod walk {
         }
     }
 }
+macro_rules! generate_comment_pruning_visit_methods {
+    () => {
+        comment_pruning_visit_method!(visit_program, walk_program, Program, Program < 'a
+        >); comment_pruning_visit_method!(visit_identifier_name, walk_identifier_name,
+        IdentifierName, IdentifierName < 'a >);
+        comment_pruning_visit_method!(visit_identifier_reference,
+        walk_identifier_reference, IdentifierReference, IdentifierReference < 'a >);
+        comment_pruning_visit_method!(visit_binding_identifier, walk_binding_identifier,
+        BindingIdentifier, BindingIdentifier < 'a >);
+        comment_pruning_visit_method!(visit_label_identifier, walk_label_identifier,
+        LabelIdentifier, LabelIdentifier < 'a >);
+        comment_pruning_visit_method!(visit_this_expression, walk_this_expression,
+        ThisExpression, ThisExpression);
+        comment_pruning_visit_method!(visit_array_expression, walk_array_expression,
+        ArrayExpression, ArrayExpression < 'a >);
+        comment_pruning_visit_method!(visit_elision, walk_elision, Elision, Elision);
+        comment_pruning_visit_method!(visit_object_expression, walk_object_expression,
+        ObjectExpression, ObjectExpression < 'a >);
+        comment_pruning_visit_method!(visit_object_property, walk_object_property,
+        ObjectProperty, ObjectProperty < 'a >);
+        comment_pruning_visit_method!(visit_template_literal, walk_template_literal,
+        TemplateLiteral, TemplateLiteral < 'a >);
+        comment_pruning_visit_method!(visit_tagged_template_expression,
+        walk_tagged_template_expression, TaggedTemplateExpression,
+        TaggedTemplateExpression < 'a >);
+        comment_pruning_visit_method!(visit_template_element, walk_template_element,
+        TemplateElement, TemplateElement < 'a >);
+        comment_pruning_visit_method!(visit_computed_member_expression,
+        walk_computed_member_expression, ComputedMemberExpression,
+        ComputedMemberExpression < 'a >);
+        comment_pruning_visit_method!(visit_static_member_expression,
+        walk_static_member_expression, StaticMemberExpression, StaticMemberExpression <
+        'a >); comment_pruning_visit_method!(visit_private_field_expression,
+        walk_private_field_expression, PrivateFieldExpression, PrivateFieldExpression <
+        'a >); comment_pruning_visit_method!(visit_call_expression, walk_call_expression,
+        CallExpression, CallExpression < 'a >);
+        comment_pruning_visit_method!(visit_new_expression, walk_new_expression,
+        NewExpression, NewExpression < 'a >);
+        comment_pruning_visit_method!(visit_import_meta, walk_import_meta, ImportMeta,
+        ImportMeta); comment_pruning_visit_method!(visit_new_target, walk_new_target,
+        NewTarget, NewTarget); comment_pruning_visit_method!(visit_spread_element,
+        walk_spread_element, SpreadElement, SpreadElement < 'a >);
+        comment_pruning_visit_method!(visit_update_expression, walk_update_expression,
+        UpdateExpression, UpdateExpression < 'a >);
+        comment_pruning_visit_method!(visit_unary_expression, walk_unary_expression,
+        UnaryExpression, UnaryExpression < 'a >);
+        comment_pruning_visit_method!(visit_binary_expression, walk_binary_expression,
+        BinaryExpression, BinaryExpression < 'a >);
+        comment_pruning_visit_method!(visit_private_in_expression,
+        walk_private_in_expression, PrivateInExpression, PrivateInExpression < 'a >);
+        comment_pruning_visit_method!(visit_logical_expression, walk_logical_expression,
+        LogicalExpression, LogicalExpression < 'a >);
+        comment_pruning_visit_method!(visit_conditional_expression,
+        walk_conditional_expression, ConditionalExpression, ConditionalExpression < 'a
+        >); comment_pruning_visit_method!(visit_assignment_expression,
+        walk_assignment_expression, AssignmentExpression, AssignmentExpression < 'a >);
+        comment_pruning_visit_method!(visit_array_assignment_target,
+        walk_array_assignment_target, ArrayAssignmentTarget, ArrayAssignmentTarget < 'a
+        >); comment_pruning_visit_method!(visit_object_assignment_target,
+        walk_object_assignment_target, ObjectAssignmentTarget, ObjectAssignmentTarget <
+        'a >); comment_pruning_visit_method!(visit_assignment_target_rest,
+        walk_assignment_target_rest, AssignmentTargetRest, AssignmentTargetRest < 'a >);
+        comment_pruning_visit_method!(visit_assignment_target_with_default,
+        walk_assignment_target_with_default, AssignmentTargetWithDefault,
+        AssignmentTargetWithDefault < 'a >);
+        comment_pruning_visit_method!(visit_assignment_target_property_identifier,
+        walk_assignment_target_property_identifier, AssignmentTargetPropertyIdentifier,
+        AssignmentTargetPropertyIdentifier < 'a >);
+        comment_pruning_visit_method!(visit_assignment_target_property_property,
+        walk_assignment_target_property_property, AssignmentTargetPropertyProperty,
+        AssignmentTargetPropertyProperty < 'a >);
+        comment_pruning_visit_method!(visit_sequence_expression,
+        walk_sequence_expression, SequenceExpression, SequenceExpression < 'a >);
+        comment_pruning_visit_method!(visit_super, walk_super, Super, Super);
+        comment_pruning_visit_method!(visit_await_expression, walk_await_expression,
+        AwaitExpression, AwaitExpression < 'a >);
+        comment_pruning_visit_method!(visit_chain_expression, walk_chain_expression,
+        ChainExpression, ChainExpression < 'a >);
+        comment_pruning_visit_method!(visit_parenthesized_expression,
+        walk_parenthesized_expression, ParenthesizedExpression, ParenthesizedExpression <
+        'a >); comment_pruning_visit_method!(visit_directive, walk_directive, Directive,
+        Directive < 'a >); comment_pruning_visit_method!(visit_hashbang, walk_hashbang,
+        Hashbang, Hashbang < 'a >); comment_pruning_visit_method!(visit_block_statement,
+        walk_block_statement, BlockStatement, BlockStatement < 'a >);
+        comment_pruning_visit_method!(visit_variable_declaration,
+        walk_variable_declaration, VariableDeclaration, VariableDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_variable_declarator,
+        walk_variable_declarator, VariableDeclarator, VariableDeclarator < 'a >);
+        comment_pruning_visit_method!(visit_empty_statement, walk_empty_statement,
+        EmptyStatement, EmptyStatement);
+        comment_pruning_visit_method!(visit_expression_statement,
+        walk_expression_statement, ExpressionStatement, ExpressionStatement < 'a >);
+        comment_pruning_visit_method!(visit_if_statement, walk_if_statement, IfStatement,
+        IfStatement < 'a >); comment_pruning_visit_method!(visit_do_while_statement,
+        walk_do_while_statement, DoWhileStatement, DoWhileStatement < 'a >);
+        comment_pruning_visit_method!(visit_while_statement, walk_while_statement,
+        WhileStatement, WhileStatement < 'a >);
+        comment_pruning_visit_method!(visit_for_statement, walk_for_statement,
+        ForStatement, ForStatement < 'a >);
+        comment_pruning_visit_method!(visit_for_in_statement, walk_for_in_statement,
+        ForInStatement, ForInStatement < 'a >);
+        comment_pruning_visit_method!(visit_for_of_statement, walk_for_of_statement,
+        ForOfStatement, ForOfStatement < 'a >);
+        comment_pruning_visit_method!(visit_continue_statement, walk_continue_statement,
+        ContinueStatement, ContinueStatement < 'a >);
+        comment_pruning_visit_method!(visit_break_statement, walk_break_statement,
+        BreakStatement, BreakStatement < 'a >);
+        comment_pruning_visit_method!(visit_return_statement, walk_return_statement,
+        ReturnStatement, ReturnStatement < 'a >);
+        comment_pruning_visit_method!(visit_with_statement, walk_with_statement,
+        WithStatement, WithStatement < 'a >);
+        comment_pruning_visit_method!(visit_switch_statement, walk_switch_statement,
+        SwitchStatement, SwitchStatement < 'a >);
+        comment_pruning_visit_method!(visit_switch_case, walk_switch_case, SwitchCase,
+        SwitchCase < 'a >); comment_pruning_visit_method!(visit_labeled_statement,
+        walk_labeled_statement, LabeledStatement, LabeledStatement < 'a >);
+        comment_pruning_visit_method!(visit_throw_statement, walk_throw_statement,
+        ThrowStatement, ThrowStatement < 'a >);
+        comment_pruning_visit_method!(visit_try_statement, walk_try_statement,
+        TryStatement, TryStatement < 'a >);
+        comment_pruning_visit_method!(visit_catch_clause, walk_catch_clause, CatchClause,
+        CatchClause < 'a >); comment_pruning_visit_method!(visit_catch_parameter,
+        walk_catch_parameter, CatchParameter, CatchParameter < 'a >);
+        comment_pruning_visit_method!(visit_debugger_statement, walk_debugger_statement,
+        DebuggerStatement, DebuggerStatement);
+        comment_pruning_visit_method!(visit_assignment_pattern, walk_assignment_pattern,
+        AssignmentPattern, AssignmentPattern < 'a >);
+        comment_pruning_visit_method!(visit_object_pattern, walk_object_pattern,
+        ObjectPattern, ObjectPattern < 'a >);
+        comment_pruning_visit_method!(visit_binding_property, walk_binding_property,
+        BindingProperty, BindingProperty < 'a >);
+        comment_pruning_visit_method!(visit_array_pattern, walk_array_pattern,
+        ArrayPattern, ArrayPattern < 'a >);
+        comment_pruning_visit_method!(visit_binding_rest_element,
+        walk_binding_rest_element, BindingRestElement, BindingRestElement < 'a >);
+        comment_pruning_visit_method!(visit_function, walk_function, Function, Function <
+        'a >, flags : ScopeFlags); comment_pruning_visit_method!(visit_formal_parameters,
+        walk_formal_parameters, FormalParameters, FormalParameters < 'a >);
+        comment_pruning_visit_method!(visit_formal_parameter, walk_formal_parameter,
+        FormalParameter, FormalParameter < 'a >);
+        comment_pruning_visit_method!(visit_formal_parameter_rest,
+        walk_formal_parameter_rest, FormalParameterRest, FormalParameterRest < 'a >);
+        comment_pruning_visit_method!(visit_function_body, walk_function_body,
+        FunctionBody, FunctionBody < 'a >);
+        comment_pruning_visit_method!(visit_arrow_function_expression,
+        walk_arrow_function_expression, ArrowFunctionExpression, ArrowFunctionExpression
+        < 'a >); comment_pruning_visit_method!(visit_yield_expression,
+        walk_yield_expression, YieldExpression, YieldExpression < 'a >);
+        comment_pruning_visit_method!(visit_class, walk_class, Class, Class < 'a >);
+        comment_pruning_visit_method!(visit_class_body, walk_class_body, ClassBody,
+        ClassBody < 'a >); comment_pruning_visit_method!(visit_method_definition,
+        walk_method_definition, MethodDefinition, MethodDefinition < 'a >);
+        comment_pruning_visit_method!(visit_property_definition,
+        walk_property_definition, PropertyDefinition, PropertyDefinition < 'a >);
+        comment_pruning_visit_method!(visit_private_identifier, walk_private_identifier,
+        PrivateIdentifier, PrivateIdentifier < 'a >);
+        comment_pruning_visit_method!(visit_static_block, walk_static_block, StaticBlock,
+        StaticBlock < 'a >); comment_pruning_visit_method!(visit_accessor_property,
+        walk_accessor_property, AccessorProperty, AccessorProperty < 'a >);
+        comment_pruning_visit_method!(visit_import_expression, walk_import_expression,
+        ImportExpression, ImportExpression < 'a >);
+        comment_pruning_visit_method!(visit_import_declaration, walk_import_declaration,
+        ImportDeclaration, ImportDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_import_specifier, walk_import_specifier,
+        ImportSpecifier, ImportSpecifier < 'a >);
+        comment_pruning_visit_method!(visit_import_default_specifier,
+        walk_import_default_specifier, ImportDefaultSpecifier, ImportDefaultSpecifier <
+        'a >); comment_pruning_visit_method!(visit_import_namespace_specifier,
+        walk_import_namespace_specifier, ImportNamespaceSpecifier,
+        ImportNamespaceSpecifier < 'a >);
+        comment_pruning_visit_method!(visit_with_clause, walk_with_clause, WithClause,
+        WithClause < 'a >); comment_pruning_visit_method!(visit_import_attribute,
+        walk_import_attribute, ImportAttribute, ImportAttribute < 'a >);
+        comment_pruning_visit_method!(visit_export_declaration, walk_export_declaration,
+        ExportDeclaration, ExportDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_export_named_declaration,
+        walk_export_named_declaration, ExportNamedDeclaration, ExportNamedDeclaration <
+        'a >); comment_pruning_visit_method!(visit_export_from_declaration,
+        walk_export_from_declaration, ExportFromDeclaration, ExportFromDeclaration < 'a
+        >); comment_pruning_visit_method!(visit_export_default_declaration,
+        walk_export_default_declaration, ExportDefaultDeclaration,
+        ExportDefaultDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_export_all_declaration,
+        walk_export_all_declaration, ExportAllDeclaration, ExportAllDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_export_specifier, walk_export_specifier,
+        ExportSpecifier, ExportSpecifier < 'a >);
+        comment_pruning_visit_method!(visit_v8_intrinsic_expression,
+        walk_v8_intrinsic_expression, V8IntrinsicExpression, V8IntrinsicExpression < 'a
+        >); comment_pruning_visit_method!(visit_boolean_literal, walk_boolean_literal,
+        BooleanLiteral, BooleanLiteral);
+        comment_pruning_visit_method!(visit_null_literal, walk_null_literal, NullLiteral,
+        NullLiteral); comment_pruning_visit_method!(visit_numeric_literal,
+        walk_numeric_literal, NumericLiteral, NumericLiteral < 'a >);
+        comment_pruning_visit_method!(visit_string_literal, walk_string_literal,
+        StringLiteral, StringLiteral < 'a >);
+        comment_pruning_visit_method!(visit_big_int_literal, walk_big_int_literal,
+        BigIntLiteral, BigIntLiteral < 'a >);
+        comment_pruning_visit_method!(visit_reg_exp_literal, walk_reg_exp_literal,
+        RegExpLiteral, RegExpLiteral < 'a >);
+        comment_pruning_visit_method!(visit_jsx_element, walk_jsx_element, JSXElement,
+        JSXElement < 'a >); comment_pruning_visit_method!(visit_jsx_opening_element,
+        walk_jsx_opening_element, JSXOpeningElement, JSXOpeningElement < 'a >);
+        comment_pruning_visit_method!(visit_jsx_closing_element,
+        walk_jsx_closing_element, JSXClosingElement, JSXClosingElement < 'a >);
+        comment_pruning_visit_method!(visit_jsx_fragment, walk_jsx_fragment, JSXFragment,
+        JSXFragment < 'a >); comment_pruning_visit_method!(visit_jsx_opening_fragment,
+        walk_jsx_opening_fragment, JSXOpeningFragment, JSXOpeningFragment);
+        comment_pruning_visit_method!(visit_jsx_closing_fragment,
+        walk_jsx_closing_fragment, JSXClosingFragment, JSXClosingFragment);
+        comment_pruning_visit_method!(visit_jsx_namespaced_name,
+        walk_jsx_namespaced_name, JSXNamespacedName, JSXNamespacedName < 'a >);
+        comment_pruning_visit_method!(visit_jsx_member_expression,
+        walk_jsx_member_expression, JSXMemberExpression, JSXMemberExpression < 'a >);
+        comment_pruning_visit_method!(visit_jsx_expression_container,
+        walk_jsx_expression_container, JSXExpressionContainer, JSXExpressionContainer <
+        'a >); comment_pruning_visit_method!(visit_jsx_empty_expression,
+        walk_jsx_empty_expression, JSXEmptyExpression, JSXEmptyExpression);
+        comment_pruning_visit_method!(visit_jsx_attribute, walk_jsx_attribute,
+        JSXAttribute, JSXAttribute < 'a >);
+        comment_pruning_visit_method!(visit_jsx_spread_attribute,
+        walk_jsx_spread_attribute, JSXSpreadAttribute, JSXSpreadAttribute < 'a >);
+        comment_pruning_visit_method!(visit_jsx_identifier, walk_jsx_identifier,
+        JSXIdentifier, JSXIdentifier < 'a >);
+        comment_pruning_visit_method!(visit_jsx_spread_child, walk_jsx_spread_child,
+        JSXSpreadChild, JSXSpreadChild < 'a >);
+        comment_pruning_visit_method!(visit_jsx_text, walk_jsx_text, JSXText, JSXText <
+        'a >); comment_pruning_visit_method!(visit_ts_this_parameter,
+        walk_ts_this_parameter, TSThisParameter, TSThisParameter < 'a >);
+        comment_pruning_visit_method!(visit_ts_enum_declaration,
+        walk_ts_enum_declaration, TSEnumDeclaration, TSEnumDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_enum_body, walk_ts_enum_body, TSEnumBody,
+        TSEnumBody < 'a >); comment_pruning_visit_method!(visit_ts_enum_member,
+        walk_ts_enum_member, TSEnumMember, TSEnumMember < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_annotation, walk_ts_type_annotation,
+        TSTypeAnnotation, TSTypeAnnotation < 'a >);
+        comment_pruning_visit_method!(visit_ts_literal_type, walk_ts_literal_type,
+        TSLiteralType, TSLiteralType < 'a >);
+        comment_pruning_visit_method!(visit_ts_conditional_type,
+        walk_ts_conditional_type, TSConditionalType, TSConditionalType < 'a >);
+        comment_pruning_visit_method!(visit_ts_union_type, walk_ts_union_type,
+        TSUnionType, TSUnionType < 'a >);
+        comment_pruning_visit_method!(visit_ts_intersection_type,
+        walk_ts_intersection_type, TSIntersectionType, TSIntersectionType < 'a >);
+        comment_pruning_visit_method!(visit_ts_parenthesized_type,
+        walk_ts_parenthesized_type, TSParenthesizedType, TSParenthesizedType < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_operator, walk_ts_type_operator,
+        TSTypeOperator, TSTypeOperator < 'a >);
+        comment_pruning_visit_method!(visit_ts_array_type, walk_ts_array_type,
+        TSArrayType, TSArrayType < 'a >);
+        comment_pruning_visit_method!(visit_ts_indexed_access_type,
+        walk_ts_indexed_access_type, TSIndexedAccessType, TSIndexedAccessType < 'a >);
+        comment_pruning_visit_method!(visit_ts_tuple_type, walk_ts_tuple_type,
+        TSTupleType, TSTupleType < 'a >);
+        comment_pruning_visit_method!(visit_ts_named_tuple_member,
+        walk_ts_named_tuple_member, TSNamedTupleMember, TSNamedTupleMember < 'a >);
+        comment_pruning_visit_method!(visit_ts_optional_type, walk_ts_optional_type,
+        TSOptionalType, TSOptionalType < 'a >);
+        comment_pruning_visit_method!(visit_ts_rest_type, walk_ts_rest_type, TSRestType,
+        TSRestType < 'a >); comment_pruning_visit_method!(visit_ts_any_keyword,
+        walk_ts_any_keyword, TSAnyKeyword, TSAnyKeyword);
+        comment_pruning_visit_method!(visit_ts_string_keyword, walk_ts_string_keyword,
+        TSStringKeyword, TSStringKeyword);
+        comment_pruning_visit_method!(visit_ts_boolean_keyword, walk_ts_boolean_keyword,
+        TSBooleanKeyword, TSBooleanKeyword);
+        comment_pruning_visit_method!(visit_ts_number_keyword, walk_ts_number_keyword,
+        TSNumberKeyword, TSNumberKeyword);
+        comment_pruning_visit_method!(visit_ts_never_keyword, walk_ts_never_keyword,
+        TSNeverKeyword, TSNeverKeyword);
+        comment_pruning_visit_method!(visit_ts_intrinsic_keyword,
+        walk_ts_intrinsic_keyword, TSIntrinsicKeyword, TSIntrinsicKeyword);
+        comment_pruning_visit_method!(visit_ts_unknown_keyword, walk_ts_unknown_keyword,
+        TSUnknownKeyword, TSUnknownKeyword);
+        comment_pruning_visit_method!(visit_ts_null_keyword, walk_ts_null_keyword,
+        TSNullKeyword, TSNullKeyword);
+        comment_pruning_visit_method!(visit_ts_undefined_keyword,
+        walk_ts_undefined_keyword, TSUndefinedKeyword, TSUndefinedKeyword);
+        comment_pruning_visit_method!(visit_ts_void_keyword, walk_ts_void_keyword,
+        TSVoidKeyword, TSVoidKeyword);
+        comment_pruning_visit_method!(visit_ts_symbol_keyword, walk_ts_symbol_keyword,
+        TSSymbolKeyword, TSSymbolKeyword);
+        comment_pruning_visit_method!(visit_ts_this_type, walk_ts_this_type, TSThisType,
+        TSThisType); comment_pruning_visit_method!(visit_ts_object_keyword,
+        walk_ts_object_keyword, TSObjectKeyword, TSObjectKeyword);
+        comment_pruning_visit_method!(visit_ts_big_int_keyword, walk_ts_big_int_keyword,
+        TSBigIntKeyword, TSBigIntKeyword);
+        comment_pruning_visit_method!(visit_ts_type_reference, walk_ts_type_reference,
+        TSTypeReference, TSTypeReference < 'a >);
+        comment_pruning_visit_method!(visit_ts_qualified_name, walk_ts_qualified_name,
+        TSQualifiedName, TSQualifiedName < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_parameter_instantiation,
+        walk_ts_type_parameter_instantiation, TSTypeParameterInstantiation,
+        TSTypeParameterInstantiation < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_parameter, walk_ts_type_parameter,
+        TSTypeParameter, TSTypeParameter < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_parameter_declaration,
+        walk_ts_type_parameter_declaration, TSTypeParameterDeclaration,
+        TSTypeParameterDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_alias_declaration,
+        walk_ts_type_alias_declaration, TSTypeAliasDeclaration, TSTypeAliasDeclaration <
+        'a >); comment_pruning_visit_method!(visit_ts_class_implements,
+        walk_ts_class_implements, TSClassImplements, TSClassImplements < 'a >);
+        comment_pruning_visit_method!(visit_ts_interface_declaration,
+        walk_ts_interface_declaration, TSInterfaceDeclaration, TSInterfaceDeclaration <
+        'a >); comment_pruning_visit_method!(visit_ts_interface_body,
+        walk_ts_interface_body, TSInterfaceBody, TSInterfaceBody < 'a >);
+        comment_pruning_visit_method!(visit_ts_property_signature,
+        walk_ts_property_signature, TSPropertySignature, TSPropertySignature < 'a >);
+        comment_pruning_visit_method!(visit_ts_index_signature, walk_ts_index_signature,
+        TSIndexSignature, TSIndexSignature < 'a >);
+        comment_pruning_visit_method!(visit_ts_call_signature_declaration,
+        walk_ts_call_signature_declaration, TSCallSignatureDeclaration,
+        TSCallSignatureDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_method_signature,
+        walk_ts_method_signature, TSMethodSignature, TSMethodSignature < 'a >);
+        comment_pruning_visit_method!(visit_ts_construct_signature_declaration,
+        walk_ts_construct_signature_declaration, TSConstructSignatureDeclaration,
+        TSConstructSignatureDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_index_signature_name,
+        walk_ts_index_signature_name, TSIndexSignatureName, TSIndexSignatureName < 'a >);
+        comment_pruning_visit_method!(visit_ts_interface_heritage,
+        walk_ts_interface_heritage, TSInterfaceHeritage, TSInterfaceHeritage < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_predicate, walk_ts_type_predicate,
+        TSTypePredicate, TSTypePredicate < 'a >);
+        comment_pruning_visit_method!(visit_ts_external_module_declaration,
+        walk_ts_external_module_declaration, TSExternalModuleDeclaration,
+        TSExternalModuleDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_namespace_declaration,
+        walk_ts_namespace_declaration, TSNamespaceDeclaration, TSNamespaceDeclaration <
+        'a >); comment_pruning_visit_method!(visit_ts_global_declaration,
+        walk_ts_global_declaration, TSGlobalDeclaration, TSGlobalDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_module_block, walk_ts_module_block,
+        TSModuleBlock, TSModuleBlock < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_literal, walk_ts_type_literal,
+        TSTypeLiteral, TSTypeLiteral < 'a >);
+        comment_pruning_visit_method!(visit_ts_infer_type, walk_ts_infer_type,
+        TSInferType, TSInferType < 'a >);
+        comment_pruning_visit_method!(visit_ts_type_query, walk_ts_type_query,
+        TSTypeQuery, TSTypeQuery < 'a >);
+        comment_pruning_visit_method!(visit_ts_import_type, walk_ts_import_type,
+        TSImportType, TSImportType < 'a >);
+        comment_pruning_visit_method!(visit_ts_import_type_qualified_name,
+        walk_ts_import_type_qualified_name, TSImportTypeQualifiedName,
+        TSImportTypeQualifiedName < 'a >);
+        comment_pruning_visit_method!(visit_ts_function_type, walk_ts_function_type,
+        TSFunctionType, TSFunctionType < 'a >);
+        comment_pruning_visit_method!(visit_ts_constructor_type,
+        walk_ts_constructor_type, TSConstructorType, TSConstructorType < 'a >);
+        comment_pruning_visit_method!(visit_ts_mapped_type, walk_ts_mapped_type,
+        TSMappedType, TSMappedType < 'a >);
+        comment_pruning_visit_method!(visit_ts_template_literal_type,
+        walk_ts_template_literal_type, TSTemplateLiteralType, TSTemplateLiteralType < 'a
+        >); comment_pruning_visit_method!(visit_ts_as_expression, walk_ts_as_expression,
+        TSAsExpression, TSAsExpression < 'a >);
+        comment_pruning_visit_method!(visit_ts_satisfies_expression,
+        walk_ts_satisfies_expression, TSSatisfiesExpression, TSSatisfiesExpression < 'a
+        >); comment_pruning_visit_method!(visit_ts_type_assertion,
+        walk_ts_type_assertion, TSTypeAssertion, TSTypeAssertion < 'a >);
+        comment_pruning_visit_method!(visit_ts_import_equals_declaration,
+        walk_ts_import_equals_declaration, TSImportEqualsDeclaration,
+        TSImportEqualsDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_external_module_reference,
+        walk_ts_external_module_reference, TSExternalModuleReference,
+        TSExternalModuleReference < 'a >);
+        comment_pruning_visit_method!(visit_ts_non_null_expression,
+        walk_ts_non_null_expression, TSNonNullExpression, TSNonNullExpression < 'a >);
+        comment_pruning_visit_method!(visit_decorator, walk_decorator, Decorator,
+        Decorator < 'a >); comment_pruning_visit_method!(visit_ts_export_assignment,
+        walk_ts_export_assignment, TSExportAssignment, TSExportAssignment < 'a >);
+        comment_pruning_visit_method!(visit_ts_namespace_export_declaration,
+        walk_ts_namespace_export_declaration, TSNamespaceExportDeclaration,
+        TSNamespaceExportDeclaration < 'a >);
+        comment_pruning_visit_method!(visit_ts_instantiation_expression,
+        walk_ts_instantiation_expression, TSInstantiationExpression,
+        TSInstantiationExpression < 'a >);
+        comment_pruning_visit_method!(visit_js_doc_nullable_type,
+        walk_js_doc_nullable_type, JSDocNullableType, JSDocNullableType < 'a >);
+        comment_pruning_visit_method!(visit_js_doc_non_nullable_type,
+        walk_js_doc_non_nullable_type, JSDocNonNullableType, JSDocNonNullableType < 'a
+        >); comment_pruning_visit_method!(visit_js_doc_unknown_type,
+        walk_js_doc_unknown_type, JSDocUnknownType, JSDocUnknownType);
+    };
+}
+pub(crate) use generate_comment_pruning_visit_methods;

--- a/crates/oxc_ast_visit/src/lib.rs
+++ b/crates/oxc_ast_visit/src/lib.rs
@@ -9,5 +9,7 @@ mod generated {
 
 pub use generated::{visit::*, visit_js::*, visit_js_mut::*, visit_mut::*};
 
+pub mod comments;
+
 #[cfg(feature = "serialize")]
 pub mod utf8_to_utf16;

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -239,15 +239,24 @@ impl<'a> BinaryExpressionVisitor<'a> {
         self.operator.r#gen(p);
         p.print_soft_space();
         let right = self.e.right();
-        if let Binaryish::Logical(e) = self.e {
+        let suppress_normal_comments = if let Binaryish::Logical(e) = self.e {
             // Annotation-gated (see the helper's doc): statements get merged
             // into logical RHS positions on mutated ASTs. Pass the unstripped
             // right — `Binaryish::right()` removes the paren layers the helper
             // needs to probe.
             p.print_annotation_comments_before_expression(&e.right);
-        }
+            true
+        } else {
+            false
+        };
         if !cjs_module_lexer::try_print_equality_string(p, self.operator, right) {
-            right.gen_expr(p, self.right_precedence, self.ctx);
+            if suppress_normal_comments {
+                p.with_suppressed_normal_comments(|p| {
+                    right.gen_expr(p, self.right_precedence, self.ctx);
+                });
+            } else {
+                right.gen_expr(p, self.right_precedence, self.ctx);
+            }
         }
         if self.wrap {
             p.print_ascii_byte(b')');

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -99,6 +99,19 @@ impl NodeCommentStore {
         Some(std::mem::take(&mut self.hosts[host_index].1))
     }
 
+    fn has_before(&self, node_id: NodeId) -> bool {
+        let index = node_id.index();
+        let Some(word) = self.presence.get(index >> 6) else { return false };
+        if word & (1 << (index & 63)) == 0 {
+            return false;
+        }
+        let Ok(host_index) = self.hosts.binary_search_by_key(&index, |(id, _)| id.index()) else {
+            return false;
+        };
+        let comments = &self.hosts[host_index].1;
+        !comments.before.is_empty() || !comments.inside.is_empty()
+    }
+
     fn remove_comments(&mut self, removed: &[Comment]) {
         for comment in removed {
             let Some(node_id) = self.owners.remove(&comment.span.start) else { continue };
@@ -569,6 +582,10 @@ impl Codegen<'_> {
     #[inline]
     pub(crate) fn take_node_comments(&mut self, node_id: NodeId) -> Option<NodeComments> {
         self.node_comments.take_all(node_id)
+    }
+
+    pub(crate) fn has_node_comments_before_id(&self, node_id: NodeId) -> bool {
+        self.node_comments.has_before(node_id)
     }
 
     #[inline]
@@ -1099,9 +1116,12 @@ impl Codegen<'_> {
     /// Print comments attached to any position in the given range `(start, end)` (exclusive).
     /// Returns `true` if any comments were printed.
     pub(crate) fn print_comments_in_range(&mut self, start: u32, end: u32) -> bool {
-        let comments = self.comments.take_between(start, end, |comment| {
+        let source_text = self.source_text;
+        let mut comments = self.comments.take_between(start, end, |comment| {
             !comment.is_pure() && !comment.is_no_side_effects()
         });
+        comments
+            .retain(|comment| !comment.is_trailing() || !is_html_comment(*comment, source_text));
         if comments.is_empty() {
             return false;
         }
@@ -1115,7 +1135,9 @@ impl Codegen<'_> {
 
     pub(crate) fn comments_in_range_need_space_after(&self, start: u32, end: u32) -> bool {
         let Some(comment) = self.comments.first_between(start, end, |comment| {
-            !comment.is_pure() && !comment.is_no_side_effects()
+            !comment.is_pure()
+                && !comment.is_no_side_effects()
+                && (!comment.is_trailing() || !is_html_comment(*comment, self.source_text))
         }) else {
             return false;
         };

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -4,35 +4,466 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use oxc_ast::{
-    Comment, CommentKind,
+    AttachedCommentPosition, Comment, CommentContent, CommentKind, GetNodeId,
     ast::{Expression, Program},
 };
 use oxc_span::GetSpan;
-use oxc_syntax::line_terminator::LineTerminatorSplitter;
+use oxc_syntax::{line_terminator::LineTerminatorSplitter, node::NodeId};
 
 use crate::{Codegen, LegalComment, options::CommentOptions};
 
 type CommentList = SmallVec<[Comment; 1]>;
 
-pub type CommentsMap = FxHashMap</* attached_to */ u32, CommentList>;
+#[derive(Default)]
+pub struct NodeCommentStore {
+    hosts: Vec<(NodeId, NodeComments)>,
+    presence: Box<[u64]>,
+    owners: FxHashMap<u32, NodeId>,
+    exclusive: Vec<u32>,
+}
+
+#[derive(Default)]
+pub struct NodeComments {
+    before: CommentList,
+    inside: CommentList,
+    after: CommentList,
+}
+
+pub struct BoundaryComments {
+    pub node: Option<NodeComments>,
+    pub leading: bool,
+    pub trailing: bool,
+}
+
+impl NodeCommentStore {
+    fn build(program: &Program<'_>, mut retain: impl FnMut(Comment) -> bool) -> Option<Self> {
+        let attachments = program.comment_attachments.0.as_deref()?;
+        if attachments.is_empty() {
+            return None;
+        }
+
+        let mut hosts = Vec::new();
+        let mut owners = FxHashMap::default();
+        let mut exclusive = Vec::new();
+        for host_index in 0..attachments.host_len() {
+            let host = attachments.host(host_index);
+            let node_id = host.node_id;
+            let start = host.start as usize;
+            let end = start + host.len as usize;
+            let mut comments = NodeComments::default();
+            for attached_index in start..end {
+                let attached = attachments.comment(attached_index);
+                let comment = attached.comment;
+                if !attached.node_owned || !retain(comment) {
+                    continue;
+                }
+                owners.insert(comment.span.start, node_id);
+                if attached.node_exclusive {
+                    exclusive.push(comment.span.start);
+                }
+                match attached.position {
+                    AttachedCommentPosition::Before => comments.before.push(comment),
+                    AttachedCommentPosition::After => comments.after.push(comment),
+                    AttachedCommentPosition::Inside => comments.inside.push(comment),
+                }
+            }
+            if !comments.before.is_empty()
+                || !comments.inside.is_empty()
+                || !comments.after.is_empty()
+            {
+                hosts.push((node_id, comments));
+            }
+        }
+
+        hosts.sort_unstable_by_key(|(node_id, _)| node_id.index());
+        let mut presence = hosts.last().map_or_else(Box::default, |(node_id, _)| {
+            vec![0; (node_id.index() >> 6) + 1].into_boxed_slice()
+        });
+        for (node_id, _) in &hosts {
+            presence[node_id.index() >> 6] |= 1 << (node_id.index() & 63);
+        }
+        exclusive.sort_unstable();
+        Some(Self { hosts, presence, owners, exclusive })
+    }
+
+    #[inline]
+    fn take_all(&mut self, node_id: NodeId) -> Option<NodeComments> {
+        let index = node_id.index();
+        let word = self.presence.get_mut(index >> 6)?;
+        let mask = 1 << (index & 63);
+        if *word & mask == 0 {
+            return None;
+        }
+        *word &= !mask;
+        let host_index = self.hosts.binary_search_by_key(&index, |(id, _)| id.index()).unwrap();
+        Some(std::mem::take(&mut self.hosts[host_index].1))
+    }
+
+    fn remove_comments(&mut self, removed: &[Comment]) {
+        for comment in removed {
+            let Some(node_id) = self.owners.remove(&comment.span.start) else { continue };
+            let node_index = node_id.index();
+            let Some(word) = self.presence.get_mut(node_index >> 6) else { continue };
+            let mask = 1 << (node_index & 63);
+            if *word & mask == 0 {
+                continue;
+            }
+            let host_index =
+                self.hosts.binary_search_by_key(&node_index, |(id, _)| id.index()).unwrap();
+            let node_comments = &mut self.hosts[host_index].1;
+            let mut removed_count = 0;
+            for comments in
+                [&mut node_comments.before, &mut node_comments.inside, &mut node_comments.after]
+            {
+                let before = comments.len();
+                comments.retain(|candidate| candidate.span != comment.span);
+                removed_count += before - comments.len();
+            }
+            if removed_count != 0
+                && node_comments.before.is_empty()
+                && node_comments.inside.is_empty()
+                && node_comments.after.is_empty()
+            {
+                *word &= !mask;
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct CommentStore {
+    groups: Vec<CommentGroup>,
+    anchor_presence: Box<[u64]>,
+    orphan_indices: Box<[usize]>,
+    remaining: usize,
+}
+
+struct CommentGroup {
+    anchor: u32,
+    leading: CommentList,
+    trailing: CommentList,
+}
+
+impl CommentStore {
+    fn build(comments: &mut Vec<Comment>) -> Self {
+        let remaining = comments.len();
+        if comments.windows(2).any(|comments| {
+            let [left, right] = comments else { unreachable!() };
+            (left.attached_to, left.span.start) > (right.attached_to, right.span.start)
+        }) {
+            comments.sort_unstable_by_key(|comment| (comment.attached_to, comment.span.start));
+        }
+        let mut groups = Vec::<CommentGroup>::new();
+        let mut anchor_presence = if let Some(last) = comments.last() {
+            vec![0; (last.attached_to as usize >> 6) + 1].into_boxed_slice()
+        } else {
+            Box::default()
+        };
+        for comment in comments.drain(..) {
+            if groups.last().is_none_or(|group| group.anchor != comment.attached_to) {
+                let anchor = comment.attached_to as usize;
+                anchor_presence[anchor >> 6] |= 1 << (anchor & 63);
+                groups.push(CommentGroup {
+                    anchor: comment.attached_to,
+                    leading: CommentList::new(),
+                    trailing: CommentList::new(),
+                });
+            }
+            let group = groups.last_mut().unwrap();
+            if comment.is_leading() {
+                group.leading.push(comment);
+            } else {
+                group.trailing.push(comment);
+            }
+        }
+        let orphan_indices = groups
+            .iter()
+            .enumerate()
+            .filter_map(|(index, group)| {
+                group
+                    .leading
+                    .iter()
+                    .chain(&group.trailing)
+                    .any(|comment| preserve_when_orphaned(*comment))
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { groups, anchor_presence, orphan_indices, remaining }
+    }
+
+    #[inline]
+    fn may_have_anchor(&self, anchor: u32) -> bool {
+        if self.remaining == 0 {
+            return false;
+        }
+        let anchor = anchor as usize;
+        self.anchor_presence.get(anchor >> 6).is_some_and(|word| word & (1 << (anchor & 63)) != 0)
+    }
+
+    #[inline]
+    fn index(&self, anchor: u32) -> Option<usize> {
+        if !self.may_have_anchor(anchor) {
+            return None;
+        }
+        self.groups.binary_search_by_key(&anchor, |group| group.anchor).ok()
+    }
+
+    #[inline]
+    fn clear_if_empty(&mut self, index: usize) {
+        let group = &self.groups[index];
+        if group.leading.is_empty() && group.trailing.is_empty() {
+            let anchor = group.anchor as usize;
+            self.anchor_presence[anchor >> 6] &= !(1 << (anchor & 63));
+        }
+    }
+
+    fn has_non_semantic_at(&self, anchor: u32) -> bool {
+        self.index(anchor).is_some_and(|index| {
+            let group = &self.groups[index];
+            group
+                .leading
+                .iter()
+                .chain(&group.trailing)
+                .any(|comment| !comment.is_pure() && !comment.is_no_side_effects())
+        })
+    }
+
+    #[inline]
+    fn leading_at(&self, anchor: u32) -> Option<&CommentList> {
+        let group = self.index(anchor).map(|index| &self.groups[index])?;
+        (!group.leading.is_empty()).then_some(&group.leading)
+    }
+
+    #[inline]
+    fn trailing_at(&self, anchor: u32) -> Option<&CommentList> {
+        let group = self.index(anchor).map(|index| &self.groups[index])?;
+        (!group.trailing.is_empty()).then_some(&group.trailing)
+    }
+
+    fn take_leading_at(&mut self, anchor: u32) -> Option<CommentList> {
+        let index = self.index(anchor)?;
+        if self.groups[index].leading.is_empty() {
+            return None;
+        }
+        let comments = std::mem::take(&mut self.groups[index].leading);
+        self.remaining -= comments.len();
+        self.clear_if_empty(index);
+        Some(comments)
+    }
+
+    fn take_trailing_at(&mut self, anchor: u32) -> Option<CommentList> {
+        let index = self.index(anchor)?;
+        if self.groups[index].trailing.is_empty() {
+            return None;
+        }
+        let comments = std::mem::take(&mut self.groups[index].trailing);
+        self.remaining -= comments.len();
+        self.clear_if_empty(index);
+        Some(comments)
+    }
+
+    fn take_matching_at(
+        &mut self,
+        anchor: u32,
+        predicate: impl Fn(&Comment) -> bool + Copy,
+    ) -> CommentList {
+        let Some(index) = self.index(anchor) else { return CommentList::new() };
+        let group = &mut self.groups[index];
+        let mut comments = take_matching(&mut group.leading, predicate);
+        comments.extend(take_matching(&mut group.trailing, predicate));
+        comments.sort_unstable_by_key(|comment| comment.span.start);
+        self.remaining -= comments.len();
+        self.clear_if_empty(index);
+        comments
+    }
+
+    fn take_matching_leading_at(
+        &mut self,
+        anchor: u32,
+        predicate: impl Fn(&Comment) -> bool,
+    ) -> CommentList {
+        let Some(index) = self.index(anchor) else { return CommentList::new() };
+        let comments = take_matching(&mut self.groups[index].leading, predicate);
+        self.remaining -= comments.len();
+        self.clear_if_empty(index);
+        comments
+    }
+
+    fn nearest_matching_leading_anchor(
+        &self,
+        anchor: u32,
+        predicate: impl Fn(&Comment) -> bool,
+    ) -> Option<u32> {
+        let end = self.groups.partition_point(|group| group.anchor <= anchor);
+        self.groups[..end]
+            .iter()
+            .rev()
+            .find(|group| group.leading.iter().any(&predicate))
+            .map(|group| group.anchor)
+    }
+
+    fn take_matching_trailing_at(
+        &mut self,
+        anchor: u32,
+        predicate: impl Fn(&Comment) -> bool,
+    ) -> CommentList {
+        let Some(index) = self.index(anchor) else { return CommentList::new() };
+        let comments = take_matching(&mut self.groups[index].trailing, predicate);
+        self.remaining -= comments.len();
+        self.clear_if_empty(index);
+        comments
+    }
+
+    fn remove_comments(&mut self, removed: &[Comment]) {
+        if removed.is_empty() || self.remaining == 0 {
+            return;
+        }
+        for comment in removed {
+            let Some(index) = self.index(comment.attached_to) else { continue };
+            let group = &mut self.groups[index];
+            for comments in [&mut group.leading, &mut group.trailing] {
+                let before = comments.len();
+                comments.retain(|candidate| candidate.span != comment.span);
+                self.remaining -= before - comments.len();
+            }
+            self.clear_if_empty(index);
+        }
+    }
+
+    #[inline]
+    fn bounds(&self, start: u32, end: u32, inclusive: bool) -> (usize, usize) {
+        let first = self.groups.partition_point(|group| group.anchor < start);
+        let last = if inclusive {
+            self.groups.partition_point(|group| group.anchor <= end)
+        } else {
+            self.groups.partition_point(|group| group.anchor < end)
+        };
+        (first, last)
+    }
+
+    fn has_between(&self, start: u32, end: u32) -> bool {
+        if start >= end {
+            return false;
+        }
+        let (first, last) = self.bounds(start.saturating_add(1), end, false);
+        self.groups[first..last]
+            .iter()
+            .any(|group| !group.leading.is_empty() || !group.trailing.is_empty())
+    }
+
+    fn first_between(
+        &self,
+        start: u32,
+        end: u32,
+        predicate: impl Fn(&Comment) -> bool,
+    ) -> Option<Comment> {
+        if start >= end {
+            return None;
+        }
+        let (first, last) = self.bounds(start.saturating_add(1), end, false);
+        self.groups[first..last]
+            .iter()
+            .flat_map(|group| group.leading.iter().chain(&group.trailing))
+            .filter(|comment| predicate(comment))
+            .min_by_key(|comment| comment.span.start)
+            .copied()
+    }
+
+    fn take_between(
+        &mut self,
+        start: u32,
+        end: u32,
+        predicate: impl Fn(&Comment) -> bool + Copy,
+    ) -> CommentList {
+        if start >= end {
+            return CommentList::new();
+        }
+        let (first, last) = self.bounds(start.saturating_add(1), end, false);
+        let mut comments = CommentList::new();
+        for group in &mut self.groups[first..last] {
+            comments.extend(take_matching(&mut group.leading, predicate));
+            comments.extend(take_matching(&mut group.trailing, predicate));
+        }
+        for index in first..last {
+            self.clear_if_empty(index);
+        }
+        comments.sort_unstable_by_key(|comment| comment.span.start);
+        self.remaining -= comments.len();
+        comments
+    }
+
+    fn has_orphan_before(&self, end: u32) -> bool {
+        let last = self.orphan_indices.partition_point(|&index| self.groups[index].anchor < end);
+        self.orphan_indices[..last].iter().any(|&index| {
+            let group = &self.groups[index];
+            group
+                .leading
+                .iter()
+                .chain(&group.trailing)
+                .any(|comment| preserve_when_orphaned(*comment))
+        })
+    }
+
+    fn take_orphans_before(&mut self, end: u32) -> CommentList {
+        let last = self.orphan_indices.partition_point(|&index| self.groups[index].anchor < end);
+        let mut comments = CommentList::new();
+        for orphan_index in 0..last {
+            let group_index = self.orphan_indices[orphan_index];
+            let group = &mut self.groups[group_index];
+            comments.extend(take_matching(&mut group.leading, |comment| {
+                preserve_when_orphaned(*comment)
+            }));
+            comments.extend(take_matching(&mut group.trailing, |comment| {
+                preserve_when_orphaned(*comment)
+            }));
+            self.clear_if_empty(group_index);
+        }
+        comments.sort_unstable_by_key(|comment| comment.span.start);
+        self.remaining -= comments.len();
+        comments
+    }
+}
+
+fn take_matching(comments: &mut CommentList, predicate: impl Fn(&Comment) -> bool) -> CommentList {
+    let mut taken = CommentList::new();
+    comments.retain(|comment| {
+        if predicate(comment) {
+            taken.push(*comment);
+            false
+        } else {
+            true
+        }
+    });
+    taken
+}
 
 /// Whether a comment remains meaningful if its original AST anchor is removed.
 fn preserve_when_orphaned(comment: Comment) -> bool {
     comment.is_legal() || comment.is_coverage_ignore_file()
 }
 
+fn is_html_comment(comment: Comment, source_text: Option<&str>) -> bool {
+    comment.is_line()
+        && source_text.is_some_and(|source_text| {
+            let value = comment.span.source_text(source_text);
+            value.starts_with("<!--") || value.starts_with("-->")
+        })
+}
+
 /// A `pife`-marked arrow or function expression prints its leading comments
 /// inside its own `(` wrap, so operand emission sites must not consume them.
-fn is_pife_function(expression: &Expression<'_>) -> bool {
+pub fn is_pife_function(expression: &Expression<'_>) -> bool {
     match expression {
         Expression::ArrowFunctionExpression(arrow) => arrow.pife,
         Expression::FunctionExpression(function) => function.pife,
+        Expression::ParenthesizedExpression(paren) => is_pife_function(&paren.expression),
         _ => false,
     }
 }
 
 /// Which annotation kind an emission site expects to recover from
-/// [`Codegen::annotation_comments`].
+/// [`Codegen::comments`].
 ///
 /// `@__PURE__` / `#__PURE__` on a `CallExpression` or `NewExpression`, and
 /// `@__NO_SIDE_EFFECTS__` / `#__NO_SIDE_EFFECTS__` on a function declaration or
@@ -71,49 +502,174 @@ impl AnnotationKind {
 }
 
 impl Codegen<'_> {
+    #[inline]
+    pub(crate) fn has_pending_comments(&self) -> bool {
+        self.comments.remaining != 0
+    }
+
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
         if self.options.comments == CommentOptions::disabled() {
             return;
         }
-        // Each retained comment can create at most one map entry. Reserving
-        // this upper bound avoids incremental map growth while preprocessing.
-        self.comments.reserve(comments.len());
+        let mut retained = Vec::with_capacity(comments.len());
         for comment in comments {
-            // Stash pure / no-side-effects comments by `attached_to` so the
-            // emission site can recover the verbatim source text instead of
-            // falling back to the canonical literal (rolldown#9408).
-            // Best-effort: when several annotation comments share an
-            // `attached_to`, only the last survives; the emission site falls
-            // back to the canonical literal for the dropped ones.
             if comment.is_pure() || comment.is_no_side_effects() {
                 if comment.is_leading() && self.options.print_annotation_comment() {
-                    self.annotation_comments.insert(comment.attached_to, *comment);
+                    retained.push(*comment);
                 }
                 continue;
             }
 
-            let mut add = false;
-            if comment.is_leading() {
-                add = (comment.is_legal() && self.options.print_legal_comment())
-                    || (comment.is_jsdoc() && self.options.print_jsdoc_comment())
-                    || (comment.is_annotation() && self.options.print_annotation_comment())
-                    || (comment.is_normal() && self.options.print_normal_comment());
-            }
+            let add = (comment.is_legal() && self.options.print_legal_comment())
+                || (comment.is_jsdoc() && self.options.print_jsdoc_comment())
+                || (comment.is_annotation() && self.options.print_annotation_comment())
+                || (comment.is_normal() && self.options.print_normal_comment());
 
             if add {
                 self.has_property_key_annotations |= comment.is_property_key_annotation();
-                if preserve_when_orphaned(*comment)
-                    && let Err(idx) = self.orphan_comment_keys.binary_search(&comment.attached_to)
-                {
-                    self.orphan_comment_keys.insert(idx, comment.attached_to);
-                }
-                self.comments.entry(comment.attached_to).or_default().push(*comment);
+                retained.push(*comment);
             }
+        }
+        self.comments = CommentStore::build(&mut retained);
+    }
+
+    /// Build the fast NodeId-owned comment store produced by semantic analysis.
+    pub(crate) fn build_node_comments(&mut self, program: &Program<'_>) -> bool {
+        let Some(store) = NodeCommentStore::build(program, |comment| {
+            if comment.is_line()
+                || comment.is_pure()
+                || comment.is_no_side_effects()
+                || comment.is_property_key_annotation()
+                || preserve_when_orphaned(comment)
+            {
+                return false;
+            }
+            (comment.is_legal() && self.options.print_legal_comment())
+                || (comment.is_jsdoc() && self.options.print_jsdoc_comment())
+                || (comment.is_annotation() && self.options.print_annotation_comment())
+                || (comment.is_normal() && self.options.print_normal_comment())
+        }) else {
+            return false;
+        };
+        self.node_comments = store;
+        // Keep the source-offset store as the recovery owner for removed or
+        // replaced hosts. A successful node claim removes its matching copy.
+        let fallback_comments = program
+            .comments
+            .iter()
+            .copied()
+            .filter(|comment| {
+                self.node_comments.exclusive.binary_search(&comment.span.start).is_err()
+            })
+            .collect::<Vec<_>>();
+        self.build_comments(&fallback_comments);
+        true
+    }
+
+    #[inline]
+    pub(crate) fn take_node_comments(&mut self, node_id: NodeId) -> Option<NodeComments> {
+        self.node_comments.take_all(node_id)
+    }
+
+    #[inline]
+    pub(crate) fn take_boundary_comments(
+        &mut self,
+        node_id: NodeId,
+        start: u32,
+        end: u32,
+    ) -> Option<BoundaryComments> {
+        let node = self.node_comments.take_all(node_id);
+        let leading = self.comments.may_have_anchor(start);
+        let trailing = self.comments.may_have_anchor(end);
+        (node.is_some() || leading || trailing).then_some(BoundaryComments {
+            node,
+            leading,
+            trailing,
+        })
+    }
+
+    #[inline]
+    pub(crate) fn take_expression_boundary_comments(
+        &mut self,
+        expression: &Expression<'_>,
+    ) -> Option<BoundaryComments> {
+        let node = self.node_comments.take_all(expression.get_node_id());
+        let leading = self.may_have_comments_before_expression(expression);
+        let trailing = self.comments.may_have_anchor(expression.span().end);
+        (node.is_some() || leading || trailing).then_some(BoundaryComments {
+            node,
+            leading,
+            trailing,
+        })
+    }
+
+    fn may_have_comments_before_expression(&self, expression: &Expression<'_>) -> bool {
+        if is_pife_function(expression) || matches!(expression, Expression::ObjectExpression(_)) {
+            return false;
+        }
+        self.comments.may_have_anchor(expression.span().start)
+            || matches!(expression, Expression::ParenthesizedExpression(paren) if self.may_have_comments_before_expression(&paren.expression))
+    }
+
+    pub(crate) fn print_node_comments_before_id(&mut self, node_id: NodeId) {
+        if let Some(mut comments) = self.take_node_comments(node_id) {
+            self.print_node_comments_before(&mut comments);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn print_node_comments_before(&mut self, node_comments: &mut NodeComments) {
+        let comments = if node_comments.before.is_empty() {
+            std::mem::take(&mut node_comments.inside)
+        } else {
+            let mut comments = std::mem::take(&mut node_comments.before);
+            if !node_comments.inside.is_empty() {
+                comments.extend(std::mem::take(&mut node_comments.inside));
+                comments.sort_unstable_by_key(|comment| comment.span.start);
+            }
+            comments
+        };
+        // Until a delimiter claims `inside` explicitly, printing it at the
+        // host's entry is the safe lossless fallback.
+        if comments.is_empty() {
+            return;
+        }
+        self.comments.remove_comments(&comments);
+        self.print_comments_inner(&comments);
+        if self.last_byte() != Some(b'\n') {
+            self.consume_pending_indent_space();
+        }
+    }
+
+    #[inline]
+    pub(crate) fn print_node_comments_after(&mut self, node_comments: &mut NodeComments) {
+        let comments = std::mem::take(&mut node_comments.after);
+        if comments.is_empty() {
+            return;
+        }
+        self.comments.remove_comments(&comments);
+        let removed_newline = self.last_byte() == Some(b'\n');
+        if removed_newline {
+            self.code.pop_byte();
+        }
+        if self.last_byte() != Some(b'\n') && !self.consume_pending_indent_space() {
+            self.print_soft_space();
+        }
+        self.print_comments_inner(&comments);
+        self.clear_pending_indent_space();
+        if removed_newline && self.last_byte() != Some(b'\n') {
+            self.print_hard_newline();
         }
     }
 
     pub(crate) fn has_comment(&self, start: u32) -> bool {
-        self.comments.contains_key(&start)
+        self.comments.has_non_semantic_at(start)
+    }
+
+    pub(crate) fn has_normal_comment(&self, start: u32) -> bool {
+        self.comments
+            .leading_at(start)
+            .is_some_and(|comments| comments.iter().any(|comment| comment.is_normal()))
     }
 
     /// Emit a pure / no-side-effects annotation comment for the AST node at
@@ -140,14 +696,28 @@ impl Codegen<'_> {
         kind: AnnotationKind,
         newline_after: bool,
     ) {
+        let source_anchor = self.comments.nearest_matching_leading_anchor(start, |comment| {
+            kind.matches(comment) && (newline_after || !comment.is_line())
+        });
         if self.source_text.is_some()
-            && let Some(comment) = self.annotation_comments.get(&start).copied()
-            && kind.matches(&comment)
-            // Inline line comments would swallow the rest of the line.
-            && (!comment.is_line() || newline_after)
+            && let Some(source_anchor) = source_anchor
         {
-            self.annotation_comments.remove(&start);
-            self.print_comment(&comment);
+            let mut comments = self.comments.take_matching_leading_at(source_anchor, |comment| {
+                kind.matches(comment) && (newline_after || !comment.is_line())
+            });
+            // The semantic claim above remains kind-specific. Once its source
+            // anchor is owned, retain compatible sibling comments at that
+            // exact boundary instead of relocating them to statement fallback.
+            comments.extend(self.comments.take_matching_leading_at(source_anchor, |comment| {
+                newline_after || !comment.is_line()
+            }));
+            comments.sort_unstable_by_key(|comment| comment.span.start);
+            for (index, comment) in comments.iter().enumerate() {
+                if index != 0 {
+                    self.print_str(" ");
+                }
+                self.print_comment(comment);
+            }
             if newline_after {
                 self.print_hard_newline();
             } else {
@@ -159,16 +729,17 @@ impl Codegen<'_> {
     }
 
     pub(crate) fn print_leading_comments(&mut self, start: u32) {
-        if let Some(comments) = self.comments.remove(&start) {
+        if let Some(comments) = self.comments.take_leading_at(start) {
             self.print_comments(&comments);
         }
     }
 
     pub(crate) fn get_comments(&mut self, start: u32) -> Option<CommentList> {
-        if self.comments.is_empty() {
-            return None;
-        }
-        self.comments.remove(&start)
+        let comments = self
+            .comments
+            .take_matching_at(start, |comment| !comment.is_pure() && !comment.is_no_side_effects());
+        self.node_comments.remove_comments(&comments);
+        (!comments.is_empty()).then_some(comments)
     }
 
     #[inline]
@@ -176,6 +747,222 @@ impl Codegen<'_> {
         if let Some(comments) = self.get_comments(start) {
             self.print_comments(&comments);
         }
+    }
+
+    /// Print parser-attached annotations and JSDoc at a surviving AST node.
+    /// Normal comments keep using their existing syntax-specific emitters,
+    /// which preserve punctuation-sensitive spacing and transformed-AST
+    /// behavior. Invalid pure annotations and property-key annotations also
+    /// have dedicated emission sites.
+    #[inline]
+    fn has_attached_comments_at(&self, start: u32) -> bool {
+        self.comments.leading_at(start).is_some_and(|comments| {
+            comments.iter().any(|comment| {
+                (!self.suppress_normal_comments && comment.is_normal())
+                    || comment.is_jsdoc()
+                    || (comment.is_annotation()
+                        && comment.content != CommentContent::PureNotApplied
+                        && !comment.is_pure()
+                        && !comment.is_no_side_effects()
+                        && !comment.is_property_key_annotation())
+            })
+        })
+    }
+
+    #[inline]
+    pub(crate) fn print_attached_comments_at(&mut self, start: u32) {
+        if !self.comments.may_have_anchor(start) {
+            return;
+        }
+        self.print_attached_comments_at_slow(start);
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn print_attached_comments_at_slow(&mut self, start: u32) {
+        let comments = self.take_attached_comments_at(start);
+        if !comments.is_empty() {
+            self.print_comments(&comments);
+            if self.last_byte() != Some(b'\n') {
+                self.consume_pending_indent_space();
+            }
+        }
+    }
+
+    fn take_attached_comments_at(&mut self, start: u32) -> CommentList {
+        if !self.has_attached_comments_at(start) {
+            return CommentList::new();
+        }
+        let suppress_normal_comments = self.suppress_normal_comments;
+        self.comments.take_matching_leading_at(start, |comment| {
+            (!suppress_normal_comments && comment.is_normal())
+                || comment.is_jsdoc()
+                || (comment.is_annotation()
+                    && comment.content != CommentContent::PureNotApplied
+                    && !comment.is_pure()
+                    && !comment.is_no_side_effects()
+                    && !comment.is_property_key_annotation())
+        })
+    }
+
+    #[inline]
+    pub(crate) fn print_trailing_attached_comments_at(&mut self, end: u32) {
+        if !self.comments.may_have_anchor(end) {
+            return;
+        }
+        self.print_trailing_attached_comments_at_slow(end);
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn print_trailing_attached_comments_at_slow(&mut self, end: u32) {
+        let source_text = self.source_text;
+        let should_print = self.comments.trailing_at(end).is_some_and(|comments| {
+            comments.iter().any(|comment| {
+                !is_html_comment(*comment, source_text)
+                    && (comment.is_normal()
+                        || comment.is_jsdoc()
+                        || (comment.is_annotation() && !comment.is_property_key_annotation()))
+            })
+        });
+        if should_print {
+            // Statement printers commonly emit their terminating newline
+            // before the generic `Gen::print` trailing hook runs. Move that
+            // newline behind the trailing comment so `x; // comment` does not
+            // become a leading comment for the next statement on pass two.
+            let removed_newline = self.last_byte() == Some(b'\n');
+            if removed_newline {
+                self.code.pop_byte();
+            }
+            let needs_space = self.comments.trailing_at(end).is_some_and(|comments| {
+                comments
+                    .iter()
+                    .find(|comment| !is_html_comment(**comment, source_text))
+                    .is_some_and(|comment| {
+                        source_text.is_none_or(|source_text| {
+                            let Ok(start) = usize::try_from(end) else { return true };
+                            let Ok(comment_start) = usize::try_from(comment.span.start) else {
+                                return true;
+                            };
+                            source_text.get(start..comment_start).is_none_or(|gap| {
+                                gap.bytes().any(|byte| byte.is_ascii_whitespace())
+                            })
+                        })
+                    })
+            });
+            if self.last_byte() != Some(b'\n') {
+                if needs_space {
+                    if !self.consume_pending_indent_space() {
+                        self.print_soft_space();
+                    }
+                } else {
+                    self.clear_pending_indent_space();
+                }
+            }
+            let has_html = self.comments.trailing_at(end).is_some_and(|comments| {
+                comments.iter().any(|comment| is_html_comment(*comment, source_text))
+            });
+            let comments = if has_html {
+                self.comments.take_matching_trailing_at(end, |comment| {
+                    !is_html_comment(*comment, source_text)
+                })
+            } else {
+                self.comments.take_trailing_at(end).unwrap()
+            };
+            self.print_comments(&comments);
+            self.clear_pending_indent_space();
+            if removed_newline && self.last_byte() != Some(b'\n') {
+                self.print_hard_newline();
+            }
+        }
+    }
+
+    pub(crate) fn print_attached_comments_before_expression(
+        &mut self,
+        expression: &Expression<'_>,
+    ) {
+        if is_pife_function(expression) || matches!(expression, Expression::ObjectExpression(_)) {
+            return;
+        }
+        let start = expression.span().start;
+        let comments = self.take_attached_comments_at(start);
+        if !comments.is_empty() {
+            self.print_comments(&comments);
+            if self.last_byte() == Some(b'\n') {
+                self.print_indent();
+            }
+        }
+        if let Expression::ParenthesizedExpression(paren) = expression {
+            self.print_attached_comments_before_expression(&paren.expression);
+        }
+    }
+
+    /// Parentheses around a return/yield/arrow operand cannot be discarded when
+    /// printing its leading comments would put the operand on the next line.
+    /// Without them, ASI changes the parse on the following codegen pass.
+    pub(crate) fn leading_comments_cause_newline_before_expression(
+        &self,
+        expression: &Expression<'_>,
+    ) -> bool {
+        if self.comments.remaining == 0 || is_pife_function(expression) {
+            return false;
+        }
+        let start = expression.span().start;
+        let causes_newline = self.comments.leading_at(start).is_some_and(|comments| {
+            comments.iter().any(|comment| {
+                let printable = (!self.suppress_normal_comments && comment.is_normal())
+                    || comment.is_jsdoc()
+                    || (comment.is_annotation()
+                        && comment.content != CommentContent::PureNotApplied
+                        && !comment.is_pure()
+                        && !comment.is_no_side_effects()
+                        && !comment.is_property_key_annotation());
+                printable && (comment.is_line() || comment.preceded_by_newline())
+            })
+        });
+        causes_newline
+            || match expression {
+                Expression::ParenthesizedExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::TSAsExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::TSSatisfiesExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::TSTypeAssertion(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::TSNonNullExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::TSInstantiationExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.expression)
+                }
+                Expression::BinaryExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.left)
+                }
+                Expression::LogicalExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.left)
+                }
+                Expression::ConditionalExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.test)
+                }
+                Expression::StaticMemberExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.object)
+                }
+                Expression::ComputedMemberExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.object)
+                }
+                Expression::CallExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.callee)
+                }
+                Expression::TaggedTemplateExpression(expression) => {
+                    self.leading_comments_cause_newline_before_expression(&expression.tag)
+                }
+                _ => false,
+            }
     }
 
     /// Print leading comments at `start` and glue the next token to them: after a
@@ -186,7 +973,7 @@ impl Codegen<'_> {
     /// pending indent-as-space so the token glues with a single space.
     #[inline]
     pub(crate) fn print_leading_comments_anchored_to_self(&mut self, start: u32) {
-        if let Some(comments) = self.get_comments(start) {
+        if let Some(comments) = self.comments.take_leading_at(start) {
             self.print_comments(&comments);
             if self.last_byte() == Some(b'\n') {
                 self.print_indent();
@@ -202,7 +989,7 @@ impl Codegen<'_> {
         if !self.has_property_key_annotations {
             return;
         }
-        if self.comments.get(&start).is_some_and(|comments| {
+        if self.comments.leading_at(start).is_some_and(|comments| {
             comments.iter().any(|comment| comment.is_property_key_annotation())
         }) {
             self.print_leading_comments_anchored_to_self(start);
@@ -215,10 +1002,21 @@ impl Codegen<'_> {
     /// comment at the `(`, `a || (/* c */ x)` at `x` — an operand printer only
     /// sees one node, so the walk happens here for every emission site.
     pub(crate) fn print_leading_comments_before_expression(&mut self, expression: &Expression<'_>) {
-        if self.comments.is_empty() || is_pife_function(expression) {
+        if is_pife_function(expression) {
             return;
         }
-        self.print_leading_comments_anchored_to_self(expression.span().start);
+        let start = expression.span().start;
+        let comments = self.comments.take_matching_leading_at(start, |comment| {
+            !comment.is_pure() && !comment.is_no_side_effects()
+        });
+        if !comments.is_empty() {
+            self.print_comments(&comments);
+            if self.last_byte() == Some(b'\n') {
+                self.print_indent();
+            } else {
+                self.consume_pending_indent_space();
+            }
+        }
         if let Expression::ParenthesizedExpression(paren) = expression {
             self.print_leading_comments_before_expression(&paren.expression);
         }
@@ -242,16 +1040,31 @@ impl Codegen<'_> {
         &mut self,
         expression: &Expression<'_>,
     ) {
-        if self.comments.is_empty() || is_pife_function(expression) {
+        if is_pife_function(expression) {
             return;
         }
         let start = expression.span().start;
-        if self
-            .comments
-            .get(&start)
-            .is_some_and(|comments| comments.iter().any(|comment| comment.is_annotation()))
-        {
-            self.print_leading_comments_anchored_to_self(start);
+        let has_annotation = self.comments.leading_at(start).is_some_and(|comments| {
+            comments.iter().any(|comment| {
+                comment.is_annotation()
+                    && !comment.is_pure()
+                    && !comment.is_no_side_effects()
+                    && !comment.is_property_key_annotation()
+            })
+        });
+        if has_annotation {
+            let comments = self.comments.take_matching_leading_at(start, |comment| {
+                comment.is_annotation()
+                    && !comment.is_pure()
+                    && !comment.is_no_side_effects()
+                    && !comment.is_property_key_annotation()
+            });
+            self.print_comments(&comments);
+            if self.last_byte() == Some(b'\n') {
+                self.print_indent();
+            } else {
+                self.consume_pending_indent_space();
+            }
         }
         if let Expression::ParenthesizedExpression(paren) = expression {
             self.print_annotation_comments_before_expression(&paren.expression);
@@ -262,10 +1075,7 @@ impl Codegen<'_> {
     /// Used by block emitters to keep an empty body multi-line.
     #[inline]
     pub(crate) fn has_orphan_comments_before(&self, end: u32) -> bool {
-        self.orphan_comment_keys
-            .iter()
-            .take_while(|&&k| k < end)
-            .any(|k| self.comments.contains_key(k))
+        self.comments.has_orphan_before(end)
     }
 
     /// Drain pending orphan comments with `attached_to < end` and emit them in
@@ -274,33 +1084,7 @@ impl Codegen<'_> {
     /// upstream pass.
     #[inline]
     pub(crate) fn print_orphan_comments_before(&mut self, end: u32) {
-        if self.orphan_comment_keys.is_empty() {
-            return;
-        }
-        let idx = self.orphan_comment_keys.partition_point(|&k| k < end);
-        if idx == 0 {
-            return;
-        }
-        // Concatenate across keys so `print_comments` sees one sequence;
-        // per-key calls would leak `print_next_indent_as_space` and produce
-        // stray leading spaces.
-        let mut orphans: Vec<Comment> = Vec::new();
-        let comments = &mut self.comments;
-        for k in self.orphan_comment_keys.drain(..idx) {
-            let Some(entry) = comments.get_mut(&k) else { continue };
-            debug_assert!(entry.iter().any(|c| preserve_when_orphaned(*c)));
-            entry.retain(|comment| {
-                if preserve_when_orphaned(*comment) {
-                    orphans.push(*comment);
-                    false
-                } else {
-                    true
-                }
-            });
-            if entry.is_empty() {
-                comments.remove(&k);
-            }
-        }
+        let mut orphans = self.comments.take_orphans_before(end);
         if let Some(last) = orphans.last_mut() {
             // Orphans aren't in their original position, so the source's
             // `followed_by_newline` hint no longer applies. Force it on so
@@ -315,26 +1099,154 @@ impl Codegen<'_> {
     /// Print comments attached to any position in the given range `(start, end)` (exclusive).
     /// Returns `true` if any comments were printed.
     pub(crate) fn print_comments_in_range(&mut self, start: u32, end: u32) -> bool {
-        if self.comments.is_empty() {
+        let comments = self.comments.take_between(start, end, |comment| {
+            !comment.is_pure() && !comment.is_no_side_effects()
+        });
+        if comments.is_empty() {
             return false;
         }
-        // Find and remove the first key in the range.
-        let key = self.comments.keys().find(|&&k| k > start && k < end).copied();
-        if let Some(key) = key {
-            let comments = self.comments.remove(&key).unwrap();
-            self.print_comments(&comments);
-            return true;
+        self.print_comments(&comments);
+        true
+    }
+
+    pub(crate) fn has_comments_in_range(&self, start: u32, end: u32) -> bool {
+        self.comments.has_between(start, end)
+    }
+
+    pub(crate) fn comments_in_range_need_space_after(&self, start: u32, end: u32) -> bool {
+        let Some(comment) = self.comments.first_between(start, end, |comment| {
+            !comment.is_pure() && !comment.is_no_side_effects()
+        }) else {
+            return false;
+        };
+        self.source_text.is_none_or(|source_text| {
+            let Ok(start) = usize::try_from(start) else { return true };
+            let Ok(comment_start) = usize::try_from(comment.span.start) else { return true };
+            source_text
+                .get(start..comment_start)
+                .is_none_or(|gap| gap.as_bytes().last().is_some_and(u8::is_ascii_whitespace))
+        })
+    }
+
+    pub(crate) fn print_comments_before_closing_delimiter(&mut self, close: u32) -> bool {
+        let Some(comments) = self.comments.take_leading_at(close) else { return false };
+        let needs_space = comments.last().is_some_and(|comment| {
+            self.source_text.is_some_and(|source_text| {
+                let Ok(comment_end) = usize::try_from(comment.span.end) else { return false };
+                let Ok(close) = usize::try_from(close) else { return false };
+                source_text
+                    .get(comment_end..close)
+                    .and_then(|gap| gap.as_bytes().last())
+                    .is_some_and(u8::is_ascii_whitespace)
+            })
+        });
+        self.print_comments(&comments);
+        if needs_space && self.last_byte() != Some(b'\n') {
+            self.consume_pending_indent_space();
+        } else {
+            self.clear_pending_indent_space();
         }
-        false
+        true
+    }
+
+    pub(crate) fn print_comments_in_range_anchored_to_next(
+        &mut self,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        if !self.print_comments_in_range(start, end) {
+            return false;
+        }
+        if self.last_byte() == Some(b'\n') {
+            self.print_indent();
+        } else {
+            self.consume_pending_indent_space();
+        }
+        true
+    }
+
+    pub(crate) fn print_leading_comments_in_range_anchored_to_next(
+        &mut self,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        let comments = self.comments.take_between(start, end, |comment| {
+            comment.is_leading() && !comment.is_pure() && !comment.is_no_side_effects()
+        });
+        if comments.is_empty() {
+            return false;
+        }
+        self.print_comments(&comments);
+        if self.last_byte() == Some(b'\n') {
+            self.print_indent();
+        } else {
+            self.consume_pending_indent_space();
+        }
+        true
+    }
+
+    pub(crate) fn print_trailing_comments_in_range_anchored_to_next(
+        &mut self,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        let comments = self.comments.take_between(start, end, |comment| {
+            comment.is_trailing() && !comment.is_pure() && !comment.is_no_side_effects()
+        });
+        if comments.is_empty() {
+            return false;
+        }
+        self.print_comments(&comments);
+        if self.last_byte() == Some(b'\n') {
+            self.print_indent();
+        } else {
+            self.consume_pending_indent_space();
+        }
+        true
+    }
+
+    pub(crate) fn print_expr_comments_before_closing_delimiter(
+        &mut self,
+        start: u32,
+        close: u32,
+    ) -> bool {
+        let mut comments = self.comments.take_between(start, close, |comment| {
+            !comment.is_pure() && !comment.is_no_side_effects()
+        });
+        comments.extend(self.comments.take_matching_leading_at(close, |comment| {
+            !comment.is_pure() && !comment.is_no_side_effects()
+        }));
+        comments.sort_unstable_by_key(|comment| comment.span.start);
+        self.print_expr_comment_list(&comments)
+    }
+
+    pub(crate) fn print_all_remaining_orphan_comments(&mut self) {
+        let mut comments = self.comments.take_orphans_before(u32::MAX);
+        if comments.is_empty() {
+            return;
+        }
+        if self.last_byte() != Some(b'\n')
+            && comments.first().is_some_and(|comment| !comment.preceded_by_newline())
+        {
+            self.print_soft_space();
+        }
+        comments.last_mut().unwrap().set_followed_by_newline(true);
+        self.print_comments(&comments);
     }
 
     pub(crate) fn print_expr_comments(&mut self, start: u32) -> bool {
-        if self.comments.is_empty() {
+        let comments = self
+            .comments
+            .take_matching_at(start, |comment| !comment.is_pure() && !comment.is_no_side_effects());
+        self.print_expr_comment_list(&comments)
+    }
+
+    fn print_expr_comment_list(&mut self, comments: &[Comment]) -> bool {
+        if comments.is_empty() {
             return false;
         }
-        let Some(comments) = self.comments.remove(&start) else { return false };
-
-        for comment in &comments {
+        self.node_comments.remove_comments(comments);
+        for comment in comments {
             self.print_hard_newline();
             self.print_indent();
             self.print_comment(comment);
@@ -349,6 +1261,11 @@ impl Codegen<'_> {
     }
 
     pub(crate) fn print_comments(&mut self, comments: &[Comment]) {
+        self.node_comments.remove_comments(comments);
+        self.print_comments_inner(comments);
+    }
+
+    fn print_comments_inner(&mut self, comments: &[Comment]) {
         let Some((first, rest)) = comments.split_first() else {
             return;
         };

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use oxc_ast::{
-    AttachedCommentPosition, Comment, CommentContent, CommentKind, GetNodeId,
+    AttachedCommentPosition, Comment, CommentContent, CommentKind,
     ast::{Expression, Program},
 };
 use oxc_span::GetSpan;
@@ -593,7 +593,7 @@ impl Codegen<'_> {
         &mut self,
         expression: &Expression<'_>,
     ) -> Option<BoundaryComments> {
-        let node = self.node_comments.take_all(expression.get_node_id());
+        let node = self.node_comments.take_all(expression.node_id());
         let leading = self.may_have_comments_before_expression(expression);
         let trailing = self.comments.may_have_anchor(expression.span().end);
         (node.is_some() || leading || trailing).then_some(BoundaryComments {

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -891,7 +891,9 @@ impl Gen for Function<'_> {
                 type_parameters.print(p, ctx);
             }
             if has_comments_at_params {
-                p.print_soft_space();
+                if !matches!(p.last_byte(), Some(b' ' | b'\n' | b'\t')) {
+                    p.print_soft_space();
+                }
                 p.print_leading_comments_anchored_to_self(self.params.span.start);
             }
             if p.has_node_comments_before_id(self.params.node_id())

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -864,11 +864,17 @@ impl Gen for Function<'_> {
             p.print_str("function");
             let next_node_start =
                 self.id.as_ref().map_or(self.params.span.start, |id| id.span.start);
+            let has_comments_at_params = p.has_comment(self.params.span.start);
             if p.has_comments_in_range(self.span.start, next_node_start) {
                 p.print_soft_space();
                 p.print_comments_in_range(self.span.start, next_node_start);
                 if p.last_byte() == Some(b'\n') {
                     p.print_indent();
+                } else if has_comments_at_params {
+                    // The parameter-anchor path below owns the separator. This
+                    // occurs when a transform removes a function-expression
+                    // name between two source comment groups.
+                    p.clear_pending_indent_space();
                 } else {
                     p.consume_pending_indent_space();
                 }
@@ -884,9 +890,14 @@ impl Gen for Function<'_> {
             if let Some(type_parameters) = &self.type_parameters {
                 type_parameters.print(p, ctx);
             }
-            if p.has_comment(self.params.span.start) {
+            if has_comments_at_params {
                 p.print_soft_space();
                 p.print_leading_comments_anchored_to_self(self.params.span.start);
+            }
+            if p.has_node_comments_before_id(self.params.node_id())
+                && !matches!(p.last_byte(), Some(b' ' | b'\n' | b'\t'))
+            {
+                p.print_soft_space();
             }
             p.print_node_comments_before_id(self.params.node_id());
             p.print_ascii_byte(b'(');

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2,10 +2,10 @@ use std::ops::Not;
 
 use cow_utils::CowUtils;
 
-use oxc_ast::GetNodeId;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{
+    GetNodeId,
     operator::UnaryOperator,
     precedence::{GetPrecedence, Precedence},
 };
@@ -26,7 +26,7 @@ pub trait Gen: GetSpan + GetNodeId {
     #[inline]
     fn print(&self, p: &mut Codegen, ctx: Context) {
         let span = self.span();
-        let mut boundary = p.take_boundary_comments(self.get_node_id(), span.start, span.end);
+        let mut boundary = p.take_boundary_comments(self.node_id(), span.start, span.end);
         if let Some(boundary) = boundary.as_mut() {
             if let Some(comments) = boundary.node.as_mut() {
                 p.print_node_comments_before(comments);
@@ -63,7 +63,7 @@ pub trait GenExpr: GetSpan + GetNodeId {
     #[inline]
     fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let span = self.span();
-        let mut boundary = p.take_boundary_comments(self.get_node_id(), span.start, span.end);
+        let mut boundary = p.take_boundary_comments(self.node_id(), span.start, span.end);
         if let Some(boundary) = boundary.as_mut() {
             if let Some(comments) = boundary.node.as_mut() {
                 p.print_node_comments_before(comments);
@@ -888,7 +888,7 @@ impl Gen for Function<'_> {
                 p.print_soft_space();
                 p.print_leading_comments_anchored_to_self(self.params.span.start);
             }
-            p.print_node_comments_before_id(self.params.get_node_id());
+            p.print_node_comments_before_id(self.params.node_id());
             p.print_ascii_byte(b'(');
             if let Some(this_param) = &self.this_param {
                 this_param.print(p, ctx);
@@ -999,7 +999,7 @@ impl Gen for FormalParameterRest<'_> {
 impl Gen for FormalParameters<'_> {
     #[inline]
     fn print(&self, p: &mut Codegen, ctx: Context) {
-        let mut node_comments = p.take_node_comments(self.get_node_id());
+        let mut node_comments = p.take_node_comments(self.node_id());
         if let Some(comments) = node_comments.as_mut() {
             p.print_node_comments_before(comments);
         }
@@ -2032,8 +2032,8 @@ impl Gen for ObjectProperty<'_> {
                 if let Some(type_parameters) = &func.type_parameters {
                     type_parameters.print(p, ctx);
                 }
-                p.print_node_comments_before_id(func.get_node_id());
-                p.print_node_comments_before_id(func.params.get_node_id());
+                p.print_node_comments_before_id(func.node_id());
+                p.print_node_comments_before_id(func.params.node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &func.this_param {
                     this_param.print(p, ctx);
@@ -2145,7 +2145,7 @@ impl GenExpr for ArrowFunctionExpression<'_> {
                         && param.initializer.is_none()
                         && !param.optional
                 };
-            p.print_node_comments_before_id(self.params.get_node_id());
+            p.print_node_comments_before_id(self.params.node_id());
             p.wrap(!remove_params_wrap, |p| {
                 self.params.print(p, params_ctx);
             });
@@ -3222,8 +3222,8 @@ impl Gen for MethodDefinition<'_> {
         if let Some(type_parameters) = self.value.type_parameters.as_ref() {
             type_parameters.print(p, ctx);
         }
-        p.print_node_comments_before_id(self.value.get_node_id());
-        p.print_node_comments_before_id(self.value.params.get_node_id());
+        p.print_node_comments_before_id(self.value.node_id());
+        p.print_node_comments_before_id(self.value.params.node_id());
         p.print_ascii_byte(b'(');
         if let Some(this_param) = &self.value.this_param {
             this_param.print(p, ctx);
@@ -4022,7 +4022,7 @@ impl Gen for TSFunctionType<'_> {
         if let Some(type_parameters) = &self.type_parameters {
             type_parameters.print(p, ctx);
         }
-        p.print_node_comments_before_id(self.params.get_node_id());
+        p.print_node_comments_before_id(self.params.node_id());
         p.print_ascii_byte(b'(');
         if let Some(this_param) = &self.this_param {
             this_param.print(p, ctx);
@@ -4061,7 +4061,7 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = signature.type_parameters.as_ref() {
                     type_parameters.print(p, ctx);
                 }
-                p.print_node_comments_before_id(signature.params.get_node_id());
+                p.print_node_comments_before_id(signature.params.node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &signature.this_param {
                     this_param.print(p, ctx);
@@ -4084,7 +4084,7 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = signature.type_parameters.as_ref() {
                     type_parameters.print(p, ctx);
                 }
-                p.print_node_comments_before_id(signature.params.get_node_id());
+                p.print_node_comments_before_id(signature.params.node_id());
                 p.print_ascii_byte(b'(');
                 signature.params.print(p, ctx);
                 p.print_ascii_byte(b')');
@@ -4127,7 +4127,7 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = &signature.type_parameters {
                     type_parameters.print(p, ctx);
                 }
-                p.print_node_comments_before_id(signature.params.get_node_id());
+                p.print_node_comments_before_id(signature.params.node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &signature.this_param {
                     this_param.print(p, ctx);
@@ -4552,7 +4552,7 @@ impl Gen for TSConstructorType<'_> {
         if let Some(type_parameters) = &self.type_parameters {
             type_parameters.print(p, ctx);
         }
-        p.print_node_comments_before_id(self.params.get_node_id());
+        p.print_node_comments_before_id(self.params.node_id());
         p.print_ascii_byte(b'(');
         self.params.print(p, ctx);
         p.print_ascii_byte(b')');

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2,6 +2,7 @@ use std::ops::Not;
 
 use cow_utils::CowUtils;
 
+use oxc_ast::GetNodeId;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{
@@ -13,31 +14,83 @@ use crate::{
     Codegen, Context, Operator, Quote,
     binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
     cjs_module_lexer,
-    comment::AnnotationKind,
+    comment::{AnnotationKind, is_pife_function},
 };
 
 /// Generate source code for an AST node.
-pub trait Gen: GetSpan {
+pub trait Gen: GetSpan + GetNodeId {
     /// Generate code for an AST node.
     fn r#gen(&self, p: &mut Codegen, ctx: Context);
 
     /// Generate code for an AST node. Alias for `gen`.
     #[inline]
     fn print(&self, p: &mut Codegen, ctx: Context) {
+        let span = self.span();
+        let mut boundary = p.take_boundary_comments(self.get_node_id(), span.start, span.end);
+        if let Some(boundary) = boundary.as_mut() {
+            if let Some(comments) = boundary.node.as_mut() {
+                p.print_node_comments_before(comments);
+            }
+            if boundary.leading {
+                p.print_attached_comments_at(span.start);
+            }
+        }
+        self.r#gen(p, ctx);
+        if let Some(boundary) = boundary.as_mut() {
+            if boundary.trailing {
+                p.print_trailing_attached_comments_at(span.end);
+            }
+            if let Some(comments) = boundary.node.as_mut() {
+                p.print_node_comments_after(comments);
+            }
+        }
+    }
+
+    /// Print a concrete node whose enclosing enum already owns the same
+    /// comment boundaries.
+    #[inline]
+    fn print_inner(&self, p: &mut Codegen, ctx: Context) {
         self.r#gen(p, ctx);
     }
 }
 
 /// Generate source code for an expression.
-pub trait GenExpr: GetSpan {
+pub trait GenExpr: GetSpan + GetNodeId {
     /// Generate code for an expression, respecting operator precedence.
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context);
 
     /// Generate code for an expression, respecting operator precedence. Alias for `gen_expr`.
     #[inline]
     fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+        let span = self.span();
+        let mut boundary = p.take_boundary_comments(self.get_node_id(), span.start, span.end);
+        if let Some(boundary) = boundary.as_mut() {
+            if let Some(comments) = boundary.node.as_mut() {
+                p.print_node_comments_before(comments);
+            }
+            if boundary.leading {
+                p.print_attached_comments_at(span.start);
+            }
+        }
         self.gen_expr(p, precedence, ctx);
+        if let Some(boundary) = boundary.as_mut() {
+            if boundary.trailing {
+                p.print_trailing_attached_comments_at(span.end);
+            }
+            if let Some(comments) = boundary.node.as_mut() {
+                p.print_node_comments_after(comments);
+            }
+        }
         // Map chain punctuation after a postfix operand ending in `)`/`]`.
+        p.add_source_mapping_after_postfix(self.span(), precedence);
+    }
+
+    /// Print a concrete expression whose enclosing [`Expression`] already
+    /// owns the same comment boundaries. Keep the postfix mapping hook: it is
+    /// observable in the JS/Rust source-map parity suite.
+    #[inline]
+    fn print_expr_inner(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+        self.gen_expr(p, precedence, ctx);
         p.add_source_mapping_after_postfix(self.span(), precedence);
     }
 }
@@ -217,6 +270,14 @@ impl Gen for ExpressionStatement<'_> {
         }
         p.start_of_stmt = p.code_len();
         p.print_expression(&self.expression);
+        if p.comments_in_range_need_space_after(self.expression.span().end, self.span.end)
+            && !p.consume_pending_indent_space()
+        {
+            p.print_soft_space();
+        }
+        if p.print_comments_in_range(self.expression.span().end, self.span.end) {
+            p.clear_pending_indent_space();
+        }
         p.print_semicolon_after_statement();
     }
 }
@@ -604,7 +665,9 @@ impl Gen for ReturnStatement<'_> {
         p.print_str("return");
         if let Some(arg) = &self.argument {
             p.print_soft_space();
-            p.print_expression(arg);
+            let wrap = !matches!(arg, Expression::ParenthesizedExpression(_))
+                && p.leading_comments_cause_newline_before_expression(arg);
+            p.wrap(wrap, |p| p.print_expression(arg));
         }
         p.print_semicolon_after_statement();
     }
@@ -651,6 +714,7 @@ impl Gen for CatchClause<'_> {
         p.print_soft_space();
         p.print_comments_at(self.span.start);
         p.print_str("catch");
+        let mut printed_header_comment = false;
         if let Some(param) = &self.param {
             p.print_soft_space();
             p.print_ascii_byte(b'(');
@@ -661,8 +725,19 @@ impl Gen for CatchClause<'_> {
                 type_annotation.print(p, ctx);
             }
             p.print_ascii_byte(b')');
+            let param_end = param
+                .type_annotation
+                .as_ref()
+                .map_or(param.pattern.span().end, |annotation| annotation.span.end);
+            if p.has_comments_in_range(param_end, self.body.span.start) {
+                p.print_soft_space();
+                printed_header_comment =
+                    p.print_comments_in_range_anchored_to_next(param_end, self.body.span.start);
+            }
         }
-        p.print_soft_space();
+        if !printed_header_comment {
+            p.print_soft_space();
+        }
         p.print_comments_at(self.body.span.start);
         // Flush the pending-indent-as-space flag so `/* */ {` doesn't
         // collapse to `/* */{`.
@@ -730,6 +805,12 @@ impl Gen for VariableDeclaration<'_> {
             p.print_soft_space();
         }
         p.print_list(&self.declarations, ctx);
+        if let Some(last) = self.declarations.last()
+            && p.print_comments_in_range(last.span.end, self.span.end)
+        {
+            p.clear_pending_indent_space();
+        }
+        p.print_comments_before_closing_delimiter(self.span.end);
     }
 }
 
@@ -748,6 +829,13 @@ impl Gen for VariableDeclarator<'_> {
             p.print_soft_space();
             p.print_equal();
             p.print_soft_space();
+            let binding_end = self
+                .type_annotation
+                .as_ref()
+                .map_or(self.id.span().end, |annotation| annotation.span.end);
+            if p.print_comments_in_range(binding_end, init.span().start) {
+                p.consume_pending_indent_space();
+            }
             init.print_expr(p, Precedence::Comma, ctx);
         }
     }
@@ -774,6 +862,17 @@ impl Gen for Function<'_> {
                 p.print_str("async ");
             }
             p.print_str("function");
+            let next_node_start =
+                self.id.as_ref().map_or(self.params.span.start, |id| id.span.start);
+            if p.has_comments_in_range(self.span.start, next_node_start) {
+                p.print_soft_space();
+                p.print_comments_in_range(self.span.start, next_node_start);
+                if p.last_byte() == Some(b'\n') {
+                    p.print_indent();
+                } else {
+                    p.consume_pending_indent_space();
+                }
+            }
             if self.generator {
                 p.print_ascii_byte(b'*');
                 p.print_soft_space();
@@ -785,6 +884,11 @@ impl Gen for Function<'_> {
             if let Some(type_parameters) = &self.type_parameters {
                 type_parameters.print(p, ctx);
             }
+            if p.has_comment(self.params.span.start) {
+                p.print_soft_space();
+                p.print_leading_comments_anchored_to_self(self.params.span.start);
+            }
+            p.print_node_comments_before_id(self.params.get_node_id());
             p.print_ascii_byte(b'(');
             if let Some(this_param) = &self.this_param {
                 this_param.print(p, ctx);
@@ -795,6 +899,7 @@ impl Gen for Function<'_> {
             }
             self.params.print(p, ctx);
             p.print_ascii_byte(b')');
+            p.print_trailing_attached_comments_at(self.params.span.end);
             if let Some(return_type) = &self.return_type {
                 p.print_colon();
                 p.print_soft_space();
@@ -892,6 +997,16 @@ impl Gen for FormalParameterRest<'_> {
 }
 
 impl Gen for FormalParameters<'_> {
+    #[inline]
+    fn print(&self, p: &mut Codegen, ctx: Context) {
+        let mut node_comments = p.take_node_comments(self.get_node_id());
+        if let Some(comments) = node_comments.as_mut() {
+            p.print_node_comments_before(comments);
+        }
+        p.print_attached_comments_at(self.span.start);
+        self.r#gen(p, ctx);
+    }
+
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_list(&self.items, ctx);
         if let Some(rest) = &self.rest {
@@ -900,6 +1015,12 @@ impl Gen for FormalParameters<'_> {
                 p.print_soft_space();
             }
             rest.print(p, ctx);
+        }
+        if self.span.end > 0 {
+            p.print_comments_before_closing_delimiter(self.span.end - 1);
+            if p.last_byte() == Some(b'\n') {
+                p.print_indent();
+            }
         }
     }
 }
@@ -1003,6 +1124,12 @@ impl Gen for ImportDeclaration<'_> {
             }
             if in_block {
                 p.print_soft_space();
+                if let Some(last_specifier) = specifiers.last() {
+                    p.print_comments_in_range_anchored_to_next(
+                        last_specifier.span().end,
+                        self.source.span.start,
+                    );
+                }
                 p.print_ascii_byte(b'}');
                 p.print_soft_space();
             }
@@ -1075,6 +1202,9 @@ impl Gen for ExportDeclaration<'_> {
         match decl {
             Declaration::VariableDeclaration(decl) => decl.print(p, ctx),
             Declaration::FunctionDeclaration(decl) => decl.print(p, ctx),
+            Declaration::ClassDeclaration(decl) if !decl.decorators.is_empty() => {
+                decl.r#gen(p, ctx);
+            }
             Declaration::ClassDeclaration(decl) => decl.print(p, ctx),
             Declaration::TSExternalModuleDeclaration(decl) => decl.print(p, ctx),
             Declaration::TSNamespaceDeclaration(decl) => decl.print(p, ctx),
@@ -1141,6 +1271,7 @@ fn gen_export_specifiers(
         p.print_soft_space();
         p.print_list(specifiers, ctx);
         p.print_soft_space();
+        p.print_comments_in_range_anchored_to_next(specifiers.last().unwrap().span.end, span.end);
     }
     p.print_ascii_byte(b'}');
 }
@@ -1259,9 +1390,28 @@ impl Gen for ExportDefaultDeclaration<'_> {
         }
         p.print_indent();
         p.add_source_mapping(self.span);
-        p.print_str("export default");
+        p.print_str("export");
+        let header_end = match &self.declaration {
+            ExportDefaultDeclarationKind::ClassDeclaration(class) => class
+                .decorators
+                .first()
+                .filter(|decorator| decorator.span.start > self.span.start)
+                .map_or(class.span.start, |decorator| decorator.span.start),
+            _ => self.declaration.span().start,
+        };
+        p.print_hard_space();
+        p.print_leading_comments_in_range_anchored_to_next(self.span.start, header_end);
+        p.print_str("default");
         p.print_soft_space();
-        self.declaration.print(p, ctx);
+        p.print_trailing_comments_in_range_anchored_to_next(self.span.start, header_end);
+        if matches!(
+            &self.declaration,
+            ExportDefaultDeclarationKind::ClassDeclaration(class) if !class.decorators.is_empty()
+        ) {
+            self.declaration.r#gen(p, ctx);
+        } else {
+            self.declaration.print(p, ctx);
+        }
     }
 }
 impl Gen for ExportDefaultDeclarationKind<'_> {
@@ -1272,7 +1422,11 @@ impl Gen for ExportDefaultDeclarationKind<'_> {
                 p.print_soft_newline();
             }
             Self::ClassDeclaration(class) => {
-                class.print(p, ctx);
+                if class.decorators.is_empty() {
+                    class.print(p, ctx);
+                } else {
+                    class.r#gen(p, ctx);
+                }
                 p.print_soft_newline();
             }
             Self::TSInterfaceDeclaration(interface) => {
@@ -1289,31 +1443,97 @@ impl Gen for ExportDefaultDeclarationKind<'_> {
 }
 
 impl GenExpr for Expression<'_> {
+    #[inline]
+    fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+        self.gen_expr(p, precedence, ctx);
+        p.add_source_mapping_after_postfix(self.span(), precedence);
+    }
+
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+        let before_node_comments = p.code_len();
+        let node_starts_statement = p.start_of_stmt == before_node_comments;
+        let node_starts_arrow_expression = p.start_of_arrow_expr == before_node_comments;
+        let node_starts_default_export = p.start_of_default_export == before_node_comments;
+        let mut boundary = p.take_expression_boundary_comments(self);
+        if let Some(comments) = boundary.as_mut().and_then(|boundary| boundary.node.as_mut()) {
+            p.print_node_comments_before(comments);
+        }
+        if p.code_len() != before_node_comments {
+            if node_starts_statement {
+                p.start_of_stmt = p.code_len();
+            }
+            if node_starts_arrow_expression {
+                p.start_of_arrow_expr = p.code_len();
+            }
+            if node_starts_default_export {
+                p.start_of_default_export = p.code_len();
+            }
+        }
+        if let Self::ParenthesizedExpression(paren) = self
+            && p.leading_comments_cause_newline_before_expression(self)
+        {
+            // Keep the opening parenthesis before a leading line break. This
+            // is semantically required after `return` / `yield`, and keeps
+            // arrow expression bodies from becoming blocks through ASI.
+            p.print_ascii_byte(b'(');
+            if boundary.as_ref().is_some_and(|boundary| boundary.leading) {
+                p.print_attached_comments_before_expression(self);
+            }
+            paren.gen_expr(p, precedence, ctx);
+            p.print_ascii_byte(b')');
+            if boundary.as_ref().is_some_and(|boundary| boundary.trailing) {
+                p.print_trailing_attached_comments_at(self.span().end);
+            }
+            if let Some(comments) = boundary.as_mut().and_then(|boundary| boundary.node.as_mut()) {
+                p.print_node_comments_after(comments);
+            }
+            return;
+        }
+        let before_comments = p.code_len();
+        let starts_statement = p.start_of_stmt == before_comments;
+        let starts_arrow_expression = p.start_of_arrow_expr == before_comments;
+        let starts_default_export = p.start_of_default_export == before_comments;
+        if boundary.as_ref().is_some_and(|boundary| boundary.leading) {
+            p.print_attached_comments_before_expression(self);
+        }
+        if p.code_len() != before_comments {
+            if p.last_byte() != Some(b'\n') {
+                p.consume_pending_indent_space();
+            }
+            if starts_statement {
+                p.start_of_stmt = p.code_len();
+            }
+            if starts_arrow_expression {
+                p.start_of_arrow_expr = p.code_len();
+            }
+            if starts_default_export {
+                p.start_of_default_export = p.code_len();
+            }
+        }
         match self {
             // Most common expressions first (identifiers, member access, calls)
-            Self::Identifier(ident) => ident.print(p, ctx),
-            Self::StaticMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::ComputedMemberExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::CallExpression(expr) => expr.print_expr(p, precedence, ctx),
+            Self::Identifier(ident) => ident.print_inner(p, ctx),
+            Self::StaticMemberExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::ComputedMemberExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::CallExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
             // Literals (very common)
-            Self::NumericLiteral(lit) => lit.print_expr(p, precedence, ctx),
-            Self::StringLiteral(lit) => lit.print(p, ctx),
-            Self::BooleanLiteral(lit) => lit.print(p, ctx),
-            Self::NullLiteral(lit) => lit.print(p, ctx),
+            Self::NumericLiteral(lit) => lit.print_expr_inner(p, precedence, ctx),
+            Self::StringLiteral(lit) => lit.print_inner(p, ctx),
+            Self::BooleanLiteral(lit) => lit.print_inner(p, ctx),
+            Self::NullLiteral(lit) => lit.print_inner(p, ctx),
             // Binary and logical operations (common)
-            Self::BinaryExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::LogicalExpression(expr) => expr.print_expr(p, precedence, ctx),
+            Self::BinaryExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::LogicalExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
             // Object and array literals (common)
-            Self::ObjectExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::ArrayExpression(expr) => expr.print(p, ctx),
+            Self::ObjectExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::ArrayExpression(expr) => expr.print_inner(p, ctx),
             // Assignment and update (common)
-            Self::AssignmentExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::UpdateExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::UnaryExpression(expr) => expr.print_expr(p, precedence, ctx),
+            Self::AssignmentExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::UpdateExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::UnaryExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
             // Conditional and sequence
-            Self::ConditionalExpression(expr) => expr.print_expr(p, precedence, ctx),
-            Self::SequenceExpression(expr) => expr.print_expr(p, precedence, ctx),
+            Self::ConditionalExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
+            Self::SequenceExpression(expr) => expr.print_expr_inner(p, precedence, ctx),
             // Function expressions
             Self::ArrowFunctionExpression(func) => {
                 if func.pure && p.options.print_annotation_comment() {
@@ -1323,7 +1543,11 @@ impl GenExpr for Expression<'_> {
                         false,
                     );
                 }
-                func.print_expr(p, precedence, ctx);
+                if func.pife {
+                    func.gen_expr(p, precedence, ctx);
+                } else {
+                    func.print_expr(p, precedence, ctx);
+                }
             }
             Self::FunctionExpression(func) => {
                 if func.pure && p.options.print_annotation_comment() {
@@ -1333,7 +1557,11 @@ impl GenExpr for Expression<'_> {
                         false,
                     );
                 }
-                func.print(p, ctx);
+                if func.pife {
+                    func.r#gen(p, ctx);
+                } else {
+                    func.print(p, ctx);
+                }
             }
             // This and super
             Self::ThisExpression(expr) => expr.print(p, ctx),
@@ -1362,7 +1590,13 @@ impl GenExpr for Expression<'_> {
             Self::PrivateFieldExpression(expr) => expr.print_expr(p, precedence, ctx),
             Self::PrivateInExpression(expr) => expr.print_expr(p, precedence, ctx),
             // Parenthesized
-            Self::ParenthesizedExpression(e) => e.print_expr(p, precedence, ctx),
+            Self::ParenthesizedExpression(e) => {
+                if p.has_pending_comments() {
+                    e.gen_expr(p, precedence, ctx);
+                } else {
+                    e.print_expr(p, precedence, ctx);
+                }
+            }
             // JSX (less common in typical JS code)
             Self::JSXElement(el) => el.print(p, ctx),
             Self::JSXFragment(fragment) => fragment.print(p, ctx),
@@ -1375,12 +1609,22 @@ impl GenExpr for Expression<'_> {
             // V8 intrinsics (rare)
             Self::V8IntrinsicExpression(e) => e.print_expr(p, precedence, ctx),
         }
+        if boundary.as_ref().is_some_and(|boundary| boundary.trailing) {
+            p.print_trailing_attached_comments_at(self.span().end);
+        }
+        if let Some(comments) = boundary.as_mut().and_then(|boundary| boundary.node.as_mut()) {
+            p.print_node_comments_after(comments);
+        }
     }
 }
 
 impl GenExpr for ParenthesizedExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        self.expression.print_expr(p, precedence, ctx);
+        if p.has_pending_comments() && is_pife_function(&self.expression) {
+            self.expression.gen_expr(p, precedence, ctx);
+        } else {
+            self.expression.print_expr(p, precedence, ctx);
+        }
     }
 }
 
@@ -1660,15 +1904,26 @@ impl Gen for ArrayExpression<'_> {
             } else if i != 0 {
                 p.print_soft_space();
             }
-            item.print(p, ctx);
             if i == self.elements.len() - 1 && matches!(item, ArrayExpressionElement::Elision(_)) {
+                p.print_attached_comments_at(item.span().start);
                 p.print_comma();
+                p.print_trailing_attached_comments_at(item.span().end);
+            } else {
+                item.print(p, ctx);
             }
         }
         if is_multi_line {
-            p.print_soft_newline();
+            if p.last_byte() != Some(b'\n') {
+                p.print_soft_newline();
+            }
             p.dedent();
             p.print_indent();
+        }
+        if self.span.end > 0 {
+            p.print_comments_before_closing_delimiter(self.span.end - 1);
+            if p.last_byte() == Some(b'\n') {
+                p.print_indent();
+            }
         }
         p.add_source_mapping_end(self.span);
         p.print_ascii_byte(b']');
@@ -1681,7 +1936,9 @@ impl GenExpr for ObjectExpression<'_> {
         let len = self.properties.len();
         let is_multi_line = len > 1;
         let has_comment = p.has_comment(self.span.start);
-        let wrap = has_comment || p.start_of_stmt == n || p.start_of_arrow_expr == n;
+        let wrap = p.has_normal_comment(self.span.start)
+            || p.start_of_stmt == n
+            || p.start_of_arrow_expr == n;
         p.wrap(wrap, |p| {
             // Print comments for lingui https://lingui.dev/ref/macro#definemessage
             // `const message = /*i18n*/ { };`
@@ -1717,6 +1974,12 @@ impl GenExpr for ObjectExpression<'_> {
                 p.print_indent();
             } else if len > 0 {
                 p.print_soft_space();
+            }
+            if self.span.end > 0 {
+                p.print_comments_before_closing_delimiter(self.span.end - 1);
+                if p.last_byte() == Some(b'\n') {
+                    p.print_indent();
+                }
             }
             p.add_source_mapping_end(self.span);
             p.print_ascii_byte(b'}');
@@ -1769,6 +2032,8 @@ impl Gen for ObjectProperty<'_> {
                 if let Some(type_parameters) = &func.type_parameters {
                     type_parameters.print(p, ctx);
                 }
+                p.print_node_comments_before_id(func.get_node_id());
+                p.print_node_comments_before_id(func.params.get_node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &func.this_param {
                     this_param.print(p, ctx);
@@ -1779,6 +2044,7 @@ impl Gen for ObjectProperty<'_> {
                 }
                 func.params.print(p, ctx);
                 p.print_ascii_byte(b')');
+                p.print_trailing_attached_comments_at(func.params.span.end);
                 if let Some(return_type) = &func.return_type {
                     p.print_colon();
                     p.print_soft_space();
@@ -1867,6 +2133,7 @@ impl GenExpr for ArrowFunctionExpression<'_> {
             let remove_params_wrap = p.options.minify
                 && self.params.items.len() == 1
                 && self.params.rest.is_none()
+                && (self.params.span.end == 0 || !p.has_comment(self.params.span.end - 1))
                 && self.type_parameters.is_none()
                 && self.return_type.is_none()
                 && {
@@ -1878,9 +2145,11 @@ impl GenExpr for ArrowFunctionExpression<'_> {
                         && param.initializer.is_none()
                         && !param.optional
                 };
+            p.print_node_comments_before_id(self.params.get_node_id());
             p.wrap(!remove_params_wrap, |p| {
                 self.params.print(p, params_ctx);
             });
+            p.print_trailing_attached_comments_at(self.params.span.end);
             if let Some(return_type) = &self.return_type {
                 p.print_colon();
                 p.print_soft_space();
@@ -1914,7 +2183,11 @@ impl GenExpr for YieldExpression<'_> {
             }
             if let Some(argument) = self.argument.as_ref() {
                 p.print_soft_space();
-                argument.print_expr(p, Precedence::Yield, Context::empty());
+                let wrap = !matches!(argument, Expression::ParenthesizedExpression(_))
+                    && p.leading_comments_cause_newline_before_expression(argument);
+                p.wrap(wrap, |p| {
+                    argument.print_expr(p, Precedence::Yield, Context::empty());
+                });
             }
         });
     }
@@ -2050,12 +2323,18 @@ impl GenExpr for ConditionalExpression<'_> {
             // Annotation-gated (see the helper's doc): `if/else` bodies get
             // merged into consequents on mutated ASTs.
             p.print_annotation_comments_before_expression(&self.consequent);
-            self.consequent.print_expr(p, Precedence::Yield, Context::empty());
+            p.with_suppressed_normal_comments(|p| {
+                self.consequent.print_expr(p, Precedence::Yield, Context::empty());
+            });
             p.print_soft_space();
             p.print_colon();
             p.print_soft_space();
             p.print_leading_comments_before_expression(&self.alternate);
-            self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
+            if is_pife_function(&self.alternate) {
+                self.alternate.gen_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
+            } else {
+                self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
+            }
         });
     }
 }
@@ -2293,8 +2572,14 @@ impl GenExpr for ImportExpression<'_> {
         let has_comment_before_right_paren = p.options.print_annotation_comment()
             && self.span.end > 0
             && p.has_comment(self.span.end - 1);
+        let trailing_gap_start =
+            self.options.as_ref().map_or(self.source.span().end, |options| options.span().end);
+        let has_comment_in_trailing_gap = p.options.print_annotation_comment()
+            && self.span.end > 0
+            && p.has_comments_in_range(trailing_gap_start, self.span.end - 1);
         let has_comment = p.options.print_annotation_comment()
-            && (has_comment_before_right_paren
+            && (has_comment_in_trailing_gap
+                || has_comment_before_right_paren
                 || p.has_comment(self.source.span().start)
                 || self
                     .options
@@ -2331,8 +2616,11 @@ impl GenExpr for ImportExpression<'_> {
                 options.gen_expr(p, Precedence::Comma, Context::empty());
             }
             if has_comment {
-                // Handle `/* comment */);`
-                if !has_comment_before_right_paren || !p.print_expr_comments(self.span.end - 1) {
+                let printed_trailing_comment = p.print_expr_comments_before_closing_delimiter(
+                    trailing_gap_start,
+                    self.span.end - 1,
+                );
+                if !printed_trailing_comment {
                     p.print_soft_newline();
                 }
                 p.dedent();
@@ -2546,6 +2834,14 @@ impl Gen for Class<'_> {
         let ctx = ctx.and_forbid_call(false);
         p.wrap(wrap, |p| {
             p.print_decorators(&self.decorators, ctx);
+            if let Some(last_decorator) = self.decorators.last() {
+                let next_node_start =
+                    self.id.as_ref().map_or_else(|| self.body.span.start, |id| id.span.start);
+                p.print_comments_in_range_anchored_to_next(
+                    last_decorator.span.end,
+                    next_node_start,
+                );
+            }
             p.print_space_before_identifier();
             p.add_source_mapping(self.span);
             if self.declare {
@@ -2926,6 +3222,8 @@ impl Gen for MethodDefinition<'_> {
         if let Some(type_parameters) = self.value.type_parameters.as_ref() {
             type_parameters.print(p, ctx);
         }
+        p.print_node_comments_before_id(self.value.get_node_id());
+        p.print_node_comments_before_id(self.value.params.get_node_id());
         p.print_ascii_byte(b'(');
         if let Some(this_param) = &self.value.this_param {
             this_param.print(p, ctx);
@@ -2936,6 +3234,7 @@ impl Gen for MethodDefinition<'_> {
         }
         self.value.params.print(p, ctx);
         p.print_ascii_byte(b')');
+        p.print_trailing_attached_comments_at(self.value.params.span.end);
         if let Some(return_type) = &self.value.return_type {
             p.print_colon();
             p.print_soft_space();
@@ -3251,7 +3550,9 @@ impl Gen for TSTypeParameterDeclaration<'_> {
             item.print(p, ctx);
         }
         if is_multi_line {
-            p.print_soft_newline();
+            if p.last_byte() != Some(b'\n') {
+                p.print_soft_newline();
+            }
             p.dedent();
             p.print_indent();
         } else if p.is_jsx {
@@ -3721,6 +4022,7 @@ impl Gen for TSFunctionType<'_> {
         if let Some(type_parameters) = &self.type_parameters {
             type_parameters.print(p, ctx);
         }
+        p.print_node_comments_before_id(self.params.get_node_id());
         p.print_ascii_byte(b'(');
         if let Some(this_param) = &self.this_param {
             this_param.print(p, ctx);
@@ -3731,6 +4033,7 @@ impl Gen for TSFunctionType<'_> {
         }
         self.params.print(p, ctx);
         p.print_ascii_byte(b')');
+        p.print_trailing_attached_comments_at(self.params.span.end);
         p.print_soft_space();
         p.print_str("=>");
         p.print_soft_space();
@@ -3758,6 +4061,7 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = signature.type_parameters.as_ref() {
                     type_parameters.print(p, ctx);
                 }
+                p.print_node_comments_before_id(signature.params.get_node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &signature.this_param {
                     this_param.print(p, ctx);
@@ -3768,6 +4072,7 @@ impl Gen for TSSignature<'_> {
                 }
                 signature.params.print(p, ctx);
                 p.print_ascii_byte(b')');
+                p.print_trailing_attached_comments_at(signature.params.span.end);
                 if let Some(return_type) = &signature.return_type {
                     p.print_colon();
                     p.print_soft_space();
@@ -3779,9 +4084,11 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = signature.type_parameters.as_ref() {
                     type_parameters.print(p, ctx);
                 }
+                p.print_node_comments_before_id(signature.params.get_node_id());
                 p.print_ascii_byte(b'(');
                 signature.params.print(p, ctx);
                 p.print_ascii_byte(b')');
+                p.print_trailing_attached_comments_at(signature.params.span.end);
                 if let Some(return_type) = &signature.return_type {
                     p.print_colon();
                     p.print_soft_space();
@@ -3820,6 +4127,7 @@ impl Gen for TSSignature<'_> {
                 if let Some(type_parameters) = &signature.type_parameters {
                     type_parameters.print(p, ctx);
                 }
+                p.print_node_comments_before_id(signature.params.get_node_id());
                 p.print_ascii_byte(b'(');
                 if let Some(this_param) = &signature.this_param {
                     this_param.print(p, ctx);
@@ -3830,12 +4138,24 @@ impl Gen for TSSignature<'_> {
                 }
                 signature.params.print(p, ctx);
                 p.print_ascii_byte(b')');
+                p.print_trailing_attached_comments_at(signature.params.span.end);
                 if let Some(return_type) = &signature.return_type {
                     p.print_colon();
                     p.print_soft_space();
                     return_type.print(p, ctx);
                 }
             }
+        }
+        // Type-member terminators are optional and regenerated by the
+        // containing type body. Claim comments attached to an original comma
+        // or semicolon before that container prints its canonical semicolon.
+        if p.has_comments_in_range(self.span().start, self.span().end) {
+            if p.comments_in_range_need_space_after(self.span().start, self.span().end)
+                && !p.consume_pending_indent_space()
+            {
+                p.print_soft_space();
+            }
+            p.print_comments_in_range(self.span().start, self.span().end);
         }
     }
 }
@@ -4232,9 +4552,11 @@ impl Gen for TSConstructorType<'_> {
         if let Some(type_parameters) = &self.type_parameters {
             type_parameters.print(p, ctx);
         }
+        p.print_node_comments_before_id(self.params.get_node_id());
         p.print_ascii_byte(b'(');
         self.params.print(p, ctx);
         p.print_ascii_byte(b')');
+        p.print_trailing_attached_comments_at(self.params.span.end);
         p.print_soft_space();
         p.print_str("=>");
         p.print_soft_space();

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -34,7 +34,7 @@ mod sourcemap_builder;
 mod str;
 
 use binary_expr_visitor::BinaryExpressionVisitor;
-use comment::CommentsMap;
+use comment::{CommentStore, NodeCommentStore};
 use operator::Operator;
 #[cfg(feature = "sourcemap")]
 use sourcemap_builder::SourcemapBuilder;
@@ -126,23 +126,13 @@ pub struct Codegen<'a> {
     quote: Quote,
 
     // Builders
-    comments: CommentsMap,
+    comments: CommentStore,
+    node_comments: NodeCommentStore,
     has_property_key_annotations: bool,
 
-    /// Pure / no-side-effects annotation comments keyed by `attached_to`,
-    /// so the emission site can recover verbatim source text instead of a
-    /// canonicalised literal (rolldown#9408). The emission site falls back
-    /// to the canonical literal when (a) no comment is stashed, (b) the
-    /// stashed comment's kind doesn't match the emission site (mixed
-    /// `@__PURE__` and `@__NO_SIDE_EFFECTS__` on the same `attached_to`),
-    /// (c) the comment is a line comment but the site can't break the line,
-    /// or (d) source text isn't available.
-    annotation_comments: FxHashMap<u32, Comment>,
-
-    /// Sorted, deduped `attached_to` keys for comments that must survive a
-    /// removed anchor. Lets `print_orphan_comments_before` flush via
-    /// `partition_point` + `drain`.
-    orphan_comment_keys: Vec<u32>,
+    /// Suppress normal comments at a moved expression boundary. They remain
+    /// unclaimed for the enclosing statement's safe fallback.
+    suppress_normal_comments: bool,
 
     #[cfg(feature = "sourcemap")]
     sourcemap_builder: Option<SourcemapBuilder<'a>>,
@@ -195,10 +185,10 @@ impl<'a> Codegen<'a> {
             is_jsx: false,
             indent: 0,
             quote: Quote::Double,
-            comments: CommentsMap::default(),
+            comments: CommentStore::default(),
+            node_comments: NodeCommentStore::default(),
             has_property_key_annotations: false,
-            annotation_comments: FxHashMap::default(),
-            orphan_comment_keys: Vec::new(),
+            suppress_normal_comments: false,
             #[cfg(feature = "sourcemap")]
             sourcemap_builder: None,
         }
@@ -258,12 +248,15 @@ impl<'a> Codegen<'a> {
         self.source_text = Some(program.source_text);
         self.indent = self.options.initial_indent;
         self.code.reserve(program.source_text.len());
-        self.build_comments(&program.comments);
+        if !self.build_node_comments(program) {
+            self.build_comments(&program.comments);
+        }
         #[cfg(feature = "sourcemap")]
         if let Some(path) = &self.options.source_map_path {
             self.sourcemap_builder = Some(SourcemapBuilder::new(path, program.source_text));
         }
         program.print(&mut self, Context::default());
+        self.print_all_remaining_orphan_comments();
         let legal_comments = self.handle_eof_linked_or_external_comments(program);
         let code = self.code.into_string();
         #[cfg(feature = "sourcemap")]
@@ -578,6 +571,14 @@ impl<'a> Codegen<'a> {
         self.print_next_indent_as_space = false;
     }
 
+    fn with_suppressed_normal_comments<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let previous = self.suppress_normal_comments;
+        self.suppress_normal_comments = true;
+        let result = f(self);
+        self.suppress_normal_comments = previous;
+        result
+    }
+
     #[inline]
     fn print_semicolon_after_statement(&mut self) {
         if self.options.minify {
@@ -620,7 +621,23 @@ impl<'a> Codegen<'a> {
         op(self);
         if !single_line {
             self.dedent();
+            let close = span.end.saturating_sub(1);
+            if self.has_comment(close) {
+                self.indent();
+                self.print_indent();
+                self.print_comments_before_closing_delimiter(close);
+                self.dedent();
+                if self.last_byte() != Some(b'\n') {
+                    self.trim_trailing_indent_space();
+                    self.print_hard_newline();
+                }
+            }
             self.print_indent();
+        } else if span.end > 0 {
+            self.print_comments_before_closing_delimiter(span.end - 1);
+            if self.last_byte() == Some(b'\n') {
+                self.print_indent();
+            }
         }
         self.add_source_mapping_end(span);
         self.print_ascii_byte(b'}');
@@ -634,10 +651,18 @@ impl<'a> Codegen<'a> {
     }
 
     fn print_block_end(&mut self, span: Span) {
+        self.trim_trailing_indent_space();
         self.dedent();
         self.print_indent();
         self.add_source_mapping_end(span);
         self.print_ascii_byte(b'}');
+    }
+
+    #[inline]
+    fn trim_trailing_indent_space(&mut self) {
+        while matches!(self.last_byte(), Some(b' ' | b'\t')) {
+            self.code.pop_byte();
+        }
     }
 
     fn print_body(&mut self, stmt: &Statement<'_>, ctx: Context) {
@@ -773,18 +798,23 @@ impl<'a> Codegen<'a> {
     fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
         self.print_ascii_byte(b'(');
 
-        let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
+        let right_paren = span.end.saturating_sub(1);
+        let trailing_gap_start =
+            arguments.last().map_or(span.start, |argument| argument.span().end);
+        let has_comment_in_trailing_gap =
+            self.has_comments_in_range(trailing_gap_start, right_paren);
+        let has_comment_before_right_paren = span.end > 0 && self.has_comment(right_paren);
 
-        let has_comment = has_comment_before_right_paren
+        let has_comment = has_comment_in_trailing_gap
+            || has_comment_before_right_paren
             || arguments.iter().any(|item| self.has_comment(item.span().start));
 
         if has_comment {
             self.indent();
             self.print_list_with_comments(arguments, ctx);
-            // Handle `/* comment */);`
-            if !has_comment_before_right_paren
-                || (span.end > 0 && !self.print_expr_comments(span.end - 1))
-            {
+            let printed_trailing_comment =
+                self.print_expr_comments_before_closing_delimiter(trailing_gap_start, right_paren);
+            if !printed_trailing_comment {
                 self.print_soft_newline();
             }
             self.dedent();
@@ -900,8 +930,10 @@ impl<'a> Codegen<'a> {
             decorator.print(self, ctx);
             // Only separate from the following token when the decorator ends in an
             // identifier char (`@dec class`); `@dec() class` can be `@dec()class`.
-            self.print_soft_space();
-            self.print_space_before_identifier();
+            if self.last_byte() != Some(b'\n') {
+                self.print_soft_space();
+                self.print_space_before_identifier();
+            }
         }
     }
 

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -1,7 +1,437 @@
+use oxc_allocator::Allocator;
+use oxc_ast::{AttachedCommentPosition, CommentPosition};
+use oxc_codegen::Codegen;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::{GetSpan, SourceType};
+
 use crate::{
-    test_idempotency, test_idempotency_options,
+    codegen, codegen_options, test_idempotency, test_idempotency_options,
     tester::{test, test_same},
 };
+
+#[test]
+fn comments_are_not_lost() {
+    for case in [
+        "/* comment */ const value = initializer;",
+        "const /* comment */ value = initializer;",
+        "const value /* comment */ = initializer;",
+        "const value = /* comment */ initializer;",
+        "/* comment 1 */ function /* comment 2 */ foo /* comment 3 */ ();",
+        "/* comment 1 */ function /* comment 2 */ * /* comment 3 */ foo() {}",
+    ] {
+        let allocator = Allocator::default();
+        let source_type = SourceType::ts();
+        let ret = Parser::new(&allocator, case, source_type).parse();
+        assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+        assert!(!ret.program.comments.is_empty());
+        let codegen_ret = Codegen::new().build(&ret.program);
+        let original_source_text = case;
+        let printed = codegen_ret.code;
+        for comment in ret.program.comments {
+            let expected_comment_content = comment.content_span().source_text(original_source_text);
+            assert_eq!(
+                printed.matches(expected_comment_content).count(),
+                1,
+                "expected comment content `{expected_comment_content}` exactly once in printed: `{printed}`, original: `{original_source_text}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn semantic_comment_hosts_are_assigned_and_printed_once() {
+    for source in [
+        "/* c0 */async/* c1 */ function/* c2 */* /* c3 */foo/* c4 */() /* c5 */ {}",
+        "const foo /* #__PURE__ */ = pureOperation();",
+        "const values = [/* inside */]; class C {/* class-inside */}",
+        "test(function() {\n  var a = 1;\n  // one\n}\n// two\n);",
+        "(/* 1 */ { /* 2 */ f /* 3 */ (/* 4 */ a /* 5 */, /* 6 */) /* 7 */ { /* 8 */ } /* 9 */ } /* 10 */);",
+        "function commentedParameters(\na /* parameter a */,\nb /* parameter b */,\n/* extra comment */\n) {}",
+    ] {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+        assert!(ret.diagnostics.is_empty());
+        let semantic = SemanticBuilder::new()
+            .with_build_nodes(true)
+            .with_build_comment_attachments(true)
+            .build(&ret.program)
+            .semantic;
+        let attachments = ret.program.comment_attachments.0.as_deref().unwrap();
+        assert!(
+            (0..attachments.host_len())
+                .all(|index| attachments.host(index).node_id.index() < semantic.nodes().len())
+        );
+
+        let printed = Codegen::new().build(&ret.program).code;
+        for comment in &ret.program.comments {
+            let marker = comment.content_span().source_text(source);
+            assert_eq!(printed.matches(marker).count(), 1, "{marker}: {printed}");
+        }
+
+        let allocator2 = Allocator::default();
+        let ret2 = Parser::new(&allocator2, &printed, SourceType::ts()).parse();
+        SemanticBuilder::new()
+            .with_build_nodes(true)
+            .with_build_comment_attachments(true)
+            .build(&ret2.program);
+        let printed2 = Codegen::new().build(&ret2.program).code;
+        assert_eq!(printed2, printed, "semantic codegen is not idempotent for {source}");
+    }
+}
+
+#[test]
+fn semantic_comment_attachment() {
+    let allocator = Allocator::default();
+    let source = "first(); /* after */\n/* before */ second(); const empty = [/* inside */];";
+    let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    SemanticBuilder::new().with_build_comment_attachments(true).build(&ret.program);
+    let attachments = ret.program.comment_attachments.0.as_deref().unwrap();
+    let host_ids = (0..attachments.host_len())
+        .map(|index| attachments.host(index).node_id)
+        .collect::<Vec<_>>();
+    SemanticBuilder::new().with_build_comment_attachments(true).build(&ret.program);
+    assert_eq!(
+        host_ids,
+        (0..attachments.host_len())
+            .map(|index| attachments.host(index).node_id)
+            .collect::<Vec<_>>()
+    );
+
+    let position = |marker: &str| {
+        (0..ret.program.comments.len())
+            .map(|index| attachments.comment(index))
+            .find(|attached| attached.comment.span.source_text(source).contains(marker))
+            .map(|attached| attached.position)
+            .unwrap()
+    };
+    assert_eq!(position("after"), AttachedCommentPosition::After);
+    assert_eq!(position("before"), AttachedCommentPosition::Before);
+    assert_eq!(position("inside"), AttachedCommentPosition::Inside);
+
+    let pure_source = "const foo /* #__PURE__ */ = pureOperation();";
+    let ret = Parser::new(&allocator, pure_source, SourceType::ts()).parse();
+    SemanticBuilder::new().with_build_comment_attachments(true).build(&ret.program);
+    let attachments = ret.program.comment_attachments.0.as_deref().unwrap();
+    assert_eq!(attachments.comment(0).position, AttachedCommentPosition::After);
+}
+
+#[test]
+fn comments_are_claimed_exactly_once_across_boundaries_and_fallbacks() {
+    const TORTURE: &str =
+        "/* c0 */async/* c1 */ function/* c2 */* /* c3 */foo3/* c4 */() /* c5 */ {}";
+    let printed = codegen(TORTURE);
+    for marker in ["c0", "c1", "c2", "c3", "c4", "c5"] {
+        assert_eq!(printed.matches(marker).count(), 1, "{marker}: {printed}");
+    }
+    test_idempotency(TORTURE);
+
+    let non_generator = codegen("/* ng0 */async/* ng1 */ function/* ng2 */ foo() {}");
+    for marker in ["ng0", "ng1", "ng2"] {
+        assert_eq!(non_generator.matches(marker).count(), 1, "{marker}: {non_generator}");
+    }
+
+    let repeated = codegen("/* same-anchor-a */ /* same-anchor-b */ const value = 1;");
+    for marker in ["same-anchor-a", "same-anchor-b"] {
+        assert_eq!(repeated.matches(marker).count(), 1, "{marker}: {repeated}");
+    }
+
+    let empty = codegen(
+        "const array = [/* empty-array */]; const object = {/* empty-object */}; function f(/* empty-params */) {}",
+    );
+    for marker in ["empty-array", "empty-object", "empty-params"] {
+        assert_eq!(empty.matches(marker).count(), 1, "{marker}: {empty}");
+    }
+}
+
+#[test]
+fn semantic_annotations_are_printed_exactly_once() {
+    for (source, marker) in [
+        ("/* @__PURE__ */ (factory());", "PURE"),
+        ("const obj = { props: /*#__PURE__*/ extend({}, validators) };", "PURE"),
+        ("const symbols = new Set(/*#__PURE__*/ Object.getOwnPropertyNames(Symbol));", "PURE"),
+        ("/* @__NO_SIDE_EFFECTS__ */ (function factory() {});", "NO_SIDE_EFFECTS"),
+    ] {
+        let printed = codegen(source);
+        assert_eq!(printed.matches(marker).count(), 1, "{source} -> {printed}");
+    }
+}
+
+#[test]
+fn comments_are_claimed_without_global_source_order() {
+    let allocator = Allocator::default();
+    let source = "/* reorder-a */ first(); /* reorder-b */ second();";
+    let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let mut program = ret.program;
+    program.body.swap(0, 1);
+    let printed = Codegen::new().build(&program).code;
+    for marker in ["reorder-a", "reorder-b"] {
+        assert_eq!(printed.matches(marker).count(), 1, "{marker}: {printed}");
+    }
+
+    let source = "/* @__PURE__ reorder-pure-a */ first(); /* #__PURE__ reorder-pure-b */ second();";
+    let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let mut program = ret.program;
+    program.body.swap(0, 1);
+    let printed = Codegen::new().build(&program).code;
+    for marker in ["reorder-pure-a", "reorder-pure-b"] {
+        assert_eq!(printed.matches(marker).count(), 1, "{marker}: {printed}");
+    }
+}
+
+#[test]
+fn mixed_leading_and_trailing_comments_share_an_anchor() {
+    let allocator = Allocator::default();
+    let source = "/* mixed-trailing */ first(); /* mixed-leading */ second();";
+    let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let mut program = ret.program;
+    let anchor = program.body[1].span().start;
+    program.comments[0].attached_to = anchor;
+    program.comments[0].position = CommentPosition::Trailing;
+    program.comments[1].attached_to = anchor;
+    program.comments[1].position = CommentPosition::Leading;
+    let printed = Codegen::new().build(&program).code;
+    for marker in ["mixed-trailing", "mixed-leading"] {
+        assert_eq!(printed.matches(marker).count(), 1, "{marker}: {printed}");
+    }
+}
+
+#[test]
+fn removed_node_and_comments_disabled_fallbacks() {
+    use oxc_codegen::CodegenOptions;
+
+    let allocator = Allocator::default();
+    let source = "/* removed */ removed(); survivor();";
+    let ret = Parser::new(&allocator, source, SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let mut program = ret.program;
+    program.body.remove(0);
+    let printed = Codegen::new().build(&program).code;
+    assert_eq!(printed.matches("removed").count(), 0, "{printed}");
+
+    let ret = Parser::new(&allocator, "/* disabled */ enabled();", SourceType::ts()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let printed = Codegen::new().with_options(CodegenOptions::minify()).build(&ret.program).code;
+    assert_eq!(printed.matches("disabled").count(), 0, "{printed}");
+}
+
+#[test]
+fn test_parser_attached_comments_survive_unhandled_slots() {
+    for (slot, source, marker) in [
+        (
+            "initializer",
+            "const value = /* v8 ignore next: initializer */ initializer;",
+            "initializer",
+        ),
+        ("array element", "const values = [/* v8 ignore next: array */ value];", "array"),
+        (
+            "trailing array element",
+            "const values = [value /* v8 ignore next: trailing array */\n, other];",
+            "trailing array",
+        ),
+        ("array spread", "const values = [.../* v8 ignore next: spread */ iterable];", "spread"),
+        ("computed member", "const value = object[/* v8 ignore next: key */ key];", "key"),
+        ("sequence", "const value = (first, /* v8 ignore next: sequence */ second);", "sequence"),
+        ("assignment", "target = /* v8 ignore next: assignment */ source;", "assignment"),
+        ("unary", "const value = void /* v8 ignore next: unary */ source;", "unary"),
+        ("binary", "const value = left + /* v8 ignore next: binary */ right;", "binary"),
+        (
+            "trailing binary",
+            "const value = left /* v8 ignore next: trailing binary */ + right;",
+            "trailing binary",
+        ),
+        (
+            "conditional test",
+            "const value = /* v8 ignore next: conditional */ test ? yes : no;",
+            "conditional",
+        ),
+        (
+            "await",
+            "async function f() { return await /* v8 ignore next: await */ value; }",
+            "await",
+        ),
+        ("yield", "function* f() { yield /* v8 ignore next: yield */ value; }", "yield"),
+        ("for of", "for (const item of /* v8 ignore next: iterable */ items) {}", "iterable"),
+        ("if", "if (/* v8 ignore next: if */ test) {}", "ignore next: if"),
+        ("while", "while (/* v8 ignore next: while */ test) {}", "while"),
+        ("for test", "for (; /* v8 ignore next: for test */ test; update()) {}", "for test"),
+        ("for update", "for (; test; /* v8 ignore next: for update */ update()) {}", "for update"),
+        ("update", "++/* v8 ignore next: update */ value;", "update"),
+        ("throw", "throw /* v8 ignore next: throw */ error;", "throw"),
+        (
+            "object key",
+            "const value = { [/* v8 ignore next: object key */ key]: item };",
+            "object key",
+        ),
+        ("class field", "class C { field = /* v8 ignore next: field */ value; }", "field"),
+        ("heritage", "class Derived extends /* v8 ignore next: heritage */ Base {}", "heritage"),
+        (
+            "declarator",
+            "const first = 1, /* v8 ignore next: declarator */ second = value;",
+            "declarator",
+        ),
+        ("array pattern", "const [/* v8 ignore next: binding */ item] = values;", "binding"),
+        (
+            "object pattern",
+            "const { /* v8 ignore next: property */ key: value } = object;",
+            "property",
+        ),
+        ("parameter", "function f(/** parameter */ value) {}", "parameter"),
+        ("parameter type", "function f(value: /** parameter type */ string) {}", "parameter type"),
+        ("return type", "function f(): /** return type */ string { return \"\"; }", "return type"),
+        ("type parameter", "function f</** type parameter */ T>() {}", "type parameter"),
+        ("type alias", "type Alias = /** type alias */ string;", "type alias"),
+        ("tuple", "type Tuple = [/** tuple */ string];", "tuple"),
+        ("union", "type Union = /** union */ A | B;", "union"),
+        ("type argument", "type Generic = Container</** type argument */ Arg>;", "type argument"),
+        (
+            "import specifier",
+            "import { /** import specifier */ imported as local } from \"module\";",
+            "import specifier",
+        ),
+        (
+            "import attribute",
+            "import data from \"data\" with { /** import attribute */ type: \"json\" };",
+            "import attribute",
+        ),
+    ] {
+        let generated = codegen(source);
+        assert!(generated.contains(marker), "{slot} comment was dropped: {generated}");
+    }
+}
+
+#[test]
+fn test_parser_attached_comments_survive_additional_slots() {
+    for (slot, source, marker) in [
+        (
+            "array binding rest",
+            "const [.../* v8 ignore next: array binding rest */ rest] = values;",
+            "array binding rest",
+        ),
+        (
+            "object binding value",
+            "const { key: /* v8 ignore next: object binding value */ value } = object;",
+            "object binding value",
+        ),
+        (
+            "parameter default",
+            "function f(value = /* v8 ignore next: parameter default */ fallback) {}",
+            "parameter default",
+        ),
+        (
+            "assignment target value",
+            "({ key: /* v8 ignore next: assignment target value */ value } = object);",
+            "assignment target value",
+        ),
+        ("rest parameter", "function f(.../** rest parameter */ values) {}", "rest parameter"),
+        (
+            "this parameter",
+            "function f(/** this parameter */ this: Context, value: string) {}",
+            "this parameter",
+        ),
+        (
+            "arrow parameter",
+            "const f = (/** arrow parameter */ value) => value;",
+            "arrow parameter",
+        ),
+        (
+            "function type parameter",
+            "type F = (/** function type parameter */ value: string) => string;",
+            "function type parameter",
+        ),
+        (
+            "type parameter constraint",
+            "function f<T extends /** type parameter constraint */ Base>() {}",
+            "type parameter constraint",
+        ),
+        (
+            "type parameter default",
+            "function f<T = /** type parameter default */ Default>() {}",
+            "type parameter default",
+        ),
+        (
+            "intersection arm",
+            "type Intersection = /** intersection arm */ A & B;",
+            "intersection arm",
+        ),
+        (
+            "indexed access index",
+            "type Indexed = Container[/** indexed access index */ Key];",
+            "indexed access index",
+        ),
+        (
+            "conditional extends type",
+            "type Conditional<T> = T extends /** conditional extends */ string ? A : B;",
+            "conditional extends",
+        ),
+        (
+            "mapped constraint",
+            "type Mapped<T> = { [K in /** mapped constraint */ keyof T]: T[K] };",
+            "mapped constraint",
+        ),
+        (
+            "mapped value",
+            "type Mapped<T> = { [K in keyof T]: /** mapped value */ T[K] };",
+            "mapped value",
+        ),
+        (
+            "type operator operand",
+            "type Operator<T> = keyof /** type operator operand */ T;",
+            "type operator operand",
+        ),
+    ] {
+        let generated = codegen(source);
+        assert!(generated.contains(marker), "{slot} comment was dropped: {generated}");
+    }
+}
+
+#[test]
+fn test_parser_attached_comments_survive_special_paths() {
+    use oxc_allocator::Allocator;
+    use oxc_codegen::Codegen;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    for (source, marker) in [
+        ("<Component /** jsx attribute */ property />;", "jsx attribute"),
+        ("<Component {... /** jsx spread */ properties} />;", "jsx spread"),
+    ] {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        assert!(ret.diagnostics.is_empty());
+        assert!(Codegen::new().build(&ret.program).code.contains(marker));
+    }
+
+    let pure = codegen("/* @__PURE__ */ /* #__PURE__ */ factory();");
+    assert!(pure.contains("@__PURE__") && pure.contains("#__PURE__"), "{pure}");
+
+    let no_side_effects =
+        codegen("/* @__NO_SIDE_EFFECTS__ */ /* #__NO_SIDE_EFFECTS__ */ function factory() {}");
+    assert!(
+        no_side_effects.contains("@__NO_SIDE_EFFECTS__")
+            && no_side_effects.contains("#__NO_SIDE_EFFECTS__"),
+        "{no_side_effects}"
+    );
+}
+
+#[test]
+fn test_cjs_fast_paths_deliberately_skip_attached_comments_when_minified() {
+    use oxc_codegen::CodegenOptions;
+
+    let options = CodegenOptions { minify: true, ..CodegenOptions::default() };
+    for (source, marker) in [
+        ("require(/* v8 require */ \"module\");", "v8 require"),
+        ("exports[/* v8 exports */ \"name\"] = value;", "v8 exports"),
+        ("key === /* v8 equality */ \"default\";", "v8 equality"),
+    ] {
+        let generated = codegen_options(source, &options).code;
+        assert!(!generated.contains(marker), "{source} -> {generated}");
+    }
+}
 
 // A leading comment inside a `pife` arrow alternate of a `?:` must stay
 // inside the paren wrap on every codegen pass; otherwise the parser re-

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -204,8 +204,8 @@ fn test_new() {
     );
     test(
         "new Worker(/* webpackFoo: 1 */ 'path' /* webpackBar:2 */ ,);",
-        "new Worker(\n\t/* webpackFoo: 1 */\n\t\"path\"\n);\n",
-    ); // Not currently handled
+        "new Worker(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",
+    );
     test(
         "new Worker(/* webpackFoo: 1 */ 'path', /* webpackBar:2 */ );",
         "new Worker(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",
@@ -272,8 +272,8 @@ fn test_call() {
     );
     test(
         "require(/* webpackFoo: 1 */ 'path' /* webpackBar:2 */ ,);",
-        "require(\n\t/* webpackFoo: 1 */\n\t\"path\"\n);\n",
-    ); // Not currently handled
+        "require(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",
+    );
     test(
         "require(/* webpackFoo: 1 */ 'path', /* webpackBar:2 */ );",
         "require(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",
@@ -704,8 +704,8 @@ fn test_import() {
     );
     test(
         "import(/* webpackFoo: 1 */ 'path' /* webpackBar:2 */ ,);",
-        "import(\n\t/* webpackFoo: 1 */\n\t\"path\"\n);\n",
-    ); // Not currently handled
+        "import(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",
+    );
     test(
         "import(/* webpackFoo: 1 */ 'path', /* webpackBar:2 */ );",
         "import(\n\t/* webpackFoo: 1 */\n\t\"path\"\n\t/* webpackBar:2 */\n);\n",

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -508,8 +508,6 @@ fn pure_comment() {
     test_same(
         "/* #__PURE__ -- @preserve */ pureOperation();\n", // rolldown#9408
     );
-    test("const foo /* #__PURE__ */ = pureOperation();", "const foo = pureOperation();\n"); // INVALID: "=" not allowed after annotation
-
     test("/* @__PURE__ */ (foo());", "/* @__PURE__ */ foo();\n");
     test("/* @__PURE__ */ (new Foo());\n", "/* @__PURE__ */ new Foo();\n");
     test("/*#__PURE__*/ (foo(), bar());", "/*#__PURE__*/ foo(), bar();\n"); // INVALID, there is a comma expression in the parentheses
@@ -534,6 +532,7 @@ fn pure_comment() {
 fn unapplied_annotation_comments() {
     test_same("/* #__PURE__ */ function foo() {}\n");
     test_same("/* #__NO_SIDE_EFFECTS__ */ value;\n");
+    test_same("const foo /* #__PURE__ */ = pureOperation();\n");
 
     // A misplaced `@__NO_SIDE_EFFECTS__` comment sharing the call site's `attached_to`
     // must be preserved for downstream consumers to warn about, without replacing the

--- a/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
@@ -108,7 +108,9 @@ try {
 	something();
 } 
 /* istanbul ignore next */
-catch (e) {}
+catch (e) {
+// should never happen
+}
 
 ########## 20
 try { console.log('test'); }
@@ -137,7 +139,8 @@ catch (err) // v8 ignore next
 ----------
 try {
 	something();
-} catch (err) {
+} catch (err) // v8 ignore next
+{
 	handle(err);
 }
 

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -157,10 +157,10 @@ export default function() {}
 ----------
 /* #__NO_SIDE_EFFECTS__ */ export var v0 = function() {}, v1 = function() {};
 /* #__NO_SIDE_EFFECTS__ */ export let l0 = function() {}, l1 = function() {};
-export const c0 = /* @__NO_SIDE_EFFECTS__ */ function() {}, c1 = function() {};
+export const c0 = /* #__NO_SIDE_EFFECTS__ */ function() {}, c1 = function() {};
 /* #__NO_SIDE_EFFECTS__ */ export var v2 = () => {}, v3 = () => {};
 /* #__NO_SIDE_EFFECTS__ */ export let l2 = () => {}, l3 = () => {};
-export const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {}, c3 = () => {};
+export const c2 = /* #__NO_SIDE_EFFECTS__ */ () => {}, c3 = () => {};
 
 ########## 8
 
@@ -174,10 +174,10 @@ export const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {}, c3 = () => {};
 ----------
 /* #__NO_SIDE_EFFECTS__ */ var v0 = function() {}, v1 = function() {};
 /* #__NO_SIDE_EFFECTS__ */ let l0 = function() {}, l1 = function() {};
-const c0 = /* @__NO_SIDE_EFFECTS__ */ function() {}, c1 = function() {};
+const c0 = /* #__NO_SIDE_EFFECTS__ */ function() {}, c1 = function() {};
 /* #__NO_SIDE_EFFECTS__ */ var v2 = () => {}, v3 = () => {};
 /* #__NO_SIDE_EFFECTS__ */ let l2 = () => {}, l3 = () => {};
-const c2 = /* @__NO_SIDE_EFFECTS__ */ () => {}, c3 = () => {};
+const c2 = /* #__NO_SIDE_EFFECTS__ */ () => {}, c3 = () => {};
 
 ########## 9
 
@@ -279,7 +279,7 @@ const defineSSRCustomElement = () => {
         
 ----------
 const defineSSRCustomElement = () => {
-	return /* @__PURE__ */ defineCustomElement(options, extraOptions, hydrate);
+	return /* @__NO_SIDE_EFFECTS__ */ /* #__NO_SIDE_EFFECTS__ */ /* @__PURE__ */ defineCustomElement(options, extraOptions, hydrate);
 };
 
 ########## 20
@@ -403,8 +403,8 @@ let single_num_yes = /* @__PURE__ */ foo(bar);
 let single_num_no = /* @__PURE__ */ foo(bar());
 let new_single_num_yes = /* @__PURE__ */ new foo(bar);
 let new_single_num_no = /* @__PURE__ */ new foo(bar());
-let bad_no = foo(bar);
-let new_bad_no = new foo(bar);
+let bad_no = /* __PURE__ */ foo(bar);
+let new_bad_no = /* __PURE__ */ new foo(bar);
 let parens_no = foo(bar);
 let new_parens_no = new foo(bar);
 let exp_no = /* @__PURE__ */ foo() ** foo();

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -304,28 +304,30 @@ import { export1 } from 'module-name';
 import { export1 as alias1 } from 'module-name';
 import { default as alias } from 'module-name';
 import { export1, export2 } from 'module-name';
-import { export1, export2 as alias2 } from 'module-name';
+import { export1, export2 as alias2 /* … */ } from 'module-name';
 import { 'string name' as alias } from 'module-name';
-import defaultExport, { export1 } from 'module-name';
+import defaultExport, { export1 /* … */ } from 'module-name';
 import defaultExport, * as name from 'module-name';
 import 'module-name';
 import {} from 'mod';
-export let name1, name2;
-export const name3 = 1, name4 = 2;
+export let name1, name2/*, … */ // also var
+;
+export const name3 = 1, name4 = 2/*, … */ // also var, let
+;
 export function functionName() {/* … */}
-export class ClassName {}
+export class ClassName {/* … */ }
 export function* generatorFunctionName() {/* … */}
 export const { name5, name2: bar } = o;
 export const [name6, name7] = array;
 export { name8, /* …, */ name81 };
 export { variable1 as name9, variable2 as name10, /* …, */ name82 };
 export { variable1 as 'string name' };
-export { name1 as default1 };
+export { name1 as default1 /*, … */ };
 export * from 'module-name';
 export * as name11 from 'module-name';
 export { name12, /* …, */ nameN } from 'module-name';
 export { import1 as name13, import2 as name14, /* …, */ name15 } from 'module-name';
-export { default } from 'module-name';
+export { default /* …, */ } from 'module-name';
 export { default as name16 } from 'module-name';
 
 ########## 41

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -249,6 +249,12 @@ impl CodeBuffer {
         self.buf.last().copied()
     }
 
+    /// Remove and return the final byte in the buffer.
+    #[inline]
+    pub fn pop_byte(&mut self) -> Option<u8> {
+        self.buf.pop()
+    }
+
     /// Peek the last char from the end of the buffer.
     #[inline]
     pub fn last_char(&self) -> Option<char> {

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -849,6 +849,11 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     #[inline]
+    pub fn comment_attachments(&self) -> &CommentAttachmentsStore<'a> {
+        &self.inner.comment_attachments
+    }
+
+    #[inline]
     pub fn hashbang(&self) -> Option<&AstNode<'a, Hashbang<'a>>> {
         let following_span_start = self
             .inner

--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -2590,6 +2590,8 @@ pub(crate) const OFFSET_PROGRAM_SPAN: usize = offset_of!(Program, span);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TYPE: usize = offset_of!(Program, source_type);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TEXT: usize = offset_of!(Program, source_text);
 pub(crate) const OFFSET_PROGRAM_COMMENTS: usize = offset_of!(Program, comments);
+pub(crate) const OFFSET_PROGRAM_COMMENT_ATTACHMENTS: usize =
+    offset_of!(Program, comment_attachments);
 pub(crate) const OFFSET_PROGRAM_HASHBANG: usize = offset_of!(Program, hashbang);
 pub(crate) const OFFSET_PROGRAM_DIRECTIVES: usize = offset_of!(Program, directives);
 pub(crate) const OFFSET_PROGRAM_BODY: usize = offset_of!(Program, body);
@@ -2627,6 +2629,14 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
     pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
+    }
+
+    #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
         }
     }
 
@@ -2696,6 +2706,14 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
+        }
+    }
+
+    #[inline]
     pub fn hashbang(self) -> &'t Option<Hashbang<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_HASHBANG) as *const Option<Hashbang<'a>>)
@@ -2756,6 +2774,14 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
+    }
+
+    #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
         }
     }
 

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -157,15 +157,17 @@ impl<'a> TriviaBuilder<'a> {
     #[cold]
     fn attach_pending_comments_to_token(&mut self, token: Token, len: usize) {
         let previous_kind = self.previous_token.kind();
+        let continues_previous_expression = Self::can_end_expression(previous_kind)
+            && Self::continues_previous_expression(token.kind());
         let can_attach_to_previous = previous_kind != Kind::Undetermined
-            && (token.kind() == Kind::Eof
-                || (Self::can_end_expression(previous_kind)
-                    && Self::continues_previous_expression(token.kind())));
+            && (token.kind() == Kind::Eof || continues_previous_expression);
         let previous_token_end = self.previous_token.end();
         for comment in &mut self.comments[self.processed..len] {
             if can_attach_to_previous
                 && !comment.preceded_by_newline()
-                && !Self::should_stay_leading(comment)
+                && ((comment.content == CommentContent::PureNotApplied
+                    && continues_previous_expression)
+                    || !Self::should_stay_leading(comment))
             {
                 comment.position = CommentPosition::Trailing;
                 comment.attached_to = previous_token_end;
@@ -960,6 +962,10 @@ function bar() {}";
             let comments = get_comments_typescript(source_text);
             assert_eq!(comments[0].content, CommentContent::PureNotApplied, "{source_text}");
         }
+
+        let comments = get_comments_typescript("const foo /* #__PURE__ */ = pureOperation();");
+        assert!(comments[0].is_trailing());
+        assert_eq!(comments[0].attached_to, 9);
     }
 
     #[test]

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -89,6 +89,7 @@ pub mod lexer;
 
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::{
+    CommentAttachments,
     ast::{Expression, Program, Statement},
     builder::{AstBuilder, GetAstBuilder},
 };
@@ -758,6 +759,11 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             if panicked { ArenaVec::new_in(&self.ast) } else { self.lexer.finalize_tokens() };
 
         program.comments = self.lexer.trivia_builder.comments;
+        if !program.comments.is_empty() {
+            let attachments =
+                CommentAttachments::new_in(self.ast.allocator(), program.comments.len());
+            program.comment_attachments.0 = Some(ArenaBox::new_in(attachments, &self.ast));
+        }
 
         ParserReturn {
             program,

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -77,7 +77,11 @@ fn run_fixture(source: &str) -> String {
     // compile-only run; `lint` then re-runs the same pipeline read-only so we can
     // cross-check its diagnostics against `compile`'s below.
     let (output, diagnostics, fatal, lint_result) = {
-        let semantic = SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
+        let semantic = SemanticBuilder::new()
+            .with_build_nodes(true)
+            .with_build_comment_attachments(true)
+            .build(&program)
+            .semantic;
         let (output, diagnostics, fatal) =
             match compile(&program, &semantic, &allocator, options.clone()) {
                 CompileResult::Success { output, diagnostics } => (output, diagnostics, false),

--- a/crates/oxc_react_compiler/tests/snapshots/destructuring-default-at-array-hole.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/destructuring-default-at-array-hole.snap
@@ -9,5 +9,5 @@ function Component(props) {
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,
-	params: [{ value: [, 3.14] }]
+	params: [{ value: [, /* hole! */ 3.14] }]
 };

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 
 use oxc_allocator::{Address, ArenaVec};
 use oxc_ast::{AstKind, ast::*};
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::{Visit, comments::CommentAttachmentCollector};
 #[cfg(feature = "cfg")]
 use oxc_cfg::{
     ControlFlowGraphBuilder, CtxCursor, CtxFlags, EdgeType, ErrorEdgeKind, InstructionKind,
@@ -107,6 +107,9 @@ pub struct SemanticBuilder<'a> {
     /// Should enum member values be evaluated?
     enum_eval: bool,
 
+    /// Whether to assign source comments to NodeIds for a later codegen pass.
+    build_comment_attachments: bool,
+
     /// Should additional syntax checks be performed?
     ///
     /// See: [`crate::checker::check`]
@@ -162,6 +165,7 @@ impl<'a> SemanticBuilder<'a> {
             stats: None,
             excess_capacity: 0.0,
             enum_eval: false,
+            build_comment_attachments: false,
             check_syntax_error: false,
             #[cfg(feature = "cfg")]
             cfg: None,
@@ -243,6 +247,15 @@ impl<'a> SemanticBuilder<'a> {
     #[must_use]
     pub fn with_enum_eval(mut self, yes: bool) -> Self {
         self.enum_eval = yes;
+        self
+    }
+
+    /// Enable or disable assigning source comments to NodeIds for codegen.
+    ///
+    /// Disabled by default because semantic-only consumers do not use this metadata.
+    #[must_use]
+    pub fn with_build_comment_attachments(mut self, yes: bool) -> Self {
+        self.build_comment_attachments = yes;
         self
     }
 
@@ -343,6 +356,14 @@ impl<'a> SemanticBuilder<'a> {
 
         // Visit AST to generate scopes tree etc
         self.visit_program(program);
+        if self.build_comment_attachments
+            && let Some(attachments) = program.comment_attachments.0.as_deref()
+            && attachments.is_empty()
+        {
+            let mut collector = CommentAttachmentCollector::new(&program.comments);
+            collector.visit_program(program);
+            collector.attach(program, attachments);
+        }
 
         // Check that estimated counts accurately (unless in release mode)
         #[cfg(debug_assertions)]

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -2590,6 +2590,8 @@ pub(crate) const OFFSET_PROGRAM_SPAN: usize = offset_of!(Program, span);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TYPE: usize = offset_of!(Program, source_type);
 pub(crate) const OFFSET_PROGRAM_SOURCE_TEXT: usize = offset_of!(Program, source_text);
 pub(crate) const OFFSET_PROGRAM_COMMENTS: usize = offset_of!(Program, comments);
+pub(crate) const OFFSET_PROGRAM_COMMENT_ATTACHMENTS: usize =
+    offset_of!(Program, comment_attachments);
 pub(crate) const OFFSET_PROGRAM_HASHBANG: usize = offset_of!(Program, hashbang);
 pub(crate) const OFFSET_PROGRAM_DIRECTIVES: usize = offset_of!(Program, directives);
 pub(crate) const OFFSET_PROGRAM_BODY: usize = offset_of!(Program, body);
@@ -2627,6 +2629,14 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
     pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
+    }
+
+    #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
         }
     }
 
@@ -2696,6 +2706,14 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
+        }
+    }
+
+    #[inline]
     pub fn hashbang(self) -> &'t Option<Hashbang<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_HASHBANG) as *const Option<Hashbang<'a>>)
@@ -2756,6 +2774,14 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
+    }
+
+    #[inline]
+    pub fn comment_attachments(self) -> &'t CommentAttachmentsStore<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENT_ATTACHMENTS)
+                as *const CommentAttachmentsStore<'a>)
         }
     }
 

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -60,13 +60,13 @@ function deserializeProgram(pos) {
     program = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start,
       end,
     };
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  (program.body = deserializeVecDirective(pos + 88)).push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  (program.body = deserializeVecDirective(pos + 96)).push(...deserializeVecStatement(pos + 120));
   return program;
 }
 
@@ -4667,9 +4667,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -61,14 +61,14 @@ function deserializeProgram(pos) {
     program = (parent = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start,
       end,
       parent: null,
     });
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  (program.body = deserializeVecDirective(pos + 88)).push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  (program.body = deserializeVecDirective(pos + 96)).push(...deserializeVecStatement(pos + 120));
   parent = null;
   return program;
 }
@@ -5201,9 +5201,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -60,14 +60,14 @@ function deserializeProgram(pos) {
     program = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start,
       end,
       range: [start, end],
     };
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  (program.body = deserializeVecDirective(pos + 88)).push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  (program.body = deserializeVecDirective(pos + 96)).push(...deserializeVecStatement(pos + 120));
   return program;
 }
 
@@ -5223,9 +5223,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -61,15 +61,15 @@ function deserializeProgram(pos) {
     program = (parent = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start,
       end,
       range: [start, end],
       parent: null,
     });
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  (program.body = deserializeVecDirective(pos + 88)).push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  (program.body = deserializeVecDirective(pos + 96)).push(...deserializeVecStatement(pos + 120));
   parent = null;
   return program;
 }
@@ -5756,9 +5756,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -59,14 +59,14 @@ function deserializeProgram(pos) {
     program = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start: 0,
       end,
     };
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  let body = (program.body = deserializeVecDirective(pos + 88));
-  body.push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  let body = (program.body = deserializeVecDirective(pos + 96));
+  body.push(...deserializeVecStatement(pos + 120));
   {
     let start;
     if (body.length > 0) {
@@ -4969,9 +4969,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -60,15 +60,15 @@ function deserializeProgram(pos) {
     program = (parent = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start: 0,
       end,
       parent: null,
     });
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  let body = (program.body = deserializeVecDirective(pos + 88));
-  body.push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  let body = (program.body = deserializeVecDirective(pos + 96));
+  body.push(...deserializeVecStatement(pos + 120));
   {
     let start;
     if (body.length > 0) {
@@ -5533,9 +5533,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -59,15 +59,15 @@ function deserializeProgram(pos) {
     program = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start: 0,
       end,
       range: [0, end],
     };
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  let body = (program.body = deserializeVecDirective(pos + 88));
-  body.push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  let body = (program.body = deserializeVecDirective(pos + 96));
+  body.push(...deserializeVecStatement(pos + 120));
   {
     let start;
     if (body.length > 0) {
@@ -5552,9 +5552,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -60,16 +60,16 @@ function deserializeProgram(pos) {
     program = (parent = {
       type: "Program",
       body: null,
-      sourceType: deserializeModuleKind(pos + 137),
+      sourceType: deserializeModuleKind(pos + 145),
       hashbang: null,
       start: 0,
       end,
       range: [0, end],
       parent: null,
     });
-  program.hashbang = deserializeOptionHashbang(pos + 56);
-  let body = (program.body = deserializeVecDirective(pos + 88));
-  body.push(...deserializeVecStatement(pos + 112));
+  program.hashbang = deserializeOptionHashbang(pos + 64);
+  let body = (program.body = deserializeVecDirective(pos + 96));
+  body.push(...deserializeVecStatement(pos + 120));
   {
     let start;
     if (body.length > 0) {
@@ -6115,9 +6115,9 @@ function deserializeUpdateOperator(pos) {
 function deserializeRawTransferData(pos) {
   return {
     program: deserializeProgram(pos),
-    comments: deserializeVecComment(pos + 144),
-    module: deserializeEcmaScriptModule(pos + 168),
-    errors: deserializeVecError(pos + 272),
+    comments: deserializeVecComment(pos + 152),
+    module: deserializeEcmaScriptModule(pos + 176),
+    errors: deserializeVecError(pos + 280),
   };
 }
 

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -36,19 +36,19 @@ export class Program {
 
   get sourceType() {
     const internal = this.#internal;
-    return new SourceType(internal.pos + 136, internal.ast);
+    return new SourceType(internal.pos + 144, internal.ast);
   }
 
   get hashbang() {
     const internal = this.#internal;
-    return constructOptionHashbang(internal.pos + 56, internal.ast);
+    return constructOptionHashbang(internal.pos + 64, internal.ast);
   }
 
   get body() {
     const internal = this.#internal,
       cached = internal.$body;
     if (cached !== void 0) return cached;
-    return (internal.$body = constructVecStatement(internal.pos + 112, internal.ast));
+    return (internal.$body = constructVecStatement(internal.pos + 120, internal.ast));
   }
 
   toJSON() {
@@ -12569,19 +12569,19 @@ export class RawTransferData {
     const internal = this.#internal,
       cached = internal.$comments;
     if (cached !== void 0) return cached;
-    return (internal.$comments = constructVecComment(internal.pos + 144, internal.ast));
+    return (internal.$comments = constructVecComment(internal.pos + 152, internal.ast));
   }
 
   get module() {
     const internal = this.#internal;
-    return new EcmaScriptModule(internal.pos + 168, internal.ast);
+    return new EcmaScriptModule(internal.pos + 176, internal.ast);
   }
 
   get errors() {
     const internal = this.#internal,
       cached = internal.$errors;
     if (cached !== void 0) return cached;
-    return (internal.$errors = constructVecError(internal.pos + 272, internal.ast));
+    return (internal.$errors = constructVecError(internal.pos + 280, internal.ast));
   }
 
   toJSON() {
@@ -14037,6 +14037,15 @@ function constructBoxTSExternalModuleReference(pos, ast) {
 
 function constructU32(pos, ast) {
   return ast.buffer.int32[pos >> 2] >>> 0;
+}
+
+function constructBoxU8(pos, ast) {
+  return constructU8(ast.buffer.int32[pos >> 2], ast);
+}
+
+function constructOptionBoxU8(pos, ast) {
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
+  return constructBoxU8(pos, ast);
 }
 
 function constructU64(pos, ast) {

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -201,8 +201,8 @@ function walkProgram(pos, ast, visitors) {
     if (enter !== null) enter(node);
   }
 
-  walkOptionHashbang(pos + 56, ast, visitors);
-  walkVecStatement(pos + 112, ast, visitors);
+  walkOptionHashbang(pos + 64, ast, visitors);
+  walkVecStatement(pos + 120, ast, visitors);
 
   if (exit !== null) exit(node);
 }

--- a/napi/parser/src-js/generated/visit/type_ids.js
+++ b/napi/parser/src-js/generated/visit/type_ids.js
@@ -3,6 +3,7 @@
 
 /** Mapping from node type name to node type ID */
 export const NODE_TYPE_IDS_MAP = /* @__PURE__ */ new Map([
+  // Leaf nodes
   ["DebuggerStatement", 0],
   ["EmptyStatement", 1],
   ["Literal", 2],
@@ -30,6 +31,7 @@ export const NODE_TYPE_IDS_MAP = /* @__PURE__ */ new Map([
   ["TSUndefinedKeyword", 24],
   ["TSUnknownKeyword", 25],
   ["TSVoidKeyword", 26],
+  // Non-leaf nodes
   ["AccessorProperty", 27],
   ["ArrayExpression", 28],
   ["ArrayPattern", 29],

--- a/napi/parser/src/generated/assert_layouts.rs
+++ b/napi/parser/src/generated/assert_layouts.rs
@@ -10,12 +10,12 @@ use crate::raw_transfer_types::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 0 bytes
-    assert!(size_of::<RawTransferData>() == 296);
+    assert!(size_of::<RawTransferData>() == 304);
     assert!(align_of::<RawTransferData>() == 8);
     assert!(offset_of!(RawTransferData, program) == 0);
-    assert!(offset_of!(RawTransferData, comments) == 144);
-    assert!(offset_of!(RawTransferData, module) == 168);
-    assert!(offset_of!(RawTransferData, errors) == 272);
+    assert!(offset_of!(RawTransferData, comments) == 152);
+    assert!(offset_of!(RawTransferData, module) == 176);
+    assert!(offset_of!(RawTransferData, errors) == 280);
 
     // Padding: 1 bytes
     assert!(size_of::<RawTransferMetadata>() == 16);
@@ -71,12 +71,12 @@ const _: () = {
 #[cfg(target_pointer_width = "32")]
 const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 0 bytes
-    assert!(size_of::<RawTransferData>() == 196);
+    assert!(size_of::<RawTransferData>() == 200);
     assert!(align_of::<RawTransferData>() == 4);
     assert!(offset_of!(RawTransferData, program) == 0);
-    assert!(offset_of!(RawTransferData, comments) == 96);
-    assert!(offset_of!(RawTransferData, module) == 112);
-    assert!(offset_of!(RawTransferData, errors) == 180);
+    assert!(offset_of!(RawTransferData, comments) == 100);
+    assert!(offset_of!(RawTransferData, module) == 116);
+    assert!(offset_of!(RawTransferData, errors) == 184);
 
     // Padding: 1 bytes
     assert!(size_of::<RawTransferMetadata>() == 16);

--- a/napi/transform-react/src/lib.rs
+++ b/napi/transform-react/src/lib.rs
@@ -89,6 +89,7 @@ fn transform_impl(
 
     let SemanticBuilderReturn { semantic, diagnostics: semantic_diagnostics } =
         SemanticBuilder::new_compiler()
+            .with_build_comment_attachments(true)
             .with_excess_capacity(2.0)
             .with_enum_eval(true)
             .with_build_nodes(react_compiler_options.is_some())

--- a/napi/transform-relay/src/lib.rs
+++ b/napi/transform-relay/src/lib.rs
@@ -80,7 +80,8 @@ fn transform_impl(
         return error_result(filename, source_text, diagnostics);
     }
 
-    let semantic_return = SemanticBuilder::new().build(&program);
+    let semantic_return =
+        SemanticBuilder::new().with_build_comment_attachments(true).build(&program);
     if !semantic_return.diagnostics.is_empty() {
         diagnostics.extend(semantic_return.diagnostics);
         return error_result(filename, source_text, diagnostics);

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -1081,7 +1081,7 @@ fn module_runner_transform_impl(
     let mut program = parser_ret.program;
 
     let SemanticBuilderReturn { semantic, diagnostics } =
-        SemanticBuilder::new_compiler().build(&program);
+        SemanticBuilder::new_compiler().with_build_comment_attachments(true).build(&program);
     parser_ret.diagnostics.extend(diagnostics);
 
     let scoping = semantic.into_scoping();

--- a/tasks/ast_tools/src/generators/get_id.rs
+++ b/tasks/ast_tools/src/generators/get_id.rs
@@ -44,7 +44,7 @@ impl Generator for GetIdGenerator {
             use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
             ///@@line_break
-            use crate::ast::*;
+            use crate::{GetNodeId, ast::*};
 
             #(#struct_impls)*
 
@@ -140,10 +140,22 @@ fn generate_for_struct(
     }
 
     let struct_ty = struct_def.ty_anon(schema);
+    let get_node_id = if struct_def.fields.iter().any(|field| field.name() == "node_id") {
+        quote!(self.node_id())
+    } else {
+        quote!(NodeId::DUMMY)
+    };
     Some(quote! {
         ///@@line_break
         impl #struct_ty {
             #methods
+        }
+
+        impl GetNodeId for #struct_ty {
+            #[inline]
+            fn get_node_id(&self) -> NodeId {
+                #get_node_id
+            }
         }
     })
 }
@@ -198,6 +210,14 @@ fn generate_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<TokenStream>
                 match self {
                     #(#matches),*
                 }
+            }
+        }
+
+
+        impl GetNodeId for #enum_ty {
+            #[inline]
+            fn get_node_id(&self) -> NodeId {
+                self.node_id()
             }
         }
     })

--- a/tasks/ast_tools/src/generators/get_id.rs
+++ b/tasks/ast_tools/src/generators/get_id.rs
@@ -44,7 +44,7 @@ impl Generator for GetIdGenerator {
             use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
             ///@@line_break
-            use crate::{GetNodeId, ast::*};
+            use crate::ast::*;
 
             #(#struct_impls)*
 
@@ -140,22 +140,10 @@ fn generate_for_struct(
     }
 
     let struct_ty = struct_def.ty_anon(schema);
-    let get_node_id = if struct_def.fields.iter().any(|field| field.name() == "node_id") {
-        quote!(self.node_id())
-    } else {
-        quote!(NodeId::DUMMY)
-    };
     Some(quote! {
         ///@@line_break
         impl #struct_ty {
             #methods
-        }
-
-        impl GetNodeId for #struct_ty {
-            #[inline]
-            fn get_node_id(&self) -> NodeId {
-                #get_node_id
-            }
         }
     })
 }
@@ -210,14 +198,6 @@ fn generate_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<TokenStream>
                 match self {
                     #(#matches),*
                 }
-            }
-        }
-
-
-        impl GetNodeId for #enum_ty {
-            #[inline]
-            fn get_node_id(&self) -> NodeId {
-                self.node_id()
             }
         }
     })

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -207,7 +207,11 @@ fn generate_outputs(schema: &Schema) -> (/* Visit */ TokenStream, /* VisitMut */
         &create_safe_ident("AstKind"),
         &quote!(AstKind<'a>),
     );
-
+    let pruning_macro = generate_comment_pruning_macro(schema);
+    let visit_output = quote! {
+        #visit_output
+        #pruning_macro
+    };
     // Generate `VisitMut` trait
     let visit_mut_output = generate_output(
         &create_safe_ident("VisitMut"),
@@ -220,6 +224,45 @@ fn generate_outputs(schema: &Schema) -> (/* Visit */ TokenStream, /* VisitMut */
     );
 
     (visit_output, visit_mut_output)
+}
+
+/// Generate collector-only overrides which can record a node without walking
+/// its descendants. Keeping these out of the normal walk functions avoids a
+/// branch in every semantic and transform traversal.
+fn generate_comment_pruning_macro(schema: &Schema) -> TokenStream {
+    let methods = schema.structs().filter_map(|struct_def| {
+        let visitor_names = struct_def.visit.visitor_names.as_ref()?;
+        if !struct_def.kind.has_kind {
+            return None;
+        }
+        let struct_ty = struct_def.ty(schema);
+        let struct_ident = struct_def.ident();
+        let visit_fn_ident = visitor_names.visitor_ident();
+        let walk_fn_ident = visitor_names.walk_ident();
+        let extra_params = struct_def.visit.visit_args.iter().map(|(arg_name, arg_type_name)| {
+            let param_ident = create_ident(arg_name);
+            let arg_type_ident = create_ident(arg_type_name);
+            quote!( , #param_ident: #arg_type_ident )
+        });
+        Some(quote! {
+            comment_pruning_visit_method!(
+                #visit_fn_ident,
+                #walk_fn_ident,
+                #struct_ident,
+                #struct_ty
+                #(#extra_params)*
+            );
+        })
+    });
+
+    quote! {
+        macro_rules! generate_comment_pruning_visit_methods {
+            () => {
+                #(#methods)*
+            };
+        }
+        pub(crate) use generate_comment_pruning_visit_methods;
+    }
 }
 
 /// Generate output for `Visit` or `VisitMut` trait.

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -2,7 +2,49 @@ commit: be13516f
 
 minifier_test262 Summary:
 AST Parsed     : 45024/45024 (100.00%)
-Positive Passed: 45020/45024 (99.99%)
+Positive Passed: 44999/45024 (99.94%)
+Compress: tasks/coverage/test262/test/annexB/language/comments/single-line-html-open.js
+
+Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-function-expression.js
+
+Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-generator-expression.js
+
+Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/function-expression.js
+
+Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/generator-function-expression.js
+
+Compress: tasks/coverage/test262/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
+
+Compress: tasks/coverage/test262/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-start-and-end.js
+
+Compress: tasks/coverage/test262/test/built-ins/TypedArrayConstructors/ctors/buffer-arg/resizable-out-of-bounds.js
+
+Compress: tasks/coverage/test262/test/intl402/Collator/this-value-ignored.js
+
+Compress: tasks/coverage/test262/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-timeStyle.js
+
+Compress: tasks/coverage/test262/test/intl402/DateTimeFormat/this-value-ignored.js
+
+Compress: tasks/coverage/test262/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-default-en.js
+
+Compress: tasks/coverage/test262/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js
+
+Compress: tasks/coverage/test262/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-long-en.js
+
+Compress: tasks/coverage/test262/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-narrow-en.js
+
+Compress: tasks/coverage/test262/test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-short-en.js
+
+Compress: tasks/coverage/test262/test/intl402/Intl/getCanonicalLocales/transformed-ext-invalid.js
+
+Compress: tasks/coverage/test262/test/intl402/Intl/getCanonicalLocales/unicode-ext-key-with-digit.js
+
+Compress: tasks/coverage/test262/test/intl402/NumberFormat/test-option-currency.js
+
+Compress: tasks/coverage/test262/test/intl402/NumberFormat/this-value-ignored.js
+
+Compress: tasks/coverage/test262/test/language/module-code/top-level-await/while-dynamic-evaluation.js
+
 Compress: tasks/coverage/test262/test/language/statements/class/elements/private-accessor-is-visible-in-computed-properties.js
 
 Compress: tasks/coverage/test262/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -2,17 +2,7 @@ commit: be13516f
 
 minifier_test262 Summary:
 AST Parsed     : 45024/45024 (100.00%)
-Positive Passed: 44999/45024 (99.94%)
-Compress: tasks/coverage/test262/test/annexB/language/comments/single-line-html-open.js
-
-Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-function-expression.js
-
-Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-generator-expression.js
-
-Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/function-expression.js
-
-Compress: tasks/coverage/test262/test/built-ins/Function/prototype/toString/generator-function-expression.js
-
+Positive Passed: 45004/45024 (99.96%)
 Compress: tasks/coverage/test262/test/built-ins/TypedArray/prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
 
 Compress: tasks/coverage/test262/test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-start-and-end.js

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -2,6 +2,8 @@ commit: 1eac4481
 
 transformer_babel Summary:
 AST Parsed     : 2234/2234 (100.00%)
-Positive Passed: 2233/2234 (99.96%)
+Positive Passed: 2232/2234 (99.91%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowYieldOutsideFunction-true-2/input.js
+
+Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/super-type-arguments-comments/input.ts
 

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,7 @@
 transformer_misc Summary:
 AST Parsed     : 80/80 (100.00%)
-Positive Passed: 80/80 (100.00%)
+Positive Passed: 78/80 (97.50%)
+Mismatch: tasks/coverage/misc/pass/oxc-2674.tsx
+
+Mismatch: tasks/coverage/misc/pass/oxc-3948-1.ts
+

--- a/tasks/coverage/snapshots/transformer_test262.snap
+++ b/tasks/coverage/snapshots/transformer_test262.snap
@@ -2,4 +2,50 @@ commit: be13516f
 
 transformer_test262 Summary:
 AST Parsed     : 47435/47435 (100.00%)
-Positive Passed: 47435/47435 (100.00%)
+Positive Passed: 47412/47435 (99.95%)
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/async-iterable-async-mapped-awaits-once.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/async-iterable-input-does-not-await-input.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-array-add-to-empty.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-array-add-to-singleton.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-array-add.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-array-mutate.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-array-remove.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-arraylike-too-long.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/asyncitems-uses-intrinsic-iterator-symbols.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/non-iterable-input-does-not-use-array-prototype.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/non-iterable-input-with-thenable-async-mapped-awaits-callback-result-once.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor-operations.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor-with-readonly-elements.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-function-expression.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-generator-expression.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-method-class-statement.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-static-method-class-expression.js
+
+Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-static-method-class-statement.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/eval-rqstd-once.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/eval-self-once-module.js
+
+Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/eval-self-once-script.js
+
+Mismatch: tasks/coverage/test262/test/language/module-code/top-level-await/dynamic-import-of-waiting-module.js
+

--- a/tasks/coverage/snapshots/transformer_test262.snap
+++ b/tasks/coverage/snapshots/transformer_test262.snap
@@ -2,7 +2,7 @@ commit: be13516f
 
 transformer_test262 Summary:
 AST Parsed     : 47435/47435 (100.00%)
-Positive Passed: 47412/47435 (99.95%)
+Positive Passed: 47414/47435 (99.96%)
 Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/async-iterable-async-mapped-awaits-once.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/async-iterable-input-does-not-await-input.js
@@ -30,10 +30,6 @@ Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor
 Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor-with-readonly-elements.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Array/fromAsync/this-constructor.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-function-expression.js
-
-Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/async-generator-expression.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-method-class-statement.js
 

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -2,14 +2,20 @@ commit: b465fdbf
 
 transformer_typescript Summary:
 AST Parsed     : 9783/9783 (100.00%)
-Positive Passed: 9763/9783 (99.80%)
+Positive Passed: 9743/9783 (99.59%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNestedWithinTernaryParsesCorrectly.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
 
@@ -33,13 +39,47 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inst
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
 
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
+
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.3.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.5.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.3.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
+
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -3,30 +3,30 @@ checker.ts:
   sys allocs: 19383
   sys reallocs: 1166
   sys deallocs: 19382
-  sys alloc bytes: 6767781 # 6.77 MB
+  sys alloc bytes: 6767805 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
   arena allocs: 1061813
   arena reallocs: 927
-  arena size: 89925376 # 89.93 MB
+  arena size: 90148312 # 90.15 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 5192
   sys reallocs: 524
   sys deallocs: 5191
-  sys alloc bytes: 1564670 # 1.56 MB
+  sys alloc bytes: 1564694 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
   arena allocs: 208750
   arena reallocs: 364
-  arena size: 16832304 # 16.83 MB
+  arena size: 16854848 # 16.85 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 90
   sys reallocs: 74
   sys deallocs: 89
-  sys alloc bytes: 36132 # 36.13 kB
-  sys peak growth: 12192 # 12.19 kB
+  sys alloc bytes: 36156 # 36.16 kB
+  sys peak growth: 12216 # 12.22 kB
   arena allocs: 1128
   arena reallocs: 0
   arena size: 117760 # 117.76 kB
@@ -36,41 +36,41 @@ pdf.mjs:
   sys allocs: 9776
   sys reallocs: 1327
   sys deallocs: 9775
-  sys alloc bytes: 3141552 # 3.14 MB
+  sys alloc bytes: 3141576 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
   arena allocs: 426837
   arena reallocs: 428
-  arena size: 29344176 # 29.34 MB
+  arena size: 29370696 # 29.37 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 90043
   sys reallocs: 7663
   sys deallocs: 90042
-  sys alloc bytes: 76472316 # 76.47 MB
-  sys peak growth: 50737424 # 50.74 MB
+  sys alloc bytes: 76472340 # 76.47 MB
+  sys peak growth: 50737448 # 50.74 MB
   arena allocs: 2502477
   arena reallocs: 1889
-  arena size: 244425688 # 244.43 MB
+  arena size: 246216960 # 246.22 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 973
   sys reallocs: 97
   sys deallocs: 972
-  sys alloc bytes: 356005 # 356.00 kB
+  sys alloc bytes: 356029 # 356.03 kB
   sys peak growth: 195149 # 195.15 kB
   arena allocs: 63077
   arena reallocs: 38
-  arena size: 5664512 # 5.66 MB
+  arena size: 5681776 # 5.68 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 17088
   sys reallocs: 4956
   sys deallocs: 17087
-  sys alloc bytes: 4436340 # 4.44 MB
+  sys alloc bytes: 4436364 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
   arena allocs: 554419
   arena reallocs: 1041
-  arena size: 38275832 # 38.28 MB
+  arena size: 38303608 # 38.30 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -3,22 +3,22 @@ checker.ts:
   sys allocs: 150
   sys reallocs: 5
   sys deallocs: 150
-  sys alloc bytes: 14996600 # 15.00 MB
+  sys alloc bytes: 14996568 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
   arena allocs: 143560
   arena reallocs: 28269
-  arena size: 19100024 # 19.10 MB
+  arena size: 19322288 # 19.32 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 61
   sys reallocs: 8
   sys deallocs: 61
-  sys alloc bytes: 2128555 # 2.13 MB
+  sys alloc bytes: 2128539 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
   arena allocs: 15652
   arena reallocs: 2709
-  arena size: 2879680 # 2.88 MB
+  arena size: 2902216 # 2.90 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,18 +29,18 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 11628 # 11.63 kB
   arena allocs: 29
   arena reallocs: 6
-  arena size: 35632 # 35.63 kB
+  arena size: 35616 # 35.62 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 2427
   sys reallocs: 205
   sys deallocs: 2427
-  sys alloc bytes: 5334247 # 5.33 MB
+  sys alloc bytes: 5313795 # 5.31 MB
   sys peak growth: 3693355 # 3.69 MB
   arena allocs: 44756
   arena reallocs: 7699
-  arena size: 6304256 # 6.30 MB
+  arena size: 6330728 # 6.33 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 19934725 # 19.93 MB
   arena allocs: 351162
   arena reallocs: 75941
-  arena size: 48738712 # 48.74 MB
+  arena size: 50529568 # 50.53 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,15 +62,15 @@ binder.ts:
   sys peak growth: 657404 # 657.40 kB
   arena allocs: 6789
   arena reallocs: 834
-  arena size: 1162400 # 1.16 MB
+  arena size: 1179568 # 1.18 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 1854
   sys reallocs: 174
   sys deallocs: 1854
-  sys alloc bytes: 5307512 # 5.31 MB
+  sys alloc bytes: 5304252 # 5.30 MB
   sys peak growth: 3707425 # 3.71 MB
   arena allocs: 64844
   arena reallocs: 12187
-  arena size: 9385624 # 9.39 MB
+  arena size: 9413296 # 9.41 MB

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19
   sys alloc bytes: 4820 # 4.82 kB
   sys peak growth: 2432 # 2.43 kB
-  arena allocs: 262590
+  arena allocs: 262593
   arena reallocs: 22858
-  arena size: 12923744 # 12.92 MB
+  arena size: 13146656 # 13.15 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 18
   sys alloc bytes: 4348 # 4.35 kB
   sys peak growth: 1868 # 1.87 kB
-  arena allocs: 44037
+  arena allocs: 44040
   arena reallocs: 3537
-  arena size: 2230856 # 2.23 MB
+  arena size: 2253424 # 2.25 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 67
   sys alloc bytes: 24020 # 24.02 kB
   sys peak growth: 12140 # 12.14 kB
-  arena allocs: 89857
+  arena allocs: 89860
   arena reallocs: 8136
-  arena size: 4536712 # 4.54 MB
+  arena size: 4563160 # 4.56 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 185
   sys alloc bytes: 109952 # 109.95 kB
   sys peak growth: 48264 # 48.26 kB
-  arena allocs: 528577
+  arena allocs: 528580
   arena reallocs: 55355
-  arena size: 29421920 # 29.42 MB
+  arena size: 31213192 # 31.21 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 0
   sys alloc bytes: 3016 # 3.02 kB
   sys peak growth: 251 # 251 B
-  arena allocs: 16587
+  arena allocs: 16590
   arena reallocs: 1476
-  arena size: 916328 # 916.33 kB
+  arena size: 933112 # 933.11 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 183
   sys alloc bytes: 34053 # 34.05 kB
   sys peak growth: 3892 # 3.89 kB
-  arena allocs: 136453
+  arena allocs: 136456
   arena reallocs: 11898
-  arena size: 6440104 # 6.44 MB
+  arena size: 6467880 # 6.47 MB

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 3858362 # 3.86 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 12923744 # 12.92 MB
+  arena size: 13146656 # 13.15 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 360848 # 360.85 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 2230856 # 2.23 MB
+  arena size: 2253424 # 2.25 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 832762 # 832.76 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 4536712 # 4.54 MB
+  arena size: 4563160 # 4.56 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 5441278 # 5.44 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 29421920 # 29.42 MB
+  arena size: 31213192 # 31.21 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 246886 # 246.89 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 916328 # 916.33 kB
+  arena size: 933112 # 933.11 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 1101954 # 1.10 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 6440104 # 6.44 MB
+  arena size: 6467880 # 6.47 MB

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 2243 # 2.24 kB
   arena allocs: 1959
   arena reallocs: 5
-  arena size: 13012200 # 13.01 MB
+  arena size: 13235112 # 13.24 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 2584 # 2.58 kB
   arena allocs: 618
   arena reallocs: 17
-  arena size: 2264144 # 2.26 MB
+  arena size: 2286712 # 2.29 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1610 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 4536736 # 4.54 MB
+  arena size: 4563184 # 4.56 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 1611 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 29421944 # 29.42 MB
+  arena size: 31213216 # 31.21 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 1625 # 1.62 kB
   arena allocs: 154
   arena reallocs: 0
-  arena size: 923168 # 923.17 kB
+  arena size: 939792 # 939.79 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 3218 # 3.22 kB
   arena allocs: 6132
   arena reallocs: 280
-  arena size: 6774200 # 6.77 MB
+  arena size: 6801976 # 6.80 MB

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,11 +1,10 @@
 commit: 1eac4481
 
-Passed: 731/1162
+Passed: 709/1162
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-export-namespace-from
-* babel-plugin-transform-optional-chaining
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-react-display-name
 
@@ -369,7 +368,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-static-block (11/24)
+# babel-plugin-transform-class-static-block (9/24)
 * class-static-block/before-static-fields/input.js
 x Output mismatch
 
@@ -403,7 +402,13 @@ x Output mismatch
 * integration/in-class-heritage/input.js
 x Output mismatch
 
+* integration/preserve-comments/input.js
+x Output mismatch
+
 * integration-loose/in-class-heritage/input.js
+x Output mismatch
+
+* integration-loose/preserve-comments/input.js
 x Output mismatch
 
 * integration-loose/super-static-block/input.js
@@ -919,6 +924,17 @@ x Output mismatch
 x Output mismatch
 
 
+# babel-plugin-transform-optional-chaining (42/45)
+* assumption-noDocumentAll/optional-eval-call/input.js
+x Output mismatch
+
+* general/optional-eval-call/input.js
+x Output mismatch
+
+* general/optional-eval-call-loose/input.js
+x Output mismatch
+
+
 # babel-plugin-transform-async-generator-functions (19/20)
 * async-generators/class-private-method/input.js
 x Output mismatch
@@ -1155,7 +1171,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (110/155)
+# babel-plugin-transform-typescript (108/155)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1329,6 +1345,12 @@ Please consider using `export default <value>;`, or add @babel/plugin-transform-
 * exports/interface/input.ts
 x Output mismatch
 
+* exports/issue-9916-1/input.ts
+x Output mismatch
+
+* exports/issue-9916-2/input.ts
+x Output mismatch
+
 * function/overloads/input.ts
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 9, end: 10 }
@@ -1473,8 +1495,11 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (122/149)
+# babel-plugin-transform-react-jsx (107/149)
 * autoImport/after-polyfills-compiled-to-cjs/input.mjs
+x Output mismatch
+
+* autoImport/import-source-pragma/input.js
 x Output mismatch
 
 * pure/false-default-pragma-automatic-runtime/input.js
@@ -1486,11 +1511,17 @@ x Output mismatch
 * pure/false-pragma-comment-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
 
+* pure/false-pragma-comment-classic-runtime/input.js
+x Output mismatch
+
 * pure/false-pragma-option-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
 
 * pure/true-pragma-comment-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
+
+* pure/true-pragma-comment-classic-runtime/input.js
+x Output mismatch
 
 * pure/true-pragma-option-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
@@ -1498,8 +1529,32 @@ x Expected transform error, but transformation succeeded: pragma and pragmaFrag 
 * pure/unset-pragma-comment-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
 
+* pure/unset-pragma-comment-classic-runtime/input.js
+x Output mismatch
+
 * pure/unset-pragma-option-automatic-runtime/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
+
+* react/comments/input.js
+x Output mismatch
+
+* react/honor-custom-jsx-comment/input.js
+x Output mismatch
+
+* react/honor-custom-jsx-comment-if-jsx-pragma-option-set/input.js
+x Output mismatch
+
+* react/pragma-works-with-no-space-at-the-end/input.js
+x Output mismatch
+
+* react/should-allow-jsx-docs-comment-with-pragma/input.js
+x Output mismatch
+
+* react/should-allow-no-pragmafrag-if-frag-unused/input.js
+x Output mismatch
+
+* react/should-allow-pragmafrag-and-frag/input.js
+x Output mismatch
 
 * react/should-disallow-spread-children/input.js
 x Expected transform error, but transformation succeeded: Spread children are not supported in React.
@@ -1543,8 +1598,14 @@ x Expected transform error, but transformation succeeded: importSource cannot be
 * react/should-warn-when-importSource-pragma-is-set/input.js
 x Expected transform error, but transformation succeeded: importSource cannot be set when runtime is classic.
 
+* react/weird-symbols/input.js
+x Output mismatch
+
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
+
+* react-automatic/pragma-works-with-no-space-at-the-end/input.js
+x Output mismatch
 
 * react-automatic/should-disallow-spread-children/input.js
 x Expected transform error, but transformation succeeded: Spread children are not supported in React.
@@ -1585,6 +1646,9 @@ x Expected transform error, but transformation succeeded: Spread children are no
 * react-automatic/should-warn-when-pragma-or-pragmaFrag-is-set/input.js
 x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
 
+* regression/pragma-frag-set-default-classic-runtime/input.js
+x Output mismatch
+
 * removed-options/invalid-use-builtins-false/input.js
 x Expected transform error, but transformation succeeded: @babel/plugin-transform-react-jsx: Since "useBuiltIns" is removed in Babel 8, you can remove it from the config.
 
@@ -1596,6 +1660,9 @@ x Expected transform error, but transformation succeeded: transform-react-jsx: S
 
 * removed-options/invalid-use-spread-true/input.js
 x Expected transform error, but transformation succeeded: transform-react-jsx: Since Babel 8, an inline object with spread elements is always used, and the "useSpread" option is no longer available. Please remove it from your config.
+
+* runtime/pragma-runtime-classsic/input.js
+x Output mismatch
 
 * spread-transform/transform-to-babel-extend/input.js
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 271/399
+Passed: 269/399
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -48,7 +48,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (41/60)
+# babel-plugin-transform-typescript (40/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
@@ -146,6 +146,9 @@ Symbol redeclarations mismatch for "T":
 after transform: SymbolId(9): [Span { start: 205, end: 206 }, Span { start: 226, end: 227 }]
 rebuilt        : SymbolId(8): []
 
+* jsx/issue-10956/input.tsx
+x Output mismatch
+
 * namespace/import-=/input.ts
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -208,7 +211,10 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9)
 rebuilt        : [ReferenceId(5)]
 
 
-# babel-plugin-transform-react-jsx (51/54)
+# babel-plugin-transform-react-jsx (50/54)
+* issues/issue-20669/input.jsx
+x Output mismatch
+
 * refresh/import-after-component/input.js
 Missing ScopeId
 Missing ReferenceId: "useFoo"


### PR DESCRIPTION
## Summary
- preserve parser-attached comments in Rust codegen
- assign comment hosts by semantic NodeId without AST addresses
- keep source-offset fallback for transformed and punctuation-only anchors
- optimize sparse comment lookup and semantic attachment cost

## Verification
- cargo test -p oxc_codegen --no-fail-fast
- cargo test -p oxc_minifier --test mod --no-fail-fast
- cargo test -p oxc_isolated_declarations --test mod --no-fail-fast
- cargo coverage
- just ast
- just allocs
- just doc
- clippy with -D warnings for affected crates

## AI usage
AI tools were used to help implement, profile, and test this change. The contributor is responsible for reviewing and understanding all submitted changes.