### PR TITLE
fix(linter/unicorn/prefer-set-size): ignore shadowed `Set` constructors

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -4,6 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -131,46 +132,27 @@ fn is_array_from_call(call_expr: &CallExpression) -> bool {
 }
 
 fn is_set<'a>(maybe_set: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
-    if let Expression::NewExpression(new_expr) = maybe_set {
-        if let Expression::Identifier(identifier) = &new_expr.callee {
-            return identifier.name == "Set";
-        }
-        return false;
+    if is_new_set(maybe_set, ctx) {
+        return true;
     }
 
-    let Expression::Identifier(ident) = maybe_set else {
-        return false;
-    };
-
-    let Some(maybe_decl) = get_declaration_of_variable(ident, ctx) else {
-        return false;
-    };
-
-    let AstKind::VariableDeclarator(var_decl) = maybe_decl.kind() else {
-        return false;
-    };
-
-    if !variable_declaration_kind(var_decl, ctx).is_const() {
-        return false;
+    if let Expression::Identifier(ident) = maybe_set
+        && let Some(maybe_decl) = get_declaration_of_variable(ident, ctx)
+        && let AstKind::VariableDeclarator(var_decl) = maybe_decl.kind()
+        && variable_declaration_kind(var_decl, ctx).is_const()
+        && var_decl.id.is_binding_identifier()
+        && let Some(init) = &var_decl.init
+    {
+        return is_new_set(init, ctx);
     }
-
-    if !var_decl.id.is_binding_identifier() {
-        return false;
-    }
-
-    let Some(init) = &var_decl.init else {
-        return false;
-    };
-
-    is_new_set(init)
+    false
 }
 
-fn is_new_set(expr: &Expression) -> bool {
-    if let Expression::NewExpression(new_expr) = expr {
-        if let Expression::Identifier(identifier) = &new_expr.callee {
-            return identifier.name == "Set";
-        }
-        return false;
+fn is_new_set(expr: &Expression, ctx: &LintContext) -> bool {
+    if let Expression::NewExpression(new_expr) = expr
+        && let Expression::Identifier(identifier) = &new_expr.callee
+    {
+        return identifier.name == "Set" && identifier.is_global_reference(ctx.scoping());
     }
     false
 }
@@ -213,6 +195,7 @@ fn test() {
         "const [foo] = new Set([]);Array.from(foo).length;",
         "var foo = new Set(); var foo = new Set(); Array.from(foo).length",
         "NotArray.from(new Set(array)).length",
+        "const Set = class { constructor() { return []; } }; [...new Set(array)].length",
     ];
 
     let fail = vec![


### PR DESCRIPTION
## Summary

- verify that new Set constructors resolve to the intrinsic global before reporting or fixing
- preserve detection for direct constructions and const-bound Set instances
- add regression coverage for a locally shadowed constructor that returns an array