### PR TITLE
fix(linter): respect plugin prefixes in disable directives

### DIFF
--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use bitflags::bitflags;
+use cow_utils::CowUtils;
 use schemars::{JsonSchema, r#gen::SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize, de::Deserializer, ser::Serializer};
 
@@ -84,6 +85,28 @@ pub fn is_normal_plugin_name(plugin_name: &str) -> bool {
     match normalized {
         Cow::Owned(_) => false,
         Cow::Borrowed(normalized) => normalized.len() == plugin_name.len(),
+    }
+}
+
+/// Canonicalizes a plugin name to the internal name used by Oxc.
+///
+/// This implementation is intentionally extracted verbatim from the previous
+/// `unalias_plugin_name` implementation so that the same normalization logic
+/// can be shared by other modules. The extraction preserves all existing
+/// behavior and does not change the previous normalization rules.
+pub(crate) fn canonical_plugin_name(plugin_name: &str) -> String {
+    let normalized = normalize_plugin_name(plugin_name);
+
+    match normalized.as_ref() {
+        "@next" | "@next/next" => "nextjs".to_string(),
+        plugin_name => match LintPlugins::try_from(plugin_name) {
+            Ok(LintPlugins::ESLINT) => "eslint".to_string(),
+            Ok(plugin) => {
+                let plugin_name: &str = plugin.into();
+                plugin_name.cow_replace('-', "_").into_owned()
+            }
+            Err(()) => normalized.into_owned(),
+        },
     }
 }
 

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -25,6 +25,7 @@ use oxc_diagnostics::{Error, OxcDiagnostic};
 use crate::utils::should_skip_config_schema;
 use crate::{
     AllowWarnDeny, ExternalPluginStore, LintPlugins,
+    config::plugins::canonical_plugin_name,
     external_plugin_store::{ExternalOptionsId, ExternalRuleId, ExternalRuleLookupError},
     rules::{RULES, RuleEnum},
     utils::is_eslint_rule_adapted_to_typescript,
@@ -670,21 +671,7 @@ pub fn normalize_rule_name(name: &str) -> String {
 }
 
 pub(super) fn unalias_plugin_name(plugin_name: &str, rule_name: &str) -> (String, String) {
-    let normalized = super::plugins::normalize_plugin_name(plugin_name);
-    let plugin_name = match normalized.as_ref() {
-        // e.g. "@next/google-font-display", "@next/next/google-font-display"
-        "@next" | "@next/next" => "nextjs".to_string(),
-        plugin_name => match LintPlugins::try_from(plugin_name) {
-            Ok(LintPlugins::ESLINT) => "eslint".to_string(),
-            Ok(plugin) => {
-                let plugin_name: &str = plugin.into();
-                plugin_name.cow_replace('-', "_").into_owned()
-            }
-            Err(()) => normalized.into_owned(),
-        },
-    };
-
-    (plugin_name, rule_name.to_string())
+    (canonical_plugin_name(plugin_name), rule_name.to_string())
 }
 
 fn parse_rule_value(

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -264,7 +264,11 @@ impl<'a> LintContext<'a> {
     /// Add a diagnostic message to the list of diagnostics. Outputs a diagnostic with the current rule
     /// name, severity, and a link to the rule's documentation URL.
     fn add_diagnostic(&self, mut message: Message) {
-        if self.parent.disable_directives().contains(self.current_rule_name, message.span) {
+        if self.parent.disable_directives().contains(
+            self.current_plugin_display_name,
+            self.current_rule_name,
+            message.span,
+        ) {
             return;
         }
         message.error = message

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use rust_lapper::{Interval, Lapper};
 use rustc_hash::FxHashMap;
 
-use crate::{FixKind, fixer::Fix};
+use crate::{FixKind, config::plugins::canonical_plugin_name, fixer::Fix};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum DirectivePrefix {
@@ -302,8 +302,16 @@ impl DisableDirectives {
     fn mark_disable_directive_used(&self, disable_directive: DisabledRule) {
         self.used_disable_comments.borrow_mut().push(disable_directive);
     }
-
-    pub fn contains(&self, rule_name: &str, span: Span) -> bool {
+    fn rule_matches(disabled_rule: &str, plugin_name: &str, rule_name: &str) -> bool {
+        match disabled_rule.rsplit_once('/') {
+            Some((disabled_plugin, disabled_rule)) => {
+                canonical_plugin_name(disabled_plugin) == canonical_plugin_name(plugin_name)
+                    && disabled_rule == rule_name
+            }
+            None => disabled_rule == rule_name,
+        }
+    }
+    pub fn contains(&self, plugin_name: &str, rule_name: &str, span: Span) -> bool {
         // For `eslint-disable-next-line` and `eslint-disable-line` directives, we only check
         // if the diagnostic's starting position falls within the disabled interval.
         // This prevents suppressing diagnostics for larger constructs (like functions) that
@@ -318,23 +326,15 @@ impl DisableDirectives {
             // Check if this rule should be disabled
             let rule_matches = match &interval.val {
                 DisabledRule::All { .. } => true,
-                // `rule_name` does not contain the plugin prefix.
-                // - `vitest/foobar` will be just `foobar`.
-                // - `@typescript-eslint/no-var-requires` will be just `no-var-requires`
+                // Match a qualified directive (`plugin/rule`) against both the diagnostic's
+                // plugin and rule names. For an unqualified directive (`rule`), match only
+                // the rule name to preserve compatibility with ESLint-style directives.
                 //
-                // This enables matching rules across different plugins that share the same
-                // rule name, such as jest<->vitest rules and eslint<->typescript rules.
-                //
-                // We strip the plugin prefix from the directive name and compare equality
-                // rather than doing a substring match. Otherwise unrelated rules like
-                // `canonical/no-re-export` would accidentally match oxlint's `export`
-                // rule because `"no-re-export".contains("export")` is true.
+                // Qualified names must match exactly. Otherwise a directive such as
+                // `canonical/no-re-export` could accidentally suppress the `import/export`
+                // rule if matching used substring checks.
                 DisabledRule::Single { rule_name: name, .. } => {
-                    if rule_name.contains('/') {
-                        name == rule_name
-                    } else {
-                        name.rsplit_once('/').map_or(name.as_str(), |(_, rule)| rule) == rule_name
-                    }
+                    Self::rule_matches(name, plugin_name, rule_name)
                 }
             };
 
@@ -1489,13 +1489,11 @@ mod tests {
 
         let debugger_span = Span::sized(source_text.rfind("debugger").unwrap() as u32, 8);
         for rule in expected_rules {
-            assert!(directives.contains(rule, debugger_span), "{directive} should disable {rule}");
-            if let Some((_, rule_without_plugin)) = rule.rsplit_once('/') {
-                assert!(
-                    directives.contains(rule_without_plugin, debugger_span),
-                    "{directive} should disable {rule_without_plugin}"
-                );
-            }
+            let (plugin_name, rule_name) = rule.rsplit_once('/').unwrap_or(("", rule));
+            assert!(
+                directives.contains(plugin_name, rule_name, debugger_span),
+                "{directive} should disable {rule}"
+            );
         }
     }
 
@@ -1609,8 +1607,8 @@ mod tests {
         let console_start = source_text.find("console.log").unwrap() as u32;
         let debugger_start = source_text.find("debugger;").unwrap() as u32;
 
-        assert!(!directives.contains("no-console", Span::sized(console_start, 11)));
-        assert!(directives.contains("no-debugger", Span::sized(debugger_start, 8)));
+        assert!(!directives.contains("eslint", "no-console", Span::sized(console_start, 11)));
+        assert!(directives.contains("oxlint", "no-debugger", Span::sized(debugger_start, 8)));
         assert!(directives.unused_enable_comments().is_empty());
     }
 
@@ -1818,7 +1816,7 @@ mod tests {
             DisableDirectivesBuilder::new().build(semantic.source_text(), semantic.comments());
 
         let x_span = Span::sized(source_text.find("const x").unwrap() as u32, 5);
-        assert!(directives.contains("no-bitwise", x_span));
+        assert!(directives.contains("eslint", "no-bitwise", x_span));
 
         let unused = directives.collect_unused_disable_comments();
         assert_eq!(unused.len(), 1);
@@ -1954,7 +1952,7 @@ function test() {
         // The diagnostic for the entire function should NOT be suppressed
         // even though it contains a disable-next-line directive
         assert!(
-            !directives.contains("max-lines-per-function", function_span),
+            !directives.contains("eslint", "max-lines-per-function", function_span),
             "eslint-disable-next-line should not suppress diagnostics for the entire function"
         );
 
@@ -1963,7 +1961,7 @@ function test() {
         let first_console_log_span = Span::new(55, 66);
         assert_eq!(first_console_log_span.source_text(source_text), "console.log");
         assert!(
-            directives.contains("no-console", first_console_log_span),
+            directives.contains("eslint", "no-console", first_console_log_span),
             "eslint-disable-next-line should suppress diagnostics on the next line"
         );
 
@@ -1972,7 +1970,7 @@ function test() {
         let second_console_log_span = Span::new(97, 109);
         assert_eq!(second_console_log_span.source_text(source_text), "console.warn");
         assert!(
-            !directives.contains("no-console", second_console_log_span),
+            !directives.contains("eslint", "no-console", second_console_log_span),
             "eslint-disable-next-line should NOT suppress diagnostics on lines after the next line"
         );
     }
@@ -2103,7 +2101,7 @@ function test() {
         let export_start = source_text.find("export *").unwrap() as u32;
         let export_span = Span::sized(export_start, 21);
         assert!(
-            !directives.contains("export", export_span),
+            !directives.contains("import", "export", export_span),
             "`canonical/no-re-export` directive must not suppress the `export` rule"
         );
 
@@ -2120,7 +2118,7 @@ function test() {
         let export_start = source_text_exact.find("export *").unwrap() as u32;
         let export_span = Span::sized(export_start, 21);
         assert!(
-            directives.contains("export", export_span),
+            directives.contains("import", "export", export_span),
             "`import/export` directive must suppress the `export` rule"
         );
     }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -859,10 +859,7 @@ impl Linter {
                     let (plugin_name, rule_name) =
                         self.config.resolve_plugin_rule_names(external_rule_id);
 
-                    if ctx_host
-                        .disable_directives()
-                        .contains(&format!("{plugin_name}/{rule_name}"), span)
-                    {
+                    if ctx_host.disable_directives().contains(plugin_name, rule_name, span) {
                         continue;
                     }
 

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -58,9 +58,9 @@ impl DirectivesStore {
         let map = self.map.lock().expect("DirectivesStore mutex poisoned in should_disable");
         if let Some(directives) = map.get(path) {
             // Check with various rule name formats
-            directives.contains(rule, span)
-                || directives.contains(&format!("typescript-eslint/{rule}"), span)
-                || directives.contains(&format!("@typescript-eslint/{rule}"), span)
+            directives.contains("", rule, span)
+                || directives.contains("typescript-eslint", rule, span)
+                || directives.contains("@typescript-eslint", rule, span)
         } else {
             false
         }

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -1216,10 +1216,9 @@ fn should_skip_diagnostic(
     };
 
     if let Some(directives) = disable_directives_map.get(path) {
-        directives.contains(&tsgolint_diagnostic.rule, span)
-            || directives.contains(&format!("typescript-eslint/{}", tsgolint_diagnostic.rule), span)
-            || directives
-                .contains(&format!("@typescript-eslint/{}", tsgolint_diagnostic.rule), span)
+        directives.contains("", &tsgolint_diagnostic.rule, span)
+            || directives.contains("typescript-eslint", &tsgolint_diagnostic.rule, span)
+            || directives.contains("@typescript-eslint", &tsgolint_diagnostic.rule, span)
     } else {
         debug_assert!(
             false,


### PR DESCRIPTION
## Summary

Fixes #26115.

Plugin-qualified `oxlint-disable` directives could ignore the plugin prefix when matching diagnostics. As a result, a directive such as `WRONG-PREFIX/consistent-date-clone` could incorrectly suppress `unicorn/consistent-date-clone`.

This change:

- Matches qualified directives against both plugin and rule names.
- Preserves compatibility for unqualified rule names.
- Resolves plugin aliases through the shared canonical plugin-name helper.
- Keeps aliases such as `@typescript-eslint` compatible with the canonical
  `typescript` plugin name.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p oxc_linter`

## AI Disclosure

AI tools were used during development. The resulting changes were reviewed,understood, and validated by the contributor.