### PR TITLE
feat(oxlint): add --with-minified to opt out of the minified filename skip

### DIFF
--- a/apps/oxlint/src/command/ignore.rs
+++ b/apps/oxlint/src/command/ignore.rs
@@ -26,6 +26,10 @@ pub struct IgnoreOptions {
 
     #[bpaf(switch, hide_usage, help(NO_IGNORE_HELP))]
     pub no_ignore: bool,
+
+    /// Lint files whose name looks minified, e.g. `*.min.js` (skipped by default)
+    #[bpaf(switch, hide_usage)]
+    pub with_minified: bool,
 }
 
 #[cfg(test)]
@@ -44,6 +48,7 @@ mod ignore_options {
         let options = get_ignore_options(".");
         assert_eq!(options.ignore_path, OsString::from(".eslintignore"));
         assert!(!options.no_ignore);
+        assert!(!options.with_minified);
         assert!(options.ignore_pattern.is_empty());
     }
 
@@ -57,6 +62,12 @@ mod ignore_options {
     fn no_ignore() {
         let options = get_ignore_options("--no-ignore foo.js");
         assert!(options.no_ignore);
+    }
+
+    #[test]
+    fn with_minified() {
+        let options = get_ignore_options("--with-minified foo.js");
+        assert!(options.with_minified);
     }
 
     #[test]

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -24,11 +24,14 @@ pub struct Walk {
     inner: ignore::WalkParallel,
     /// The file extensions to include during the traversal.
     extensions: Extensions,
+    /// Whether to include files whose name looks minified, e.g. `*.min.js`.
+    with_minified: bool,
 }
 
 struct WalkBuilder {
     sender: mpsc::Sender<Vec<Arc<OsStr>>>,
     extensions: Extensions,
+    with_minified: bool,
 }
 
 impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
@@ -37,6 +40,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
             paths: vec![],
             sender: self.sender.clone(),
             extensions: self.extensions.clone(),
+            with_minified: self.with_minified,
         })
     }
 }
