### PR TITLE
fix(allocator): require Sync allocator for Drain Send

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -2750,9 +2750,11 @@ impl<'a, 's, T: 'a + 's + fmt::Debug, A: Alloc> fmt::Debug for Drain<'a, 's, T, 
     }
 }
 
-// TODO: Should these also require `A: Send` / `A: Sync` bounds?
+// SAFETY: Shared access to a `Drain` only provides shared access to its remaining `T`s.
 unsafe impl<T: Sync, A: Alloc> Sync for Drain<'_, '_, T, A> {}
-unsafe impl<T: Send, A: Alloc> Send for Drain<'_, '_, T, A> {}
+// SAFETY: `Drain` holds exclusive access to the source `Vec`. `T: Send` permits moving its
+// remaining items, and `A: Sync` permits accessing the referenced allocator from another thread.
+unsafe impl<T: Send, A: Alloc + Sync> Send for Drain<'_, '_, T, A> {}
 
 impl<T, A: Alloc> Iterator for Drain<'_, '_, T, A> {
     type Item = T;


### PR DESCRIPTION
## Summary

- require the allocator behind `vec2::Drain` to implement `Sync` before the drain can implement `Send`
- document the safety requirements for the manual `Send` and `Sync` implementations
- prevent arena-backed `Splice` values from inheriting an unsound `Send` implementation

## Why this is necessary

`Drain` holds exclusive access to its source `Vec` through a raw pointer. The vector, in turn, retains a shared reference to its allocator. Its manual `Send` implementation previously required only `T: Send`, so it erased the allocator constraint that Rust would normally derive from that shared reference.

This is especially important for `Splice`. A `Splice` contains a `Drain`, so it automatically inherited `Send` whenever its replacement iterator was also `Send`. Dropping `Splice` can extend or grow the source vector and can allocate a temporary vector through the originating allocator. Sending an arena-backed splice to another thread therefore allowed its destructor to allocate through the arena while the original thread could also allocate through the same arena. Oxc's arena uses unsynchronized interior mutation for its allocation cursor and is deliberately not `Sync`, so concurrent allocation is undefined behavior.

The correct allocator bound is `A: Sync`, rather than `A: Send`: the allocator value itself is not moved into the destination thread; a shared `&A` retained by the vector is accessed there. `Sync` is precisely the guarantee required to use that shared reference safely across threads.

Oxc's `Arena` is `Send` but not `Sync`, so this bound makes arena-backed drains and splices non-`Send`. A future allocator with synchronized shared access can still opt into the existing behavior by implementing `Sync`.

The `Drain` `Sync` implementation does not need the allocator bound. Sharing `&Drain` only exposes shared access to the remaining elements; iterator mutation and destruction still require ownership or mutable access.
