### PR TITLE
fix(linter/no-array-constructor): insert a semicolon when the fix would be an ASI hazard

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -8,7 +8,7 @@ use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 use oxc_str::static_ident;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, ast_util, context::LintContext, rule::Rule};
 
 fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid calls to the `Array` constructor")
@@ -96,7 +96,12 @@ impl Rule for NoArrayConstructor {
                 } else {
                     ctx.source_range(Span::new(arguments[0].span().start, span.end - 1))
                 };
-                fixer.replace(span, format!("[{replacement}]"))
+                // A `[` opening an expression statement continues the previous line when
+                // that line ends without a semicolon: `foo` then `Array()` on the next
+                // line would be rewritten to `[]` directly under `foo`, i.e. a member
+                // access on it, which does not even parse.
+                let semi = if ast_util::could_be_asi_hazard(node, ctx) { ";" } else { "" };
+                fixer.replace(span, format!("{semi}[{replacement}]"))
             });
         }
     }
@@ -256,7 +261,18 @@ fn test() {
         ("Array(x, y);", "[x, y];"),
         ("new Array(0, 1, 2);", "[0, 1, 2];"),
         ("Array(0, 1, 2);", "[0, 1, 2];"),
-        // TODO: These currently produce invalid syntax, need to fix the fixer.
+        // A statement-initial `[` continues the line above when it has no semicolon.
+        ("foo\nArray()", "foo\n;[]"),
+        ("foo\nArray(1, 2)", "foo\n;[1, 2]"),
+        ("foo\nnew Array()", "foo\n;[]"),
+        ("foo;\nArray()", "foo;\n[]"),
+        ("Array()", "[]"),
+        ("if (x) Array()", "if (x) []"),
+        // TODO: these no longer produce invalid syntax, but they still differ: after a
+        // `}) as Fn` line the fixer now inserts a `;` that the expected output below
+        // does not have. `[` after a type position is read as an array type (`Fn[]`),
+        // so the semicolon is not obviously wrong - the expectation needs a decision
+        // before these can be enabled.
         // (
         //     r#"
         //                 (function () {


### PR DESCRIPTION
## What

`eslint/no-array-constructor`'s fixer replaced the call with `[...]` unconditionally, so a `[` could land at the start of a line whose predecessor has no semicolon:

```js
foo
Array()
```

`oxlint --fix` rewrote that to

```js
foo
[]
```

which is a member access on `foo` and does not parse — `Unexpected token`. The fix is applied to the file, so the result is a source file the user can no longer build.

This is not a hypothetical: the linter's own fixer harness catches it. Adding `("foo\nArray()", …)` to the fix table on `main` fails with

```
Linter fixer produced invalid syntax.
Input code:  foo\nArray()
Fixed code:  foo\n[]
Parse errors: "Unexpected token"
```

The two cases at the bottom of that table were commented out with *"TODO: These currently produce invalid syntax, need to fix the fixer."* rather than fixed, so nothing in CI was exercising it.

## Why this shape

`ast_util::could_be_asi_hazard` already answers exactly this question, and every other fixer that can emit a statement-initial `[` calls it:

| rule | uses helper |
|---|---|
| `unicorn/no-new-array` | ✅ |
| `unicorn/prefer-spread` | ✅ |
| `unicorn/no-negation-in-equality-check` | ✅ |
| `unicorn/prefer-response-static-json` | ✅ |
| `shared/no-negated-condition` | ✅ |
| **`eslint/no-array-constructor`** | ❌ — this PR |

I checked the other fixers that emit a leading `[` (`no-div-regex`, `no-iterator`, `consistent-empty-array-spread`, `no-single-promise-in-promise-methods`); none of them can be at statement start, so this rule was the only gap. That also means no new machinery — one call to the helper the codebase already trusts.

## Tests

Six cases added to the fix table, covering both directions so this cannot regress into over-inserting either:

```rust
("foo\nArray()",     "foo\n;[]"),
("foo\nArray(1, 2)", "foo\n;[1, 2]"),
("foo\nnew Array()", "foo\n;[]"),
("foo;\nArray()",    "foo;\n[]"),   // already terminated -> no semicolon
("Array()",          "[]"),          // start of file -> no semicolon
("if (x) Array()",   "if (x) []"),   // unbraced body -> no semicolon
```

The last two matter because `could_be_asi_hazard` deliberately returns `false` for them; without them a naive "always prepend `;`" would pass.

- **Revert-checked**: with only the `could_be_asi_hazard` call removed and the tests kept, the harness fails with `Linter fixer produced invalid syntax`.
- `cargo test -p oxc_linter --lib` — **1222 passed, 0 failed**.
- `cargo fmt --check` and `cargo clippy -p oxc_linter --all-targets` clean.
- No snapshot changed.

## The commented-out cases, deliberately still commented

They no longer produce invalid syntax, but they still differ from their recorded expectation in one place: after

```ts
}) as Fn
Array()
```

the fixer now inserts `;`, while the expected output has none. `[` following a type position is read as an array type (`Fn[]`), so I don't think the semicolon is obviously wrong there — but changing a recorded expectation is your call, not mine, so I left them commented and replaced the stale TODO with a note saying what actually blocks them now. Happy to enable them either way once you say which output you want.

---

*Found by sweeping the linter for fixers that can emit a statement-initial `[`, after noticing the `no-array-constructor` TODO.*

**AI disclosure:** this change was prepared with the assistance of Claude Code. I reviewed the change and ran the verification above before opening, and I stand behind them as my own.

*Branch note: based on an older `main` because the token used here lacks the `workflow` scope needed to push newer upstream commits touching `.github/workflows/` (the fork cannot be synced for the same reason). `no_array_constructor.rs` is identical on both bases and `could_be_asi_hazard` is unchanged, so it applies to current `main` as-is — happy to rebase.*
