### PR TITLE
fix(linter): normalize reversed JS plugin locations

### DIFF
--- a/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
@@ -17,6 +17,13 @@
  3 | `-> debugger;
    `----
 
+  x loc-plugin(no-bugger): Misaligned location
+   ,-[files/index.js:1:4]
+ 1 | debugger;
+   :    ^
+ 2 | debugger;
+   `----
+
   x loc-plugin(no-bugger): Bugger!
    ,-[files/index.js:2:3]
  1 | debugger;
@@ -32,7 +39,7 @@
    :   ^^^^^^
    `----
 
-Found 0 warnings and 4 errors.
+Found 0 warnings and 5 errors.
 Finished in Xms on 1 file with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
@@ -11,6 +11,13 @@ const plugin: Plugin = {
         return {
           Program(_node) {
             context.report({
+              message: "Misaligned location",
+              loc: {
+                start: { line: 1, column: 3 },
+                end: { line: 1, column: 1 },
+              },
+            });
+            context.report({
               message: "Bugger debugger debug!",
               loc: {
                 start: { line: 1, column: 2 },

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -848,10 +848,12 @@ impl Linter {
             Ok(diagnostics) => {
                 for diagnostic in diagnostics {
                     // Convert UTF-16 offsets back to UTF-8.
-                    // TODO: Validate span offsets are within bounds and `start <= end`.
+                    // ESLint permits a reported location to end before it starts. Represent those
+                    // as an empty span at the reported start, preserving its displayed position.
                     // Also make sure offsets do not fall in middle of a multi-byte UTF-8 character.
                     // That's possible if UTF-16 offset points to middle of a surrogate pair.
-                    let mut span = Span::new(diagnostic.start, diagnostic.end);
+                    let mut span =
+                        Span::new(diagnostic.start, diagnostic.end.max(diagnostic.start));
                     span_converter.convert_span_back(&mut span);
 
                     let (external_rule_id, _options_id, severity) =


### PR DESCRIPTION
## Summary
- normalize reversed JS plugin diagnostic locations to empty spans at their stated start
- add an end-to-end regression fixture for reversed `loc` positions

fixes https://github.com/oxc-project/oxc/issues/25867