### PR TITLE
fix(formatter_css): space a folded sign after a call in Less operations

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -216,7 +216,7 @@ Two more files fail with MIXED hunks; they can't pass as files (the intentional 
   - a fill break-point inside a math-y value (`... * -1 +` vs breaking before `/ 2`);
     - the DIVERGENCES.md "fill-break-position" class (core-fill semantics)
 - `css/parens/parens.css` (~93% match) token-soup math spacing, three hunk classes:
-  - intentional: Prettier splits SOME source-glued `-(` into `- (` (`prop`/`prop44`, DIVERGENCES.md "glued-minus-paren")
+  - intentional: Prettier splits SOME source-glued `-(` into `- (` (`prop`/`prop44`, DIVERGENCES.md "css-glued-minus-paren")
     and glues a source-spaced `+ 20px` (`prop34`, DIVERGENCES.md "unary-plus-glue")
   - normalization-direction difference (open question, low value)
     - a math operator adjacent to a function/paren boundary gets uniform `op` spacing from Prettier regardless of source (`round(1.5)+2` -> `round(1.5) + 2`, calc `*`/`/`);

--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -595,7 +595,7 @@ Prettier glues the sign to the number (removing the source space, a postcss word
 Matching that gluing is ad-hoc work for a torture-test-only shape.
 A sign GLUED in the source never gains a space in either implementation (that direction is the parser's folded-sign handling, not a divergence).
 
-## glued-minus-paren
+## css-glued-minus-paren
 
 - Why: uniform-rule
 - Pin: `tests/fixtures/format/css/token-soup-math-glue.css` (also tracked by conformance `css/parens/parens.css`)
@@ -617,6 +617,8 @@ prop44: -(4px);
 Prettier splits only SOME source-glued `-(` (an operator-heuristic side effect: the split needs a
 binary-looking left neighbor), an internal inconsistency for the same token pair.
 Ours keeps them all glued under the one token-soup rule: never add a space the source doesn't have.
+Css mode only (hence the prefix): in Less and Scss, Prettier keeps `3px -(4px)` glued too (measured),
+so the same shape there is not a divergence.
 
 ## fill-break-position
 
@@ -688,7 +690,8 @@ For the glued `-` Prettier also diverges in value positions, via a different art
 ## value-glued-minus
 
 - Why: prettier-bug
-- Pin: `tests/fixtures/format/scss/value-glued-minus.scss`
+- Pin: `tests/fixtures/format/scss/value-glued-minus.scss` (Scss),
+  `tests/fixtures/format/less/signed-value-args.less` (Less)
 
 ```scss
 /* input */
@@ -707,14 +710,36 @@ For the glued `-` Prettier also diverges in value positions, via a different art
 }
 ```
 
-A glued `-` after a call/paren in a value position is subtraction (dart-sass); ours parses it as
-`SassBinaryExpression` and prints spaced, like every other Sass operator. Prettier's value lexer keeps the
-glued `-` verbatim (a sign-lexing artifact: `-` may start a number/ident, so no operator node forms) while
-the same glued `+` DOES get spaced; we print both ops uniformly.
-Scope: value positions parsed as `SassBinaryExpression` (property values, `$var:` declarations, SassScript function args).
-Calculation-function args (`max`, `min`, `calc`, `clamp`) parse the glued sign as a `Calc` operation instead,
-whose printer keeps the source glue verbatim — matching Prettier there,
-so that position is NOT a divergence (pin: `tests/fixtures/format/scss/calc-glued-minus.scss`).
+A glued `-` after a call/paren in a value position is subtraction (dart-sass and lessc alike);
+ours parses it as a binary operation (`SassBinaryExpression` / `LessBinaryOperation`) and prints spaced, like every other operator.
+Prettier's value lexer keeps the glued `-` verbatim
+(a sign-lexing artifact: `-` may start a number/ident, so no operator node forms) while the same glued `+` DOES get spaced;
+we print both ops uniformly.
+
+The same artifact pair exists in Less:
+
+```less
+/* input */
+p7: fade(@c, 4%)-1;
+p8: fade(@c, 4%)+1;
+
+/* ours */
+p7: fade(@c, 4%) - 1;
+p8: fade(@c, 4%) + 1;
+
+/* prettier */
+p7: fade(@c, 4%)-1;
+p8: fade(@c, 4%) + 1;
+```
+
+Scope: value positions where ours structures the glued sign as a binary operation.
+
+- In Scss, any such position (property values, `$var:` declarations, function args)
+- In Less, a call left operand only
+
+Everywhere else BOTH implementations keep the glue, so there is nothing to diverge;
+where exactly ours keeps it is printer mechanism, documented at `write_less_binary_operation` / `write_sass_binary`
+(and pinned by the same fixtures plus `tests/fixtures/format/scss/calc-glued-minus.scss` for Scss calculation args).
 
 ## map-paren-value-blank-lines
 

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -1808,10 +1808,17 @@ fn write_calc<'a>(calc: &Calc<'a>, ctx: ValueContext<'a>, f: &mut CssFormatter<'
 /// continuation lines share one uniform indent.
 /// Nested unparenthesized operations flatten into the SAME fill;
 /// a parenthesized sub-expression is its own nested group (it can break inside its parens).
-/// Operator spacing follows the source: `+`/`-` always have whitespace here
-/// (`oxc-css-parser` only treats a whitespace-followed `+`/`-` as a binary operator,
-/// a signed value like `-@b` in a `margin` shorthand stays a separate `LessNegativeValue`, never an operand here),
-/// while `*`/`/` may be glued (`@base*2`).
+///
+/// Operator spacing follows the source, with one exception:
+/// a `+`/`-` glued to a preceding CALL prints spaced
+/// (`fade(@c, 4%)-1` → `fade(@c, 4%) - 1`, a folded sign the parser split off; Prettier spaces the `+` there too).
+/// Every other glue is kept, matching Prettier's Less word lexing:
+/// `10px+20px`, `@a+1`, `(@a)+1`, `@base*2` all stay glued
+/// (unlike SCSS, where `write_sass_binary` also spaces word-like neighbors and `*`).
+/// Signed values never reach here: `-@b` in a `margin` shorthand stays a separate `LessNegativeValue`, not an operand.
+/// KNOWN GAP (pre-existing): Prettier's division word-neighbor rule
+/// (`@w/2` → `@w / 2`, `2/@w` → `2 / @w`, call left spaced; `10px/8px` glued)
+/// is not ported; ours keeps the source glue for all of them.
 fn write_less_binary_operation<'a>(
     op: &LessBinaryOperation<'a>,
     ctx: ValueContext<'a>,
@@ -1840,12 +1847,19 @@ fn write_less_binary_operation<'a>(
         let right_start = to_span(op.right.span()).start;
 
         push_operand(&op.left, chunks, current);
-        if left_end != op_span.start {
+        // The call-left exception (see the doc comment);
+        // the left neighbor in the flattened stream is the piece `push_operand` just pushed last.
+        let after_call = matches!(
+            op.op.kind,
+            LessOperationOperatorKind::Plus | LessOperationOperatorKind::Minus
+        ) && matches!(current.last(), Some(Piece::Operand(v)) if is_func_like(v));
+        if left_end != op_span.start || after_call {
             current.push(Piece::Space);
         }
         current.push(Piece::Op(op_str));
-        // Break opportunity only when the source has a gap after the operator
-        if op_span.end != right_start {
+        // Break opportunity when the source has a gap after the operator
+        // (or the call-left exception applies)
+        if op_span.end != right_start || after_call {
             chunks.push(std::mem::take(current));
         }
         push_operand(&op.right, chunks, current);

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/token-soup-math-glue.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/token-soup-math-glue.css
@@ -13,7 +13,7 @@ a {
 }
 /*
  * A source-glued `-(` stays glued in every position.
- * DIVERGES from Prettier (DIVERGENCES.md "glued-minus-paren"),
+ * DIVERGES from Prettier (DIVERGENCES.md "css-glued-minus-paren"),
  * which splits only the binary-looking `3px -(4px)` into `3px - (4px)`
  * while keeping the bare `-(4px)` glued.
  */

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/token-soup-math-glue.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/token-soup-math-glue.css.snap
@@ -17,7 +17,7 @@ a {
 }
 /*
  * A source-glued `-(` stays glued in every position.
- * DIVERGES from Prettier (DIVERGENCES.md "glued-minus-paren"),
+ * DIVERGES from Prettier (DIVERGENCES.md "css-glued-minus-paren"),
  * which splits only the binary-looking `3px -(4px)` into `3px - (4px)`
  * while keeping the bare `-(4px)` glued.
  */
@@ -45,7 +45,7 @@ a {
 }
 /*
  * A source-glued `-(` stays glued in every position.
- * DIVERGES from Prettier (DIVERGENCES.md "glued-minus-paren"),
+ * DIVERGES from Prettier (DIVERGENCES.md "css-glued-minus-paren"),
  * which splits only the binary-looking `3px -(4px)` into `3px - (4px)`
  * while keeping the bare `-(4px)` glued.
  */
@@ -72,7 +72,7 @@ a {
 }
 /*
  * A source-glued `-(` stays glued in every position.
- * DIVERGES from Prettier (DIVERGENCES.md "glued-minus-paren"),
+ * DIVERGES from Prettier (DIVERGENCES.md "css-glued-minus-paren"),
  * which splits only the binary-looking `3px -(4px)` into `3px - (4px)`
  * while keeping the bare `-(4px)` glued.
  */

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/signed-value-args.less
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/signed-value-args.less
@@ -13,4 +13,12 @@
   // p6 DIVERGES from Prettier (DIVERGENCES.md "unary-plus-glue"):
   // ours keeps the source-spaced `+ 20px`, Prettier glues it to `+20px`
   p6: func(+20px, + 20px);
+  // p7 DIVERGES from Prettier (DIVERGENCES.md "value-glued-minus"): a sign
+  // glued to a call is a binary op (lessc); ours spaces both, Prettier keeps
+  // `-` glued (sign-lexing artifact) but agrees on p8's spaced `+`
+  p7: fade(@c, 4%)-1;
+  p8: fade(@c, 4%)+1;
+  // NON-call left operands keep the glue (Prettier lexes them as one word)
+  p9: @a+1;
+  p10: (10px)+1;
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/signed-value-args.less.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/signed-value-args.less.snap
@@ -17,6 +17,14 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
   // p6 DIVERGES from Prettier (DIVERGENCES.md "unary-plus-glue"):
   // ours keeps the source-spaced `+ 20px`, Prettier glues it to `+20px`
   p6: func(+20px, + 20px);
+  // p7 DIVERGES from Prettier (DIVERGENCES.md "value-glued-minus"): a sign
+  // glued to a call is a binary op (lessc); ours spaces both, Prettier keeps
+  // `-` glued (sign-lexing artifact) but agrees on p8's spaced `+`
+  p7: fade(@c, 4%)-1;
+  p8: fade(@c, 4%)+1;
+  // NON-call left operands keep the glue (Prettier lexes them as one word)
+  p9: @a+1;
+  p10: (10px)+1;
 }
 
 ==================== Output ====================
@@ -38,6 +46,14 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
   // p6 DIVERGES from Prettier (DIVERGENCES.md "unary-plus-glue"):
   // ours keeps the source-spaced `+ 20px`, Prettier glues it to `+20px`
   p6: func(+20px, + 20px);
+  // p7 DIVERGES from Prettier (DIVERGENCES.md "value-glued-minus"): a sign
+  // glued to a call is a binary op (lessc); ours spaces both, Prettier keeps
+  // `-` glued (sign-lexing artifact) but agrees on p8's spaced `+`
+  p7: fade(@c, 4%) - 1;
+  p8: fade(@c, 4%) + 1;
+  // NON-call left operands keep the glue (Prettier lexes them as one word)
+  p9: @a+1;
+  p10: (10px)+1;
 }
 
 -------------------
@@ -58,6 +74,14 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
   // p6 DIVERGES from Prettier (DIVERGENCES.md "unary-plus-glue"):
   // ours keeps the source-spaced `+ 20px`, Prettier glues it to `+20px`
   p6: func(+20px, + 20px);
+  // p7 DIVERGES from Prettier (DIVERGENCES.md "value-glued-minus"): a sign
+  // glued to a call is a binary op (lessc); ours spaces both, Prettier keeps
+  // `-` glued (sign-lexing artifact) but agrees on p8's spaced `+`
+  p7: fade(@c, 4%) - 1;
+  p8: fade(@c, 4%) + 1;
+  // NON-call left operands keep the glue (Prettier lexes them as one word)
+  p9: @a+1;
+  p10: (10px)+1;
 }
 
 ===================== End =====================


### PR DESCRIPTION
Follow up on #26132.

By that change, Less is also possible to format binary operation like SCSS.
