### PR TITLE
test(formatter,formatter_css,formatter_json,formatter_yaml): restore coverage lost in fixture consolidation

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -82,6 +82,13 @@ NOTE: Rust written formatters never fall back to Prettier, since they exist to r
 
 Known divergences live in DIVERGENCES.md (embedding / dispatch layer only; single-language ones live in the owning crate's DIVERGENCES.md).
 
+- Pin convention: a minimal repro lives in `conformance/fixtures/edge-cases/`
+  any external fixture containing the same diff carries the same NOTE in `conformance/run.ts`;
+  the duplication is deliberate, not a consolidation target
+- All current entries are embedding-layer decisions that outlive the Prettier delegation;
+  if an entry about the Prettier-fallback boundary itself is ever added, group it under a
+  separate heading in DIVERGENCES.md so the removal scope stays obvious when the fallback goes away
+
 ### Embedded language formatting
 
 Embedded languages (e.g. css-in-js, CSS front matter YAML) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.

--- a/apps/oxfmt/DIVERGENCES.md
+++ b/apps/oxfmt/DIVERGENCES.md
@@ -2,14 +2,6 @@
 
 Admission reasons and rules: see `crates/oxc_formatter_core/FORMATTER_POLICY.md` "Known divergences".
 
-This catalog holds only divergences OWNED by the oxfmt layer (embedding / dispatch behavior).
-
-Pin convention: a minimal repro lives in `conformance/fixtures/edge-cases/`,
-and any external fixture containing the same diff carries the same NOTE in `conformance/run.ts`.
-The duplication is deliberate, not a consolidation target.
-All current entries are embedding-layer decisions that outlive the Prettier delegation;
-if an entry about the Prettier-fallback boundary itself is ever added, group it under a separate heading so the removal scope stays obvious when the fallback goes away.
-
 ## template-expression-indent
 
 - Why: prettier-bug (prettier/prettier#19725)

--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -1,7 +1,7 @@
 # Coding agent guides for `crates/oxc_formatter`
 
 Follow @../oxc_formatter_core/FORMATTER_POLICY.md , this file holds only the JS/TS-specific rules and translations.
-Known divergences live in DIVERGENCES.md.
+Known divergences live in DIVERGENCES.md (not yet an exhaustive audit against the conformance snapshots).
 
 ## Overview
 

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -1,7 +1,6 @@
 # Known divergences
 
 Admission reasons and rules: see `crates/oxc_formatter_core/FORMATTER_POLICY.md` "Known divergences".
-The entries documented so far are not yet an exhaustive audit against the conformance snapshots.
 
 ## array-hole-trailing-comment
 
@@ -242,6 +241,7 @@ assigned = a = c /* c1 */;
 
 - Why: prettier-bug (attachment artifacts of the class Prettier is fixing elsewhere: the prettier#19894 family, open prettier#12880 / prettier#7745 / prettier#5900)
 - Pin: see the per-shape list below
+- Drop when: the family fixes cover these shapes and the pin catches up
 
 The head-body comment policy family (see AGENTS.md "Comment placement invariants"): comments between a head and its body keep their position, where Prettier's attachment relocates them.
 

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -162,8 +162,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Directive<
             return;
         };
 
-        // if next_sibling's first leading_trivia has more than one new_line, we should add an extra empty line at the end of
-        // the last directive, for example:
+        // if next_sibling's first leading_trivia has more than one new_line,
+        // we should add an extra empty line at the end of the last directive, for example:
         //```js
         // "use strict"; <- first leading new_line
         //  			 <- second leading new_line
@@ -175,6 +175,9 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Directive<
 
         // If the last directive has a trailing comment, `lines_after` stops at the first
         // non-whitespace character (`/`) and returns 0 before counting any newlines.
+        // Only the LAST directive is checked here
+        // (between-directive blanks go through `get_lines_before`, which is not subject to this hazard);
+        // the per-comment-kind pins live in `tests/fixtures/js/directives/issue-21152*.js`, one file each.
         let check_pos = f
             .context()
             .comments()

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js
@@ -1,7 +1,7 @@
 var longlonglonglonglonglong = /*#__PURE__*/_interopDefaultLegacy(aaaaaaaaaaaaaaa);
 var short = /*#__PURE__*/_interopDefaultLegacy(b);
 
-// issue #19436: comments before call expressions must be preserved
+// issue #19436: comments before call expressions (incl. @__PURE__) must be preserved
 const r = /* THIS */ f()
 export const globalRegistry = /*@__PURE__*/ registry();
 

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js.snap
@@ -5,7 +5,7 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 var longlonglonglonglonglong = /*#__PURE__*/_interopDefaultLegacy(aaaaaaaaaaaaaaa);
 var short = /*#__PURE__*/_interopDefaultLegacy(b);
 
-// issue #19436: comments before call expressions must be preserved
+// issue #19436: comments before call expressions (incl. @__PURE__) must be preserved
 const r = /* THIS */ f()
 export const globalRegistry = /*@__PURE__*/ registry();
 
@@ -36,7 +36,7 @@ var longlonglonglonglonglong =
   /*#__PURE__*/ _interopDefaultLegacy(aaaaaaaaaaaaaaa);
 var short = /*#__PURE__*/ _interopDefaultLegacy(b);
 
-// issue #19436: comments before call expressions must be preserved
+// issue #19436: comments before call expressions (incl. @__PURE__) must be preserved
 const r = /* THIS */ f();
 export const globalRegistry = /*@__PURE__*/ registry();
 
@@ -65,7 +65,7 @@ class A {
 var longlonglonglonglonglong = /*#__PURE__*/ _interopDefaultLegacy(aaaaaaaaaaaaaaa);
 var short = /*#__PURE__*/ _interopDefaultLegacy(b);
 
-// issue #19436: comments before call expressions must be preserved
+// issue #19436: comments before call expressions (incl. @__PURE__) must be preserved
 const r = /* THIS */ f();
 export const globalRegistry = /*@__PURE__*/ registry();
 

--- a/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js
@@ -14,6 +14,7 @@ try
 
 try {} catch (e) /* c */ {}
 try {} catch (/* before */ err /* after */) {}
+try {} catch (/* before */ err /* after */) /* c */ {}
 try {} catch (e) // c
 {}
 try {} catch (e)

--- a/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js.snap
@@ -18,6 +18,7 @@ try
 
 try {} catch (e) /* c */ {}
 try {} catch (/* before */ err /* after */) {}
+try {} catch (/* before */ err /* after */) /* c */ {}
 try {} catch (e) // c
 {}
 try {} catch (e)
@@ -79,6 +80,8 @@ try {
 } catch (e) /* c */ {}
 try {
 } catch (/* before */ err /* after */) {}
+try {
+} catch (/* before */ err /* after */) /* c */ {}
 try {
 } catch (e) // c
 {}
@@ -162,6 +165,8 @@ try {
 } catch (e) /* c */ {}
 try {
 } catch (/* before */ err /* after */) {}
+try {
+} catch (/* before */ err /* after */) /* c */ {}
 try {
 } catch (e) // c
 {}

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment-multiline.js
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment-multiline.js
@@ -1,0 +1,7 @@
+// Issue #21152 sibling: multiline block comment (see issue-21152.js)
+"use client"; /* multi
+line
+comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment-multiline.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment-multiline.js.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #21152 sibling: multiline block comment (see issue-21152.js)
+"use client"; /* multi
+line
+comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #21152 sibling: multiline block comment (see issue-21152.js)
+"use client"; /* multi
+line
+comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #21152 sibling: multiline block comment (see issue-21152.js)
+"use client"; /* multi
+line
+comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment.js
@@ -1,0 +1,5 @@
+// Issue #21152 sibling: single-line block comment (see issue-21152.js)
+"use client"; /* single line block comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152-block-comment.js.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #21152 sibling: single-line block comment (see issue-21152.js)
+"use client"; /* single line block comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #21152 sibling: single-line block comment (see issue-21152.js)
+"use client"; /* single line block comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #21152 sibling: single-line block comment (see issue-21152.js)
+"use client"; /* single line block comment */
+
+import { Foo } from "foo";
+import { Bar } from "bar";
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152.js
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152.js
@@ -1,14 +1,6 @@
-// Issue #21152 - the blank line after a directive is preserved even when a
-// trailing comment sits between the directive and the blank line
-// (lines_after must count past the comment). One prologue directive per
-// comment token type, each followed by the load-bearing blank line.
+// Issue #21152 - the blank line after the LAST directive survives a trailing comment;
+// `end_of_line_comments_after` covers the last directive only, so one file per comment kind.
 "use client"; // browser only
-
-"use strict"; /* single line block comment */
-
-"use asm"; /* multi
-line
-comment */
 
 import { Foo } from "foo";
 import { Bar } from "bar";

--- a/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/directives/issue-21152.js.snap
@@ -2,17 +2,9 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// Issue #21152 - the blank line after a directive is preserved even when a
-// trailing comment sits between the directive and the blank line
-// (lines_after must count past the comment). One prologue directive per
-// comment token type, each followed by the load-bearing blank line.
+// Issue #21152 - the blank line after the LAST directive survives a trailing comment;
+// `end_of_line_comments_after` covers the last directive only, so one file per comment kind.
 "use client"; // browser only
-
-"use strict"; /* single line block comment */
-
-"use asm"; /* multi
-line
-comment */
 
 import { Foo } from "foo";
 import { Bar } from "bar";
@@ -21,17 +13,9 @@ import { Bar } from "bar";
 ------------------
 { printWidth: 80 }
 ------------------
-// Issue #21152 - the blank line after a directive is preserved even when a
-// trailing comment sits between the directive and the blank line
-// (lines_after must count past the comment). One prologue directive per
-// comment token type, each followed by the load-bearing blank line.
+// Issue #21152 - the blank line after the LAST directive survives a trailing comment;
+// `end_of_line_comments_after` covers the last directive only, so one file per comment kind.
 "use client"; // browser only
-
-"use strict"; /* single line block comment */
-
-"use asm"; /* multi
-line
-comment */
 
 import { Foo } from "foo";
 import { Bar } from "bar";
@@ -39,17 +23,9 @@ import { Bar } from "bar";
 -------------------
 { printWidth: 100 }
 -------------------
-// Issue #21152 - the blank line after a directive is preserved even when a
-// trailing comment sits between the directive and the blank line
-// (lines_after must count past the comment). One prologue directive per
-// comment token type, each followed by the load-bearing blank line.
+// Issue #21152 - the blank line after the LAST directive survives a trailing comment;
+// `end_of_line_comments_after` covers the last directive only, so one file per comment kind.
 "use client"; // browser only
-
-"use strict"; /* single line block comment */
-
-"use asm"; /* multi
-line
-comment */
 
 import { Foo } from "foo";
 import { Bar } from "bar";

--- a/crates/oxc_formatter/tests/fixtures/ts/parameters/object-pattern.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parameters/object-pattern.ts
@@ -20,6 +20,12 @@ function callbackUrl(
   }
 ) { }
 
+// Single hugged pattern: a source-inline type literal stays flat (contrast: useCopyToClipboard above)
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {
+}
+
 function parseTitle(
   item: PageObjectResponse | DatabaseObjectResponse,
   {

--- a/crates/oxc_formatter/tests/fixtures/ts/parameters/object-pattern.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parameters/object-pattern.ts.snap
@@ -24,6 +24,12 @@ function callbackUrl(
   }
 ) { }
 
+// Single hugged pattern: a source-inline type literal stays flat (contrast: useCopyToClipboard above)
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {
+}
+
 function parseTitle(
   item: PageObjectResponse | DatabaseObjectResponse,
   {
@@ -63,6 +69,11 @@ function callbackUrl(
   },
 ) {}
 
+// Single hugged pattern: a source-inline type literal stays flat (contrast: useCopyToClipboard above)
+export default function useTagsCount({
+  query,
+}: { query?: Record<any, any> } = {}) {}
+
 function parseTitle(
   item: PageObjectResponse | DatabaseObjectResponse,
   {
@@ -100,6 +111,9 @@ function callbackUrl(
     params: undefined,
   },
 ) {}
+
+// Single hugged pattern: a source-inline type literal stays flat (contrast: useCopyToClipboard above)
+export default function useTagsCount({ query }: { query?: Record<any, any> } = {}) {}
 
 function parseTitle(
   item: PageObjectResponse | DatabaseObjectResponse,

--- a/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts
@@ -38,3 +38,12 @@ type MultilineBlock =
 // moving it behind would force a break between the `|` and its member.
 type LineEnd = /* c */
   A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// The same kept-before-`|` rule when the union actually BREAKS
+// (the leading `|` is printed and the comment group stays above it):
+type LineEndBreak = | (
+  /* c1 */ /* c2 */
+  | A
+  // force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+);

--- a/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts.snap
@@ -43,6 +43,15 @@ type MultilineBlock =
 type LineEnd = /* c */
   A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
 
+// The same kept-before-`|` rule when the union actually BREAKS
+// (the leading `|` is printed and the comment group stays above it):
+type LineEndBreak = | (
+  /* c1 */ /* c2 */
+  | A
+  // force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+);
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -88,6 +97,14 @@ type LineEnd =
   /* c */
   A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
 
+// The same kept-before-`|` rule when the union actually BREAKS
+// (the leading `|` is printed and the comment group stays above it):
+type LineEndBreak =
+  /* c1 */ /* c2 */
+  | A
+  // force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -121,5 +138,13 @@ type MultilineBlock =
 // A comment that ENDS its source line stays before the `|`:
 // moving it behind would force a break between the `|` and its member.
 type LineEnd = /* c */ A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// The same kept-before-`|` rule when the union actually BREAKS
+// (the leading `|` is printed and the comment group stays above it):
+type LineEndBreak =
+  /* c1 */ /* c2 */
+  | A
+  // force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
 
 ===================== End =====================

--- a/crates/oxc_formatter_core/FORMATTER_POLICY.md
+++ b/crates/oxc_formatter_core/FORMATTER_POLICY.md
@@ -67,7 +67,10 @@ Choosing the reason:
 
 Rules:
 
-- Every divergence is documented in the owning layer's `DIVERGENCES.md` (entry template below) and pinned by a fixture whose comments say which lines deviate from Prettier and why
+- Every divergence is documented in the owning layer's `DIVERGENCES.md` and pinned by a fixture whose comments say which lines deviate from Prettier and why
+  - Entry format: an H2 slug (the stable anchor external pointers use), required `Why:` (admission reason keyword + upstream issue if any) and `Pin:` lines, `Drop when:` only when a convergence condition exists; an input/ours/prettier example is the body, written with OUR behavior as the spec
+  - `prettier-bug` entries drop by default when the upstream fix reaches the pin (that is what made them (2)); write `Drop when:` only when the condition is more specific than that default
+  - No status, dates, or authors: listed = accepted, condition met = delete (git holds history)
   - The owning layer is where the behavior is decided: a language crate for single-language behavior, `apps/oxfmt` for embedding E2E behavior
   - A divergence discovered through a real-world conformance case (oxfmt externals, Prettier suite) is pinned by DISTILLING a minimal fixture into the owning layer's `tests/fixtures/`; the big source file stays in conformance as a regression net, never as the pin
   - `DIVERGENCES.md` holds entries only, opening with one back-reference line to this section; `AGENTS.md` keeps policy translations and mechanism prose;

--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -301,7 +301,6 @@ verbatim. This is the policy's own reason-3 example.
 
 - Why: prettier-bug (prettier/prettier#19427)
 - Pin: `tests/fixtures/format/scss/inline-comment-before-call.scss`
-- Drop when: prettier#19427 is fixed and the pin catches up
 
 ```scss
 /* input */
@@ -552,6 +551,7 @@ intended consumer was the dropped CSS Apply Rule proposal, so the cross-mode dif
 
 - Why: prettier-bug (prettier#19550 fixed only the indentation)
 - Pin: `tests/fixtures/format/less/extend-rule.less`
+- Drop when: the selector-list leak is fully fixed and the pin catches up
 
 ```less
 /* input */
@@ -641,25 +641,28 @@ SEPARATOR instead. Layout-only. The principled fix is the shared core-fill fit-c
 ## less-value-interpolation-rejected
 
 - Why: uniform-rule
-- Pin: MISSING (parser-level: the input never reaches the formatter)
+- Pin: `tests/fixtures/mod.rs::parse_error_is_err` (parser-level: the rejection is asserted directly)
 
-Value-position `@{var}` interpolation: `oxc-css-parser` rejects it matching `lessc`; Prettier (postcss)
-accepts and prints verbatim. Per the shared error semantics, we never format what the reference compiler
-rejects (a parse error is the SAFE failure).
+```less
+/* input */
+.a { width: @{min-width}; }
 
-## less-lookup-whitespace-rejected
+/* ours: parse error, the input is left as-is */
 
-- Why: uniform-rule
-- Pin: MISSING (parser-level: the input never reaches the formatter)
+/* prettier */
+.a {
+  width: @{min-width};
+}
+```
 
-Lookup with whitespace inside (`@config   [   option1]`): `oxc-css-parser` rejects it matching `lessc`;
-Prettier accepts. Same rule as `less-value-interpolation-rejected`.
+Value-position `@{var}` interpolation: `oxc-css-parser` rejects it matching `lessc`;
+Prettier (postcss) accepts and prints verbatim. Per the shared error semantics,
+we never format what the reference compiler rejects (a parse error is the SAFE failure).
 
 ## media-query-operator-spacing
 
 - Why: prettier-bug (prettier/prettier#1811)
 - Pin: `tests/fixtures/format/scss/media-query-operator-spacing.scss` (also tracked by oxfmt's externals suite, e.g. gitlab `framework/diffs.scss`)
-- Drop when: prettier#1811 is fixed and the pin catches up
 
 ```scss
 /* input */

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-number.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-number.css
@@ -12,3 +12,9 @@ b {
 c {
   width: theme(spacing.2.5);
 }
+/* glued number-ish runs are one word too: no space injection (`is_word_glued_number`) */
+d {
+  padding: 1+1+1+1;
+  margin: 1px+1px+1px+1px;
+  width: calc(100%+2px);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-number.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/word-glued-number.css.snap
@@ -16,6 +16,12 @@ b {
 c {
   width: theme(spacing.2.5);
 }
+/* glued number-ish runs are one word too: no space injection (`is_word_glued_number`) */
+d {
+  padding: 1+1+1+1;
+  margin: 1px+1px+1px+1px;
+  width: calc(100%+2px);
+}
 
 ==================== Output ====================
 ------------------
@@ -35,6 +41,12 @@ b {
 c {
   width: theme(spacing.2.5);
 }
+/* glued number-ish runs are one word too: no space injection (`is_word_glued_number`) */
+d {
+  padding: 1+1+1+1;
+  margin: 1px+1px+1px+1px;
+  width: calc(100%+2px);
+}
 
 -------------------
 { printWidth: 100 }
@@ -52,6 +64,12 @@ b {
 /* glued number chains stay words too */
 c {
   width: theme(spacing.2.5);
+}
+/* glued number-ish runs are one word too: no space injection (`is_word_glued_number`) */
+d {
+  padding: 1+1+1+1;
+  margin: 1px+1px+1px+1px;
+  width: calc(100%+2px);
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/guards.less
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/guards.less
@@ -29,4 +29,6 @@
 }
 .box {
   .mixin();
+  // whitespace inside a lookup collapses (matching Prettier)
+  v: @config   [   option2];
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/guards.less.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/guards.less.snap
@@ -33,6 +33,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 }
 .box {
   .mixin();
+  // whitespace inside a lookup collapses (matching Prettier)
+  v: @config   [   option2];
 }
 
 ==================== Output ====================
@@ -70,6 +72,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 }
 .box {
   .mixin();
+  // whitespace inside a lookup collapses (matching Prettier)
+  v: @config[option2];
 }
 
 -------------------
@@ -106,6 +110,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 }
 .box {
   .mixin();
+  // whitespace inside a lookup collapses (matching Prettier)
+  v: @config[option2];
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/import-preludes.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/import-preludes.scss
@@ -1,4 +1,5 @@
-// `@import` preludes: comma lists and interpolated paths re-quote per `singleQuote`
+// `@import` preludes: comma lists and interpolated paths normalize to the
+// preferred quote (default `"`; the interpolation content stays verbatim)
 @import "rounded-corners", "text-shadow";
 @import 'rounded-corners', 'text-shadow';
 @import 'foo/#{$theme}.scss';

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/import-preludes.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/import-preludes.scss.snap
@@ -2,7 +2,8 @@
 source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// `@import` preludes: comma lists and interpolated paths re-quote per `singleQuote`
+// `@import` preludes: comma lists and interpolated paths normalize to the
+// preferred quote (default `"`; the interpolation content stays verbatim)
 @import "rounded-corners", "text-shadow";
 @import 'rounded-corners', 'text-shadow';
 @import 'foo/#{$theme}.scss';
@@ -12,7 +13,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ------------------
 { printWidth: 80 }
 ------------------
-// `@import` preludes: comma lists and interpolated paths re-quote per `singleQuote`
+// `@import` preludes: comma lists and interpolated paths normalize to the
+// preferred quote (default `"`; the interpolation content stays verbatim)
 @import "rounded-corners", "text-shadow";
 @import "rounded-corners", "text-shadow";
 @import "foo/#{$theme}.scss";
@@ -21,7 +23,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 -------------------
 { printWidth: 100 }
 -------------------
-// `@import` preludes: comma lists and interpolated paths re-quote per `singleQuote`
+// `@import` preludes: comma lists and interpolated paths normalize to the
+// preferred quote (default `"`; the interpolation content stays verbatim)
 @import "rounded-corners", "text-shadow";
 @import "rounded-corners", "text-shadow";
 @import "foo/#{$theme}.scss";

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/layout-major-diffs.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/layout-major-diffs.scss
@@ -1,7 +1,7 @@
 /* Regression set from the 2026-06-12 ecosystem-CI run (monkeytype / lila /
    mastodon shapes): grid values never re-wrap, @import paths fill, calc is a
    flat operator fill, media feature values never break, interpolated calls
-   get the chunk-isolated fit + double indent, @warn/@error stay raw. */
+   get the chunk-isolated fit + double indent, @error stays raw. */
 #app {
   grid-template-rows: [top-start] auto [content-start] 1fr [content-end] auto [top-end];
   grid-template-columns: 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1rem;

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/layout-major-diffs.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/layout-major-diffs.scss.snap
@@ -5,7 +5,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 /* Regression set from the 2026-06-12 ecosystem-CI run (monkeytype / lila /
    mastodon shapes): grid values never re-wrap, @import paths fill, calc is a
    flat operator fill, media feature values never break, interpolated calls
-   get the chunk-isolated fit + double indent, @warn/@error stay raw. */
+   get the chunk-isolated fit + double indent, @error stays raw. */
 #app {
   grid-template-rows: [top-start] auto [content-start] 1fr [content-end] auto [top-end];
   grid-template-columns: 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1rem;
@@ -47,7 +47,7 @@ a {
 /* Regression set from the 2026-06-12 ecosystem-CI run (monkeytype / lila /
    mastodon shapes): grid values never re-wrap, @import paths fill, calc is a
    flat operator fill, media feature values never break, interpolated calls
-   get the chunk-isolated fit + double indent, @warn/@error stay raw. */
+   get the chunk-isolated fit + double indent, @error stays raw. */
 #app {
   grid-template-rows: [top-start] auto [content-start] 1fr [content-end] auto [top-end];
   grid-template-columns: 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1rem;
@@ -105,7 +105,7 @@ a {
 /* Regression set from the 2026-06-12 ecosystem-CI run (monkeytype / lila /
    mastodon shapes): grid values never re-wrap, @import paths fill, calc is a
    flat operator fill, media feature values never break, interpolated calls
-   get the chunk-isolated fit + double indent, @warn/@error stay raw. */
+   get the chunk-isolated fit + double indent, @error stays raw. */
 #app {
   grid-template-rows: [top-start] auto [content-start] 1fr [content-end] auto [top-end];
   grid-template-columns: 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1rem;

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -129,6 +129,7 @@ fn parse_error_is_err() {
     let allocator = Allocator::default();
     let css = CssFormatOptions::default();
     let scss = CssFormatOptions { variant: CssVariant::Scss, ..css };
+    let less = CssFormatOptions { variant: CssVariant::Less, ..css };
     for (source, options) in [
         // Top-level declaration: valid only as an embedded css-in-js fragment
         // (`format_to_ir`); standalone files must reject it like Dart Sass does.
@@ -153,6 +154,8 @@ fn parse_error_is_err() {
         // `2N-1` with a glued minus is invalid An+B for oxc-css-parser
         // (postcss-selector-parser accepts and lowercases it).
         ("a:nth-child(2N-1) { color: red; }", css),
+        // Pin for crates/oxc_formatter_css/DIVERGENCES.md#less-value-interpolation-rejected
+        (".a { width: @{min-width}; }", less),
     ] {
         assert!(format(&allocator, source, options).is_err(), "{source:?} should fail to format");
     }

--- a/crates/oxc_formatter_graphql/DIVERGENCES.md
+++ b/crates/oxc_formatter_graphql/DIVERGENCES.md
@@ -2,8 +2,6 @@
 
 Admission reasons and rules: see `crates/oxc_formatter_core/FORMATTER_POLICY.md` "Known divergences".
 
-All current entries are one class: Prettier relocates a comment (an attachment artifact of `graphql-js` node boundaries, not a layout rule), we keep it between its source tokens on its source line.
-
 ## comment-after-keyword
 
 - Why: prettier-bug (attachment artifact)

--- a/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_array_block.jsonc
+++ b/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_array_block.jsonc
@@ -1,0 +1,2 @@
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]

--- a/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_array_block.jsonc.snap
+++ b/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_array_block.jsonc.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter_json/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]
+
+==================== Output ====================
+------------------------------------
+{ printWidth: 80, variant: "jsonc" }
+------------------------------------
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]
+
+-------------------------------------
+{ printWidth: 100, variant: "jsonc" }
+-------------------------------------
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]
+
+-----------------------------------------------------------
+{ printWidth: 80, trailingComma: "none", variant: "jsonc" }
+-----------------------------------------------------------
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]
+
+------------------------------------------------------------
+{ printWidth: 100, trailingComma: "none", variant: "jsonc" }
+------------------------------------------------------------
+// last element block comment stays inline; run under the jsonc option sets (trailingComma both ways)
+[1, 2 /* block */]
+
+===================== End =====================

--- a/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_prop_line.jsonc
+++ b/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_prop_line.jsonc
@@ -1,4 +1,5 @@
 {
   "a": 1,
-  "b": 2 // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"] // long comment keeps the line > 80, the value stays inline
 }

--- a/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_prop_line.jsonc.snap
+++ b/crates/oxc_formatter_json/tests/fixtures/jsonc/comment_last_prop_line.jsonc.snap
@@ -4,7 +4,8 @@ source: crates/oxc_formatter_json/tests/fixtures/mod.rs
 ==================== Input ====================
 {
   "a": 1,
-  "b": 2 // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"] // long comment keeps the line > 80, the value stays inline
 }
 
 ==================== Output ====================
@@ -13,7 +14,8 @@ source: crates/oxc_formatter_json/tests/fixtures/mod.rs
 ------------------------------------
 {
   "a": 1,
-  "b": 2, // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"], // long comment keeps the line > 80, the value stays inline
 }
 
 -------------------------------------
@@ -21,7 +23,8 @@ source: crates/oxc_formatter_json/tests/fixtures/mod.rs
 -------------------------------------
 {
   "a": 1,
-  "b": 2, // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"], // long comment keeps the line > 80, the value stays inline
 }
 
 -----------------------------------------------------------
@@ -29,7 +32,8 @@ source: crates/oxc_formatter_json/tests/fixtures/mod.rs
 -----------------------------------------------------------
 {
   "a": 1,
-  "b": 2 // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"] // long comment keeps the line > 80, the value stays inline
 }
 
 ------------------------------------------------------------
@@ -37,7 +41,8 @@ source: crates/oxc_formatter_json/tests/fixtures/mod.rs
 ------------------------------------------------------------
 {
   "a": 1,
-  "b": 2 // trailing line comment on last prop
+  "b": 2, // trailing line comment on a middle prop
+  "entry": ["dev.config.mjs", "src/*.js"] // long comment keeps the line > 80, the value stays inline
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter_tests/src/harness.rs
+++ b/crates/oxc_formatter_tests/src/harness.rs
@@ -137,6 +137,30 @@ pub fn format_options_display(json: &OptionSet) -> String {
     format!("{{ {} }}", parts.join(", "))
 }
 
+/// Snapshot-body invariant: the configured `endOfLine` is applied to every output line break.
+/// The snapshot itself cannot pin this
+/// (insta normalizes line endings when storing, and `.gitattributes eol=crlf` re-normalizes the `crlf/` fixtures on checkout),
+/// so assert it before the output is embedded.
+/// This doubles as the per-crate `endOfLine` option-plumbing check;
+/// the conversion itself is pinned by `it_converts_line_endings` in `oxc_formatter_core`
+/// (and the builders' debug_asserts keep raw `\r` out of `Text`/`Token`, so a stray `\r` can only come from the printer).
+fn assert_line_ending_applied(option_json: &OptionSet, formatted: &str, path: &Path) {
+    let Some(eol) = option_json.get("endOfLine").and_then(serde_json::Value::as_str) else {
+        return;
+    };
+    let bytes = formatted.as_bytes();
+    let ok = match eol {
+        "crlf" => bytes.iter().enumerate().all(|(i, &b)| match b {
+            b'\n' => i > 0 && bytes[i - 1] == b'\r',
+            b'\r' => bytes.get(i + 1) == Some(&b'\n'),
+            _ => true,
+        }),
+        "cr" => !bytes.contains(&b'\n'),
+        _ => !bytes.contains(&b'\r'),
+    };
+    assert!(ok, "endOfLine: {eol:?} not applied to every line break in {}", path.display());
+}
+
 /// Generates the canonical snapshot body for `path`/`source_text`.
 ///
 /// For each resolved option-set, exercises Prettier's default (`printWidth: 80`) and
@@ -201,6 +225,7 @@ fn generate_snapshot<F: FixtureFormatter>(path: &Path, source_text: &str) -> Str
 
         let options = F::parse_options(&option_json);
         let formatted = F::format(source_text, path, &options);
+        assert_line_ending_applied(&option_json, &formatted, path);
 
         snapshot.push_str(&formatted);
         snapshot.push('\n');
@@ -210,6 +235,7 @@ fn generate_snapshot<F: FixtureFormatter>(path: &Path, source_text: &str) -> Str
         // so known non-idempotent fixtures stay visible in their own snapshots
         // (and fixing one shows up as this section disappearing).
         let reformatted = F::format(&formatted, path, &options);
+        assert_line_ending_applied(&option_json, &reformatted, path);
         if reformatted != formatted {
             snapshot.push_str("---------- Not idempotent (second pass) ----------\n");
             snapshot.push_str(&reformatted);

--- a/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::LineEnding;
 use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
 use oxc_formatter_yaml::{YamlFormatOptions, format};
 
@@ -59,23 +58,6 @@ fn parse_error_is_err() {
             "{source:?} should fail to format"
         );
     }
-}
-
-/// The configured `end_of_line` is applied to EVERY output line break,
-/// including the blank-line runs emitted as raw `"\n"` text (block scalars,
-/// flow scalars) — the snapshot harness cannot pin this (insta normalizes
-/// line endings), so assert it directly.
-#[test]
-fn line_ending_is_applied() {
-    let allocator = Allocator::default();
-    let options =
-        YamlFormatOptions { line_ending: LineEnding::Crlf, ..YamlFormatOptions::default() };
-    let formatted = format(&allocator, "a: 1\nblock: |\n  x\n\n  y\nb: 2\n", options)
-        .expect("input should parse")
-        .print()
-        .expect("print should succeed")
-        .into_code();
-    assert_eq!(formatted, "a: 1\r\nblock: |\r\n  x\r\n\r\n  y\r\nb: 2\r\n");
 }
 
 /// A leading BOM is preserved (Prettier does the same).

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/basic.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/basic.yaml
@@ -1,5 +1,4 @@
-# Minimal smoke test: plain comment-free formatting (map nesting, seq markers).
-# Every other fixture exercises comments or edge shapes on top of this.
+# Minimal smoke test: map nesting and seq markers, no edge shapes.
 key: value
 map:
   nested: 1

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/basic.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/basic.yaml.snap
@@ -2,8 +2,7 @@
 source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-# Minimal smoke test: plain comment-free formatting (map nesting, seq markers).
-# Every other fixture exercises comments or edge shapes on top of this.
+# Minimal smoke test: map nesting and seq markers, no edge shapes.
 key: value
 map:
   nested: 1
@@ -15,8 +14,7 @@ map:
 ------------------
 { printWidth: 80 }
 ------------------
-# Minimal smoke test: plain comment-free formatting (map nesting, seq markers).
-# Every other fixture exercises comments or edge shapes on top of this.
+# Minimal smoke test: map nesting and seq markers, no edge shapes.
 key: value
 map:
   nested: 1
@@ -27,8 +25,7 @@ map:
 -------------------
 { printWidth: 100 }
 -------------------
-# Minimal smoke test: plain comment-free formatting (map nesting, seq markers).
-# Every other fixture exercises comments or edge shapes on top of this.
+# Minimal smoke test: map nesting and seq markers, no edge shapes.
 key: value
 map:
   nested: 1


### PR DESCRIPTION
- Restore wrongly consolidated fixtures
- State new fixtures policy and apply
- Check `endOfLine` option and output at test harness level