### PR TITLE
fix(transformer/object-rest): lower multiple declarators correctly

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -820,7 +820,7 @@ impl<'a> ObjectRestSpread<'a> {
                 new_decls.push((i, decls));
             }
         }
-        for (i, decls) in new_decls {
+        for (i, decls) in new_decls.into_iter().rev() {
             decl.declarations.splice(i..=i, decls);
         }
     }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 270/398
+Passed: 271/399
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-variable-declarators/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-variable-declarators/input.js
@@ -1,0 +1,3 @@
+let { a, ...r } = x, { b, ...s } = y;
+const { c, ...t } = z, { d, ...u } = w;
+var { e, ...v } = p, { f, ...q } = o;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-variable-declarators/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-variable-declarators/output.js
@@ -1,0 +1,3 @@
+let { a } = x, r = babelHelpers.objectWithoutProperties(x, ["a"]), { b } = y, s = babelHelpers.objectWithoutProperties(y, ["b"]);
+const { c } = z, t = babelHelpers.objectWithoutProperties(z, ["c"]), { d } = w, u = babelHelpers.objectWithoutProperties(w, ["d"]);
+var { e } = p, v = babelHelpers.objectWithoutProperties(p, ["e"]), { f } = o, q = babelHelpers.objectWithoutProperties(o, ["f"]);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-object-rest-spread"]
+}


### PR DESCRIPTION
## Summary

Fix ES2018 object-rest lowering when one variable declaration contains multiple object-rest declarators.

### Before

Given:

```js
let { a, ...r } = x, { b, ...s } = y;
```

Oxc produced:

```js
let { a } = x, { b } = y,
  s = babelHelpers.objectWithoutProperties(y, ["b"]),
  {} = null;
```

The `r` binding was lost.

Each replacement was recorded using its original declarator index. Replacing the first declarator expanded it into multiple entries, shifting the second declarator. The subsequent replacement still used the old index and overwrote part of the first expansion.

### After

Oxc now produces:

```js
let { a } = x,
  r = babelHelpers.objectWithoutProperties(x, ["a"]),
  { b } = y,
  s = babelHelpers.objectWithoutProperties(y, ["b"]);
```

Queued replacements are applied from right to left. Replacing a later declarator cannot change the index of an earlier one, so every recorded index remains valid.

Regression coverage includes multiple `let`, `const`, and `var` declarators.

