### PR TITLE
fix(ecmascript): `Math.round` only exact half ties

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -472,8 +472,7 @@ fn try_fold_math_unary<'a>(
             // In Rust, when facing `.5`, it may follow `half-away-from-zero` instead of round to upper bound.
             // So we need to handle it manually.
             let frac_part = arg_val.fract();
-            let epsilon = 2f64.powi(-52);
-            if (frac_part.abs() - 0.5).abs() < epsilon {
+            if frac_part.abs() == 0.5 {
                 // We should ceil it.
                 arg_val.ceil()
             } else {

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -523,6 +523,9 @@ fn test_fold_math_functions_round() {
     test_same_value("Math.round(Math.random())");
     test_value("Math.round(NaN)", "NaN");
     test_value("Math.round(3)", "3");
+    test_value("Math.round(0.49999999999999994)", "0");
+    test_value("Math.round(0.5)", "1");
+    test_value("Math.round(-0.5)", "-0");
     test_value("Math.round(3.5)", "4");
     test_value("Math.round(-3.5)", "-3");
 }


### PR DESCRIPTION
[ECMA-262 §21.3.2.29, `Math.round`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.round).

- If `0 < n < 0.5`, return `+0`.
- If `-0.5 ≤ n < -0`, return `-0`.
- Otherwise choose the closest integer, preferring `+∞` only for an actual tie.
