### PR TITLE
fix(linter): show JS plugin rules when using `--print-config`

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -343,7 +343,12 @@ impl CliRunner {
         .with_filters(&filters);
 
         if misc_options.print_config {
-            return crate::mode::run_print_config(&config_builder, root_config, stdout);
+            return crate::mode::run_print_config(
+                &config_builder,
+                root_config,
+                &external_plugin_store,
+                stdout,
+            );
         }
 
         let lint_config = match config_builder.build(&mut external_plugin_store) {

--- a/apps/oxlint/src/mode/print_config.rs
+++ b/apps/oxlint/src/mode/print_config.rs
@@ -1,13 +1,14 @@
-use oxc_linter::{ConfigStoreBuilder, Oxlintrc};
+use oxc_linter::{ConfigStoreBuilder, ExternalPluginStore, Oxlintrc};
 
 use crate::{cli::CliRunResult, lint::print_and_flush_stdout};
 
 pub fn run_print_config(
     store_builder: &ConfigStoreBuilder,
     oxlintrc: Oxlintrc,
+    external_plugin_store: &ExternalPluginStore,
     stdout: &mut dyn std::io::Write,
 ) -> CliRunResult {
-    let config_file = store_builder.resolve_final_config_file(oxlintrc);
+    let config_file = store_builder.resolve_final_config_file(oxlintrc, external_plugin_store);
     print_and_flush_stdout(stdout, &config_file);
     print_and_flush_stdout(stdout, "\n");
 

--- a/apps/oxlint/test/fixtures/print_config_js_plugins/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/print_config_js_plugins/.oxlintrc.json
@@ -1,0 +1,11 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "no-debugger": "error",
+    "print-config-plugin/no-foo": ["warn", { "bar": true }],
+    "print-config-plugin/no-bar": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/print_config_js_plugins/files/test.js
+++ b/apps/oxlint/test/fixtures/print_config_js_plugins/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/print_config_js_plugins/options.json
+++ b/apps/oxlint/test/fixtures/print_config_js_plugins/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--print-config"]
+}

--- a/apps/oxlint/test/fixtures/print_config_js_plugins/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_js_plugins/output.snap.md
@@ -1,0 +1,72 @@
+# Exit code
+0
+
+# stdout
+```
+{
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc"
+  ],
+  "jsPlugins": [
+    "./plugin.ts"
+  ],
+  "categories": {
+    "correctness": "allow"
+  },
+  "rules": {
+    "no-debugger": "deny",
+    "print-config-plugin/no-bar": "deny",
+    "print-config-plugin/no-foo": [
+      "warn",
+      [
+        {
+          "bar": true
+        }
+      ]
+    ]
+  },
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": null,
+      "components": {},
+      "attributes": {}
+    },
+    "next": {
+      "rootDir": []
+    },
+    "react": {
+      "formComponents": [],
+      "linkComponents": [],
+      "version": null,
+      "componentWrapperFunctions": []
+    },
+    "jsdoc": {
+      "ignorePrivate": false,
+      "ignoreInternal": false,
+      "ignoreReplacesDocs": true,
+      "overrideReplacesDocs": true,
+      "augmentsExtendsReplacesDocs": false,
+      "implementsReplacesDocs": false,
+      "exemptDestructuredRootsFromChecks": false,
+      "tagNamePreference": {}
+    },
+    "vitest": {
+      "typecheck": false
+    },
+    "jest": {
+      "version": null
+    }
+  },
+  "env": {
+    "builtin": true
+  },
+  "globals": {},
+  "ignorePatterns": []
+}
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/print_config_js_plugins/plugin.ts
+++ b/apps/oxlint/test/fixtures/print_config_js_plugins/plugin.ts
@@ -1,0 +1,21 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "print-config-plugin",
+  },
+  rules: {
+    "no-foo": {
+      create() {
+        return {};
+      },
+    },
+    "no-bar": {
+      create() {
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/apps/oxlint/test/fixtures/print_config_nested/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/print_config_nested/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "no-debugger": "error",
+    "print-config-plugin/no-foo": ["warn", { "bar": true }]
+  }
+}

--- a/apps/oxlint/test/fixtures/print_config_nested/options.json
+++ b/apps/oxlint/test/fixtures/print_config_nested/options.json
@@ -1,0 +1,4 @@
+{
+  "cwd": "package1",
+  "args": ["--print-config"]
+}

--- a/apps/oxlint/test/fixtures/print_config_nested/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_nested/output.snap.md
@@ -1,0 +1,71 @@
+# Exit code
+0
+
+# stdout
+```
+{
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc"
+  ],
+  "categories": {},
+  "rules": {
+    "no-console": "allow",
+    "no-debugger": "deny",
+    "print-config-plugin/no-bar": "deny",
+    "print-config-plugin/no-foo": [
+      "warn",
+      [
+        {
+          "bar": true
+        }
+      ]
+    ]
+  },
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": null,
+      "components": {},
+      "attributes": {}
+    },
+    "next": {
+      "rootDir": []
+    },
+    "react": {
+      "formComponents": [],
+      "linkComponents": [],
+      "version": null,
+      "componentWrapperFunctions": []
+    },
+    "jsdoc": {
+      "ignorePrivate": false,
+      "ignoreInternal": false,
+      "ignoreReplacesDocs": true,
+      "overrideReplacesDocs": true,
+      "augmentsExtendsReplacesDocs": false,
+      "implementsReplacesDocs": false,
+      "exemptDestructuredRootsFromChecks": false,
+      "tagNamePreference": {}
+    },
+    "vitest": {
+      "typecheck": false
+    },
+    "jest": {
+      "version": null
+    }
+  },
+  "env": {
+    "builtin": true
+  },
+  "globals": {},
+  "ignorePatterns": [],
+  "extends": [
+    "../.oxlintrc.json"
+  ]
+}
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/print_config_nested/package1/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/print_config_nested/package1/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../.oxlintrc.json"],
+  "rules": {
+    "no-console": "off",
+    "print-config-plugin/no-bar": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/print_config_nested/package1/files/test.js
+++ b/apps/oxlint/test/fixtures/print_config_nested/package1/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/print_config_nested/plugin.ts
+++ b/apps/oxlint/test/fixtures/print_config_nested/plugin.ts
@@ -1,0 +1,21 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "print-config-plugin",
+  },
+  rules: {
+    "no-foo": {
+      create() {
+        return {};
+      },
+    },
+    "no-bar": {
+      create() {
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/fixtures/nested_config/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/nested_config/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "categories": { "correctness": "off" },
+  "rules": {
+    "no-debugger": "error",
+    "custom/my-rule": ["warn", { "foo": 1 }]
+  }
+}

--- a/crates/oxc_linter/fixtures/nested_config/package1/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/nested_config/package1/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "categories": { "correctness": "off" },
+  "rules": {
+    "no-console": "error"
+  }
+}

--- a/crates/oxc_linter/fixtures/nested_config/package2/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/nested_config/package2/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../.oxlintrc.json"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "no-console": "off",
+    "custom/other-rule": "error"
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -583,7 +583,11 @@ impl ConfigStoreBuilder {
 
     /// # Panics
     /// This function will panic if the `oxlintrc` is not valid JSON.
-    pub fn resolve_final_config_file(&self, oxlintrc: Oxlintrc) -> String {
+    pub fn resolve_final_config_file(
+        &self,
+        oxlintrc: Oxlintrc,
+        external_plugin_store: &ExternalPluginStore,
+    ) -> String {
         let mut oxlintrc = oxlintrc;
         let previous_rules = std::mem::take(&mut oxlintrc.rules);
 
@@ -593,10 +597,9 @@ impl ConfigStoreBuilder {
             .map(|r| (get_name(&r.plugin_name, &r.rule_name), r))
             .collect::<rustc_hash::FxHashMap<_, _>>();
 
-        let new_rules = self
+        let mut new_rules: Vec<ESLintRule> = self
             .rules
             .iter()
-            .sorted_unstable_by_key(|(r, _)| (r.plugin_name(), r.name()))
             .map(|(r, severity)| ESLintRule {
                 plugin_name: r.plugin_name().to_string(),
                 rule_name: r.name().to_string(),
@@ -607,6 +610,20 @@ impl ConfigStoreBuilder {
                     .unwrap_or_default(),
             })
             .collect();
+
+        new_rules.extend(self.external_rules.iter().map(|(&rule_id, &(options_id, severity))| {
+            let (plugin_name, rule_name) = external_plugin_store.resolve_plugin_rule_names(rule_id);
+            ESLintRule {
+                plugin_name: plugin_name.to_string(),
+                rule_name: rule_name.to_string(),
+                severity,
+                config: external_plugin_store.rule_options(options_id).clone(),
+            }
+        }));
+
+        new_rules.sort_unstable_by(|a, b| {
+            a.plugin_name.cmp(&b.plugin_name).then_with(|| a.rule_name.cmp(&b.rule_name))
+        });
 
         oxlintrc.plugins = Some(self.config.plugins);
         oxlintrc.settings.clone_from(&self.config.settings);
@@ -925,6 +942,191 @@ mod test {
         let builder = ConfigStoreBuilder::empty();
         assert_eq!(builder.plugins(), LintPlugins::default());
         assert!(builder.rules.is_empty());
+    }
+
+    fn register_custom_plugin(store: &mut ExternalPluginStore) {
+        store.register_plugin(
+            PathBuf::from("path/to/custom-plugin"),
+            "custom".to_string(),
+            0,
+            vec!["my-rule".to_string(), "other-rule".to_string()],
+        );
+    }
+
+    fn parse_printed_rules(json: &str) -> serde_json::Map<String, serde_json::Value> {
+        serde_json::from_str::<serde_json::Value>(json).unwrap()["rules"]
+            .as_object()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_includes_external_rules() {
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let rule_with_options = store.lookup_rule_id("custom", "my-rule").unwrap();
+        let options = smallvec::smallvec![serde_json::json!({ "foo": 1 })];
+        let options_id = store.add_options(rule_with_options, &options);
+        let rule_without_options = store.lookup_rule_id("custom", "other-rule").unwrap();
+
+        let mut builder = ConfigStoreBuilder::empty();
+        builder.external_rules.insert(rule_with_options, (options_id, AllowWarnDeny::Warn));
+        builder
+            .external_rules
+            .insert(rule_without_options, (ExternalOptionsId::NONE, AllowWarnDeny::Deny));
+
+        let rules =
+            parse_printed_rules(&builder.resolve_final_config_file(Oxlintrc::default(), &store));
+
+        assert_eq!(rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert_eq!(rules["custom/other-rule"], serde_json::json!("deny"));
+        assert_eq!(rules.keys().collect::<Vec<_>>(), vec!["custom/my-rule", "custom/other-rule"]);
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_mixes_builtin_and_external_rules() {
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let oxlintrc: Oxlintrc = serde_json::from_str(
+            r#"
+            {
+                "categories": { "correctness": "off" },
+                "rules": {
+                    "no-debugger": "error",
+                    "custom/my-rule": ["warn", { "foo": 1 }],
+                    "custom/other-rule": "error"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let builder =
+            ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone(), None, &mut store, None)
+                .unwrap();
+
+        let rules = parse_printed_rules(&builder.resolve_final_config_file(oxlintrc, &store));
+
+        assert_eq!(rules["no-debugger"], serde_json::json!("deny"));
+        assert_eq!(rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert_eq!(rules["custom/other-rule"], serde_json::json!("deny"));
+        // Sorted by plugin name, then rule name (`custom` before `eslint`).
+        assert_eq!(
+            rules.keys().collect::<Vec<_>>(),
+            vec!["custom/my-rule", "custom/other-rule", "no-debugger"]
+        );
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_prints_external_rules_absent_from_input_oxlintrc() {
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let oxlintrc: Oxlintrc = serde_json::from_str(
+            r#"
+            {
+                "categories": { "correctness": "off" },
+                "rules": {
+                    "no-debugger": "error",
+                    "custom/my-rule": ["warn", { "foo": 1 }]
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let builder =
+            ConfigStoreBuilder::from_oxlintrc(false, oxlintrc, None, &mut store, None).unwrap();
+
+        // `--print-config` passes the original root config, which may omit rules
+        // that were resolved from `extends` into the builder.
+        let rules =
+            parse_printed_rules(&builder.resolve_final_config_file(Oxlintrc::default(), &store));
+
+        assert_eq!(rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert_eq!(rules["no-debugger"], serde_json::json!("deny"));
+        assert!(!rules.contains_key("custom/other-rule"));
+    }
+
+    const NESTED_ROOT_CONFIG: &str = "fixtures/nested_config/.oxlintrc.json";
+    const NESTED_INDEPENDENT_CONFIG: &str = "fixtures/nested_config/package1/.oxlintrc.json";
+    const NESTED_EXTENDS_CONFIG: &str = "fixtures/nested_config/package2/.oxlintrc.json";
+
+    fn builder_from_nested_config(
+        path: &str,
+        store: &mut ExternalPluginStore,
+    ) -> (ConfigStoreBuilder, Oxlintrc) {
+        let oxlintrc = Oxlintrc::from_file(&PathBuf::from(path)).unwrap();
+        let builder =
+            ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone(), None, store, None).unwrap();
+        (builder, oxlintrc)
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_nested_config_is_independent() {
+        // Nested configs are not auto-merged with the parent.
+        // https://oxc.rs/docs/guide/usage/linter/nested-config.html
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let (root_builder, root_oxlintrc) =
+            builder_from_nested_config(NESTED_ROOT_CONFIG, &mut store);
+        let root_rules =
+            parse_printed_rules(&root_builder.resolve_final_config_file(root_oxlintrc, &store));
+
+        assert_eq!(root_rules["no-debugger"], serde_json::json!("deny"));
+        assert_eq!(root_rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert!(!root_rules.contains_key("no-console"));
+        assert!(!root_rules.contains_key("custom/other-rule"));
+
+        let mut nested_store = ExternalPluginStore::new(true);
+        let (nested_builder, nested_oxlintrc) =
+            builder_from_nested_config(NESTED_INDEPENDENT_CONFIG, &mut nested_store);
+        let nested_rules = parse_printed_rules(
+            &nested_builder.resolve_final_config_file(nested_oxlintrc, &nested_store),
+        );
+
+        assert_eq!(nested_rules["no-console"], serde_json::json!("deny"));
+        assert!(!nested_rules.contains_key("no-debugger"));
+        assert!(!nested_rules.contains_key("custom/my-rule"));
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_nested_config_extends_parent() {
+        // Monorepo pattern: nested config extends the parent explicitly.
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let (builder, oxlintrc) = builder_from_nested_config(NESTED_EXTENDS_CONFIG, &mut store);
+        let rules = parse_printed_rules(&builder.resolve_final_config_file(oxlintrc, &store));
+
+        assert_eq!(rules["no-debugger"], serde_json::json!("deny"));
+        assert_eq!(rules["no-console"], serde_json::json!("allow"));
+        assert_eq!(rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert_eq!(rules["custom/other-rule"], serde_json::json!("deny"));
+        assert_eq!(
+            rules.keys().collect::<Vec<_>>(),
+            vec!["custom/my-rule", "custom/other-rule", "no-console", "no-debugger"]
+        );
+    }
+
+    #[test]
+    fn test_resolve_final_config_file_nested_config_extends_prints_from_builder() {
+        // `--print-config` passes the original nested oxlintrc, which omits rules
+        // inherited via `extends`. Those rules still come from the builder.
+        let mut store = ExternalPluginStore::new(true);
+        register_custom_plugin(&mut store);
+
+        let (builder, _) = builder_from_nested_config(NESTED_EXTENDS_CONFIG, &mut store);
+        let rules =
+            parse_printed_rules(&builder.resolve_final_config_file(Oxlintrc::default(), &store));
+
+        assert_eq!(rules["no-debugger"], serde_json::json!("deny"));
+        assert_eq!(rules["no-console"], serde_json::json!("allow"));
+        assert_eq!(rules["custom/my-rule"], serde_json::json!(["warn", [{ "foo": 1 }]]));
+        assert_eq!(rules["custom/other-rule"], serde_json::json!("deny"));
     }
 
     #[test]

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -147,6 +147,16 @@ impl ExternalPluginStore {
         (&plugin.name, &external_rule.name)
     }
 
+    /// Options recorded for `options_id`.
+    ///
+    /// [`ExternalOptionsId::NONE`] returns an empty slice.
+    pub(crate) fn rule_options(
+        &self,
+        options_id: ExternalOptionsId,
+    ) -> &SmallVec<[serde_json::Value; 1]> {
+        &self.options[options_id].1
+    }
+
     /// Add options to the store and return its [`ExternalOptionsId`].
     /// If `options` is empty, returns [`ExternalOptionsId::NONE`] without adding to the store.
     pub fn add_options(


### PR DESCRIPTION
Closes #22117.

## Problem

`oxlint --print-config` preserved the `jsPlugins` field, but silently dropped rules that came from those JS plugins. Linting still worked because external rules were resolved for the normal lint path; the bug was specific to the printed config output.

This also affected nested configs: a child config that `extends` a parent with JS plugin rules would print the inherited built-in rules, but not the inherited JS plugin rules.

## Root cause

`ConfigStoreBuilder::resolve_final_config_file` rebuilt the printed `rules` object from `ConfigStoreBuilder.rules`, which only contains built-in rules. JS plugin rules live in `ConfigStoreBuilder.external_rules`, with their names and options stored in `ExternalPluginStore`, so they were never serialized back into the printed config.

## Changes

* Pass `ExternalPluginStore` into the print-config path.
* Add `ExternalPluginStore::rule_options` to recover an external rule's options.
* Merge `external_rules` into the final printed `rules` list (using `resolve_plugin_rule_names` for names) and sort the combined output by plugin/rule name.
* Cover both a flat JS plugin config and a nested config that extends a parent with JS plugin rules.
* Add unit tests for mixed built-in/external rules, rules inherited via `extends`, and independent vs extending nested configs.

## Tests

Two layers: unit tests on `resolve_final_config_file`, and oxlint CLI fixtures that run `--print-config` end to end.

### Unit tests (`oxc_linter`)

* **External rules with and without options** — a JS plugin rule with `{ "foo": 1 }` prints as `["warn", [{ "foo": 1 }]]`; a rule with no options prints as `"deny"`.
* **Mixed built-in and JS plugin rules** — `no-debugger` and `custom/*` appear together, sorted by plugin name then rule name.
* **Rules not present on the input `Oxlintrc`** — `--print-config` passes the original root config, which may omit rules resolved from `extends`. Those rules still come from the builder.
* **Independent nested configs** — a child config that does not `extends` the parent is not auto-merged; the parent prints its JS plugin rules, the child does not.
* **Nested config that extends the parent** — a child that `extends` the parent prints inherited built-in and JS plugin rules, plus its own overrides.

### CLI fixtures (`oxlint`)

* **`print_config_js_plugins`** — a single config with `jsPlugins` and both a JS plugin rule with options and one without. Asserts the printed JSON includes `jsPlugins` and both rules.
* **`print_config_nested`** — a nested package config that `extends` a parent with JS plugin rules. Asserts the printed config includes inherited JS plugin rules plus the child's own rule.


## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