@@ -45,6 +49,7 @@ struct WalkCollector {
     paths: Vec<Arc<OsStr>>,
     sender: mpsc::Sender<Vec<Arc<OsStr>>>,
     extensions: Extensions,
+    with_minified: bool,
 }
 
 impl Drop for WalkCollector {
@@ -65,7 +70,7 @@ impl ignore::ParallelVisitor for WalkCollector {
                 {
                     return ignore::WalkState::Skip;
                 }
-                if Walk::is_wanted_entry(&entry, &self.extensions) {
+                if Walk::is_wanted_entry(&entry, &self.extensions, self.with_minified) {
                     self.paths.push(entry.path().as_os_str().into());
                 }
                 ignore::WalkState::Continue
@@ -112,12 +117,13 @@ impl Walk {
             // Use the same thread count as rayon (controlled by `--threads`)
             .threads(rayon::current_num_threads())
             .build_parallel();
-        Self { inner, extensions: Extensions::default() }
+        Self { inner, extensions: Extensions::default(), with_minified: options.with_minified }
     }
 
     pub fn paths(self) -> Vec<Arc<OsStr>> {
         let (sender, receiver) = mpsc::channel::<Vec<Arc<OsStr>>>();
-        let mut builder = WalkBuilder { sender, extensions: self.extensions };
+        let mut builder =
+            WalkBuilder { sender, extensions: self.extensions, with_minified: self.with_minified };
         self.inner.visit(&mut builder);
         drop(builder);
         receiver.into_iter().flatten().collect()
@@ -129,7 +135,7 @@ impl Walk {
         self
     }
 
-    fn is_wanted_entry(dir_entry: &DirEntry, extensions: &Extensions) -> bool {
+    fn is_wanted_entry(dir_entry: &DirEntry, extensions: &Extensions, with_minified: bool) -> bool {
         let Some(file_type) = dir_entry.file_type() else { return false };
         if file_type.is_dir() {
             return false;
@@ -137,7 +143,7 @@ impl Walk {
         let Some(file_name) = dir_entry.path().file_name() else { return false };
         let file_name = file_name.to_string_lossy();
         let file_name = file_name.as_ref();
-        if [".min.", "-min.", "_min."].iter().any(|e| file_name.contains(e)) {
+        if !with_minified && [".min.", "-min.", "_min."].iter().any(|e| file_name.contains(e)) {
             return false;
         }
         let Some(extension) = dir_entry.path().extension() else { return false };
@@ -179,6 +185,7 @@ mod test {
             no_ignore: false,
             ignore_path: OsString::from(".eslintignore"),
             ignore_pattern: vec![],
+            with_minified: false,
         }
     }
 
@@ -190,6 +197,7 @@ mod test {
             no_ignore: false,
             ignore_path: OsString::from(".gitignore"),
             ignore_pattern: vec![],
+            with_minified: false,
         };
 
         let override_builder = OverrideBuilder::new("/").build().unwrap();
@@ -217,5 +225,25 @@ mod test {
         fs::write(temp_path.join(".jj").join("ignored.js"), "debugger;").unwrap();
 
         assert_eq!(collect_js_paths(temp_path, &empty_ignore_options()), vec!["included.js"]);
+    }
+
+    #[test]
+    fn test_walk_skips_minified_files_unless_opted_in() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("included.js"), "debugger;").unwrap();
+        fs::write(temp_path.join("bundle.min.js"), "debugger;").unwrap();
+        fs::write(temp_path.join("a-min.js"), "debugger;").unwrap();
+        fs::write(temp_path.join("a_min.js"), "debugger;").unwrap();
+
+        assert_eq!(collect_js_paths(temp_path, &empty_ignore_options()), vec!["included.js"]);
+
+        let with_minified = IgnoreOptions { with_minified: true, ..empty_ignore_options() };
+
+        assert_eq!(
+            collect_js_paths(temp_path, &with_minified),
+            vec!["a-min.js", "a_min.js", "bundle.min.js", "included.js"]
+        );
     }
 }

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -105,6 +105,8 @@ Arguments:
   The supported syntax is the same as for `.eslintignore` and `.gitignore` files. You should quote your patterns in order to avoid shell interpretation of glob patterns.
 - **`    --no-ignore`** &mdash; 
   Disable excluding files from `.eslintignore` files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
+- **`    --with-minified`** &mdash; 
+  Lint files whose name looks minified, e.g. `*.min.js` (skipped by default)
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -63,6 +63,8 @@ Ignore Files
                               `.eslintignore`)
         --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path
                               flags and --ignore-pattern flags
+        --with-minified       Lint files whose name looks minified, e.g. `*.min.js` (skipped by
+                              default)
 
 Handle Warnings
         --quiet               Disable reporting on warnings, only errors are reported


### PR DESCRIPTION
> Disclosure per the [AI usage policy](https://github.com/oxc-project/oxc/blob/main/CONTRIBUTING.md#ai-usage-policy): this PR was drafted with AI assistance. Every command, output, and code reference below was run and verified by me before submitting, and I am responsible for its content.

Closes #26163

`Walk::is_wanted_entry` unconditionally drops any file whose basename contains `.min.`, `-min.` or `_min.`. The check sits outside the `if !options.no_ignore { … }` block, so no ignore layer, flag or explicit path reaches it — a source file where `min` means *minimum* is silently never linted, with no diagnostic and a zero exit code.

This adds `with_minified: bool` to `IgnoreOptions` as a `#[bpaf(switch, hide_usage)]` (giving `--with-minified`), threads it into `Walk` alongside `extensions`, and guards the existing filter with `!with_minified`. #26163 has the full case and the exact shape of the trap.

### The `oxfmt` precedent

This is the shape `oxfmt` already uses for its own hardcoded skip — [`apps/oxfmt/src/cli/command.rs`](https://github.com/oxc-project/oxc/blob/main/apps/oxfmt/src/cli/command.rs#L155-L164):

```rust
/// Format code in node_modules directory (skipped by default)
#[bpaf(switch, hide_usage)]
pub with_node_modules: bool,
```

threaded through its walker into `is_ignored_dir(dir_name, with_node_modules)` in `apps/oxfmt/src/cli/walk.rs`. `--with-minified` is the same flag for the same kind of skip.

### Default behavior is unchanged

Scratch directory with `a-min.ts`, `a.min.ts`, `a_min.ts` and `a-plain.ts`, each containing `debugger;`:

```
$ oxlint --no-ignore src
  ! eslint(no-debugger): `debugger` statement is not allowed
   ,-[src/a-plain.ts:2:1]
Found 1 warning and 0 errors.
Finished in 36ms on 1 file with 96 rules using 10 threads.

$ oxlint --no-ignore --with-minified src
  ! eslint(no-debugger) ... src/a-min.ts, src/a-plain.ts, src/a_min.ts, src/a.min.ts
Found 4 warnings and 0 errors.
Finished in 14ms on 4 files with 96 rules using 10 threads.
```

Without the flag only `a-plain.ts` is linted; with it, all four. Nothing else about the walk changes.

### It fixes a real repo

On the TypeScript monorepo where I hit this, a source file named `criteria-allocation-balance-min.ts` and its colocated test were both invisible to oxlint. In that directory the default run reports `on 24 files` and `--with-minified` reports `on 25 files`. A deliberately planted `no-floating-promises` violation in the skipped file goes unreported by default and is caught with the flag.

### Tests

```
test walk::test::test_walk_skips_minified_files_unless_opted_in ... ok
test command::ignore::ignore_options::with_minified ... ok
```

The new `walk.rs` test asserts both halves of the contract (default skips the three minified spellings; `with_minified: true` collects all four files). `cargo test -p oxlint --lib walk` and `--lib command::ignore::ignore_options` are green, as is `cargo test -p website_linter --all-features` (8 passed) — the two `tasks/website_linter` CLI snapshots are regenerated here for the new flag.

---

I left `options.withMinified` out to keep this minimal — happy to add the mirroring config key in this PR if you want `.oxlintrc.json` to reflect the flag.
