### PR TITLE
fix(linter): hide tsgolint console window on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "smallvec",
  "unicode-segmentation",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -79,7 +79,11 @@ unicode-segmentation = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Threading"] }
+windows-sys = { workspace = true, features = [
+  "Win32_Foundation",
+  "Win32_System_Console",
+  "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -78,7 +78,9 @@ smallvec = { workspace = true }
 unicode-segmentation = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_System_Threading"] }
+
 [dev-dependencies]
 insta = { workspace = true }
 markdown = { workspace = true }
-

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -379,10 +379,15 @@ impl TsGoLintState {
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt;
-            use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
+            use windows_sys::Win32::System::{
+                Console::GetConsoleWindow, Threading::CREATE_NO_WINDOW,
+            };
 
-            // `oxlint` may be launched by a GUI process with no console attached.
-            cmd.creation_flags(CREATE_NO_WINDOW);
+            // SAFETY: `GetConsoleWindow` has no preconditions.
+            if unsafe { GetConsoleWindow() }.is_null() {
+                // `oxlint` may be launched by a GUI process with no console attached.
+                cmd.creation_flags(CREATE_NO_WINDOW);
+            }
         }
 
         let mut child = match cmd.spawn() {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -376,6 +376,15 @@ impl TsGoLintState {
             cmd.arg(format!("-allocs={allocs_file}"));
         }
 
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
+
+            // `oxlint` may be launched by a GUI process with no console attached.
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {


### PR DESCRIPTION
## Summary

While using type-aware linting in the Oxc VS Code extension, I noticed that Windows Terminal briefly appeared and disappeared on every TypeScript edit. My relevant setup was:

- Oxc VS Code extension 1.60.0
- Oxlint 1.79.0
- oxlint-tsgolint 7.0.2001
- VS Code 1.134.0
- Windows 11 10.0.26200
- `oxc.typeAware: true`
- `oxc.useExecPath: true`

Disabling `oxc.typeAware` stopped every console launch, which narrowed the behavior to the tsgolint integration.

## Investigation

I traced the processes created by an edit and found this chain:

```text
Code.exe ... oxlint --lsp
└─ cmd.exe ... tsgolint.cmd headless -fix -fix-suggestions
   └─ conhost.exe
      └─ OpenConsole.exe / WindowsTerminal.exe
```

To determine whether the npm shim was responsible, I set `OXLINT_TSGOLINT_PATH` directly to the native `@oxlint-tsgolint/win32-x64/tsgolint.exe`. The terminal still flashed, so the `.cmd` shim adds a process but is not the root cause.

I also found that launching the same Oxlint LSP through a normal `node.exe` parent did not create a new console. The difference is that Electron's GUI-subsystem `Code.exe` has no console for the console-subsystem tsgolint child to inherit. Oxlint was spawning that child with an ordinary `std::process::Command::spawn()`, so Windows allocated a visible console.

Finally, I reproduced the issue with the older Vite+ 0.2.5 / Oxlint 1.73.0 / oxlint-tsgolint 0.24.0 stack, ruling out a recent tsgolint package regression.

## Fix

Apply `CREATE_NO_WINDOW` at the point where Oxlint directly spawns tsgolint:

- scope the creation flag and `windows-sys` dependency to Windows
- preserve all existing tsgolint arguments and stdin/stdout/stderr piping
- leave Unix behavior unchanged

Manually tested in VS Code by setting `oxc.path.oxlint` in `settings.json` to a release build of this branch; type-aware diagnostics appeared on file edits and no console window appeared.

## AI disclosure

This issue was investigated and fixed with assistance from OpenAI Codex. I reviewed and tested the changes and take full responsibility for the contribution.