### PR TITLE
fix(semantic): skip body bindings in type parameters and `this` param

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -740,6 +740,10 @@ impl<'a> SemanticBuilder<'a> {
     /// list for later resolution by `resolve_all_references` (which handles
     /// forward references to declarations not yet visited).
     fn resolve_references_for_current_scope(&mut self, unresolved_start: usize) {
+        if self.unresolved_references.len() == unresolved_start {
+            return;
+        }
+
         let current_scope_id = self.current_scope_id;
         let parent_scope_id = self
             .scoping
@@ -2092,16 +2096,17 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             self.visit_ts_type_annotation(return_type);
         }
 
-        if func.params.has_parameter() || func.return_type.is_some() {
-            // `function foo({bar: identifier_reference}) {}`
-            //                     ^^^^^^^^^^^^^^^^^^^^
-            // `function foo<SomeType>(v: SomeType): SomeType { return v; }`
-            //                            ^^^^^^^^   ^^^^^^^^
-            // Parameter initializers must be resolved after all parameters have been declared.
-            // Param types and return type must be resolved after type parameters have been declared.
-            // In both cases, need to avoid binding to variables/types declared inside the function body.
-            self.resolve_references_for_current_scope(unresolved_start);
-        }
+        // `function foo({bar: identifier_reference}) {}`
+        //                     ^^^^^^^^^^^^^^^^^^^^
+        // `function foo<SomeType>(v: SomeType): SomeType { return v; }`
+        //                            ^^^^^^^^   ^^^^^^^^
+        // `function foo<T extends SomeType>(this: SomeType) {}`
+        //                         ^^^^^^^^        ^^^^^^^^
+        // Parameter initializers must be resolved after all parameters have been declared.
+        // Param types, return type, type parameter constraints and the `this` type must be
+        // resolved after type parameters have been declared.
+        // In all cases, need to avoid binding to variables/types declared inside the function body.
+        self.resolve_references_for_current_scope(unresolved_start);
 
         if let Some(body) = &func.body {
             self.visit_function_body(body);
@@ -2180,16 +2185,17 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             self.visit_ts_type_annotation(return_type);
         }
 
-        if expr.params.has_parameter() || expr.return_type.is_some() {
-            // `let foo = ({bar: identifier_reference}) => {};`
-            //                   ^^^^^^^^^^^^^^^^^^^^
-            // `let foo = <SomeType>(v: SomeType): SomeType => v;`
-            //                          ^^^^^^^^   ^^^^^^^^
-            // Parameter initializers must be resolved after all parameters have been declared.
-            // Param types and return type must be resolved after type parameters have been declared.
-            // In both cases, need to avoid binding to variables/types declared inside the function body.
-            self.resolve_references_for_current_scope(unresolved_start);
-        }
+        // `let foo = ({bar: identifier_reference}) => {};`
+        //                   ^^^^^^^^^^^^^^^^^^^^
+        // `let foo = <SomeType>(v: SomeType): SomeType => v;`
+        //                          ^^^^^^^^   ^^^^^^^^
+        // `let foo = <T extends SomeType>() => {};`
+        //                       ^^^^^^^^
+        // Parameter initializers must be resolved after all parameters have been declared.
+        // Param types, return type and type parameter constraints must be resolved after
+        // type parameters have been declared.
+        // In all cases, need to avoid binding to variables/types declared inside the function body.
+        self.resolve_references_for_current_scope(unresolved_start);
 
         self.visit_arrow_function_body(&expr.body);
 

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/functions/parameter-initializers.js
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/functions/parameter-initializers.js
@@ -1,0 +1,6 @@
+let g = 0;
+
+function f(a, b = a, c = g) {
+  var g = 1;
+  return [a, b, c];
+}

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/functions/parameter-initializers.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/functions/parameter-initializers.snap
@@ -1,0 +1,104 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/js/functions/parameter-initializers.js
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(Function)",
+        "id": 1,
+        "node": "Function(f)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(FunctionScopedVariable)",
+            "id": 2,
+            "name": "a",
+            "node": "FormalParameter(a)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 0,
+                "name": "a",
+                "node_id": 12,
+                "scope_id": 1
+              },
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 2,
+                "name": "a",
+                "node_id": 23,
+                "scope_id": 1
+              }
+            ]
+          },
+          {
+            "flags": "SymbolFlags(FunctionScopedVariable)",
+            "id": 3,
+            "name": "b",
+            "node": "FormalParameter(b)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 3,
+                "name": "b",
+                "node_id": 24,
+                "scope_id": 1
+              }
+            ]
+          },
+          {
+            "flags": "SymbolFlags(FunctionScopedVariable)",
+            "id": 4,
+            "name": "c",
+            "node": "FormalParameter(c)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 4,
+                "name": "c",
+                "node_id": 25,
+                "scope_id": 1
+              }
+            ]
+          },
+          {
+            "flags": "SymbolFlags(FunctionScopedVariable)",
+            "id": 5,
+            "name": "g",
+            "node": "VariableDeclarator(g)",
+            "references": []
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(BlockScopedVariable)",
+        "id": 0,
+        "name": "g",
+        "node": "VariableDeclarator(g)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Read)",
+            "id": 1,
+            "name": "g",
+            "node_id": 15,
+            "scope_id": 1
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Function)",
+        "id": 1,
+        "name": "f",
+        "node": "Function(f)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/this-parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/this-parameter.snap
@@ -1,0 +1,67 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/functions/this-parameter.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "TSTypeAliasDeclaration",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | Function)",
+        "id": 2,
+        "node": "Function(Foo)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeAlias)",
+            "id": 2,
+            "name": "T",
+            "node": "TSTypeAliasDeclaration",
+            "references": []
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 0,
+        "name": "T",
+        "node": "TSTypeAliasDeclaration",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "T",
+            "node_id": 10,
+            "scope_id": 2
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Function)",
+        "id": 1,
+        "name": "Foo",
+        "node": "Function(Foo)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/this-parameter.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/this-parameter.ts
@@ -1,0 +1,5 @@
+export type T = number;
+
+function Foo(this: T) {
+  type T = string;
+}

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/type-parameter-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/type-parameter-constraint.snap
@@ -1,0 +1,134 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/functions/type-parameter-constraint.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(StrictMode)",
+        "id": 1,
+        "node": "TSTypeAliasDeclaration",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 3,
+            "node": "TSTypeAliasDeclaration",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | Function)",
+        "id": 2,
+        "node": "Function(Foo)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 2,
+            "name": "U",
+            "node": "TSTypeParameter(U)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 1,
+                "name": "U",
+                "node_id": 22,
+                "scope_id": 2
+              }
+            ]
+          },
+          {
+            "flags": "SymbolFlags(TypeAlias)",
+            "id": 3,
+            "name": "T",
+            "node": "TSTypeAliasDeclaration",
+            "references": []
+          }
+        ]
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(StrictMode)",
+            "id": 5,
+            "node": "TSTypeAliasDeclaration",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
+        "id": 4,
+        "node": "ArrowFunctionExpression",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(TypeParameter)",
+            "id": 5,
+            "name": "U",
+            "node": "TSTypeParameter(U)",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Type)",
+                "id": 3,
+                "name": "U",
+                "node_id": 42,
+                "scope_id": 4
+              }
+            ]
+          },
+          {
+            "flags": "SymbolFlags(TypeAlias)",
+            "id": 6,
+            "name": "T",
+            "node": "TSTypeAliasDeclaration",
+            "references": []
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(StrictMode | Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(TypeAlias)",
+        "id": 0,
+        "name": "T",
+        "node": "TSTypeAliasDeclaration",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "T",
+            "node_id": 11,
+            "scope_id": 2
+          },
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 2,
+            "name": "T",
+            "node_id": 31,
+            "scope_id": 4
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Function)",
+        "id": 1,
+        "name": "Foo",
+        "node": "Function(Foo)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 4,
+        "name": "Bar",
+        "node": "VariableDeclarator(Bar)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/type-parameter-constraint.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/functions/type-parameter-constraint.ts
@@ -1,0 +1,11 @@
+export type T = number;
+
+function Foo<U extends T>() {
+  type T = string;
+  return null! as U;
+}
+
+const Bar = <U extends T>() => {
+  type T = string;
+  return null! as U;
+}


### PR DESCRIPTION
#26099 resolves parameter and signature references before visiting the function body, so they cannot bind to declarations that only exist inside the body. That early pass only ran when the function had parameters or a return type. Type parameter constraints and a `this` parameter type are visited before that check, so a function whose signature has references only in those positions skipped the pass. Its references then resolved after the body was visited and bound to body-local types.

## Example

```ts
type U = number;
function f<T extends U>() {
  type U = string;
  return null! as T;
}
```

Before this change, `U` in the constraint resolved to the body-local `type U = string`. TypeScript scopes local types to the function body, so it must resolve to the outer alias. The same happened for `function f(this: U) { type U = string }` and for arrow functions with type parameters.

The early pass now runs for every function and arrow function. It returns immediately when the signature produced no references, so the `has_parameter() || return_type.is_some()` condition, which approximated that check, is no longer needed.

Also adds a regression test for the compaction in `resolve_references_for_current_scope`: a resolved reference followed by an unresolved one must neither drop nor duplicate entries, and no existing test covered that ordering.

Verified with the semantic and transformer unit tests, Clippy, `cargo coverage -- semantic`, and transform conformance; no snapshots changed.

AI assistance: Claude Code was used to investigate, implement, and verify this change. The contributor is responsible for the submitted change.