### PR TITLE
fix(semantic): validate chained continue labels

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -848,15 +848,11 @@ pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<
             }
             AstKind::LabeledStatement(labeled_statement) => match &stmt.label {
                 Some(label) if label.name == labeled_statement.label.name => {
-                    if matches!(
-                        labeled_statement.body,
-                        Statement::LabeledStatement(_)
-                            | Statement::DoWhileStatement(_)
-                            | Statement::WhileStatement(_)
-                            | Statement::ForStatement(_)
-                            | Statement::ForInStatement(_)
-                            | Statement::ForOfStatement(_)
-                    ) {
+                    let mut target = &labeled_statement.body;
+                    while let Statement::LabeledStatement(nested) = target {
+                        target = &nested.body;
+                    }
+                    if target.is_iteration_statement() {
                         break;
                     }
                     return ctx.error(diagnostics::invalid_label_non_iteration(

--- a/tasks/coverage/misc/fail/continue-label-chain-non-iteration.js
+++ b/tasks/coverage/misc/fail/continue-label-chain-non-iteration.js
@@ -1,0 +1,3 @@
+a: b: {
+    continue a;
+}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 80/80 (100.00%)
 Positive Passed: 80/80 (100.00%)
-Negative Passed: 167/167 (100.00%)
+Negative Passed: 168/168 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -198,6 +198,17 @@ Negative Passed: 167/167 (100.00%)
    · ─────
    ╰────
   help: Either remove this `await` or add the `async` keyword to the enclosing function
+
+  × A `continue` statement can only jump to a label of an enclosing `for`, `while` or `do while` statement.
+   ╭─[misc/fail/continue-label-chain-non-iteration.js:1:1]
+ 1 │ a: b: {
+   · ┬
+   · ╰── This is an non-iteration statement
+ 2 │     continue a;
+   ·              ┬
+   ·              ╰── for this label
+ 3 │ }
+   ╰────
 
   × Encountered diff marker
     ╭─[misc/fail/diff-markers.js:10:1]


### PR DESCRIPTION
## Summary

- follow chained labels to their terminal statement when validating labeled `continue`
- reject label chains that terminate in a non-iteration statement
- add a focused negative coverage fixture and update the parser coverage snapshot
