### PR TITLE
refactor(semantic): simplify `resolve_references_for_current_scope`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -740,44 +740,33 @@ impl<'a> SemanticBuilder<'a> {
     /// list for later resolution by `resolve_all_references` (which handles
     /// forward references to declarations not yet visited).
     fn resolve_references_for_current_scope(&mut self, unresolved_start: usize) {
-        // Process in-place using a retain-style write-cursor — no temporary
-        // `Vec`. Reads each entry by value out of the flat list (all fields are
-        // `Copy`), so calling `try_resolve_reference` (which takes `&mut self`)
-        // doesn't conflict with the index read.
-        let end = self.unresolved_references.len();
-        if end <= unresolved_start {
-            return;
-        }
-        let mut write_idx = unresolved_start;
-        for read_idx in unresolved_start..end {
-            let mut unresolved = self.unresolved_references.get(read_idx);
+        let current_scope_id = self.current_scope_id;
+        let parent_scope_id = self
+            .scoping
+            .scope_parent_id(current_scope_id)
+            .expect("function and catch parameter scopes always have a parent");
 
+        // Take the list out of `self` while resolving, so the closure can call `&mut self`
+        // methods. Resolution never pushes new unresolved references, so nothing is lost.
+        let mut unresolved_references = mem::take(&mut self.unresolved_references);
+        unresolved_references.retain_from(unresolved_start, |unresolved| {
             // Parameter decorators are visited in an outer class scope. Leave those references
             // for final resolution because the current function is not on their scope chain.
-            let is_in_current_scope = unresolved.lookup_scope_id == self.current_scope_id
-                || self
-                    .scoping
-                    .scope_is_descendant_of(unresolved.lookup_scope_id, self.current_scope_id);
-            if !is_in_current_scope {
-                self.unresolved_references.set(write_idx, unresolved);
-                write_idx += 1;
-                continue;
+            let lookup_scope_id = unresolved.lookup_scope_id;
+            if lookup_scope_id != current_scope_id
+                && !self.scoping.scope_is_descendant_of(lookup_scope_id, current_scope_id)
+            {
+                return true;
             }
-
-            if self.walk_up_resolve_reference(unresolved, self.current_scope_id) {
-                continue;
+            if self.walk_up_resolve_reference(*unresolved, current_scope_id) {
+                return false;
             }
-
             // Skip this function body during final resolution. An enclosing parameter resolution
             // may still resolve the reference before advancing the boundary again.
-            unresolved.lookup_scope_id = self
-                .scoping
-                .scope_parent_id(self.current_scope_id)
-                .expect("function and catch parameter scopes always have a parent");
-            self.unresolved_references.set(write_idx, unresolved);
-            write_idx += 1;
-        }
-        self.unresolved_references.truncate(write_idx);
+            unresolved.lookup_scope_id = parent_scope_id;
+            true
+        });
+        self.unresolved_references = unresolved_references;
     }
 
     pub(crate) fn add_redeclare_variable(

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -14,6 +14,7 @@ pub struct UnresolvedReference<'a> {
 /// Instead of maintaining per-scope hashmaps and merging them on scope exit (bubble-up),
 /// references are collected flat and resolved in a single pass after traversal (walk-up).
 /// This eliminates all hashmap drain+insert operations during scope exit.
+#[derive(Default)]
 pub struct UnresolvedReferences<'a> {
     /// The lookup scope initially matches the reference's recorded scope and advances past
     /// function bodies which are not visible to parameter references.
@@ -51,33 +52,15 @@ impl<'a> UnresolvedReferences<'a> {
         self.references.len()
     }
 
-    /// Read a reference by index, by value.
-    ///
-    /// Used by [`crate::SemanticBuilder::resolve_references_for_current_scope`]
-    /// to process the list in-place without allocating a temporary `Vec`. All
-    /// entry fields are `Copy`, so this hands the caller an owned value that's
-    /// detached from the underlying borrow.
-    ///
-    /// # Panics
-    /// Panics if `idx >= self.len()`.
+    /// Retain only the references in `self.references[start..]` for which `keep` returns `true`.
+    /// Like [`Vec::retain_mut`], but restricted to the suffix starting at `start`.
+    /// `keep` may modify the reference in place.
     #[inline]
-    pub(crate) fn get(&self, idx: usize) -> UnresolvedReference<'a> {
-        self.references[idx]
-    }
-
-    /// Overwrite the reference at `idx` (write-cursor support for in-place
-    /// processing).
-    ///
-    /// # Panics
-    /// Panics if `idx >= self.len()`.
-    #[inline]
-    pub(crate) fn set(&mut self, idx: usize, reference: UnresolvedReference<'a>) {
-        self.references[idx] = reference;
-    }
-
-    /// Truncate the list to `len`, removing references at the end.
-    #[inline]
-    pub(crate) fn truncate(&mut self, len: usize) {
-        self.references.truncate(len);
+    pub(crate) fn retain_from(
+        &mut self,
+        start: usize,
+        mut keep: impl FnMut(&mut UnresolvedReference<'a>) -> bool,
+    ) {
+        self.references.extract_if(start.., |reference| !keep(reference)).for_each(drop);
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/oxc-project/oxc/pull/26099: make it readable and easy to understand.