### PR TITLE
feat(ecmascript): add `ConstantValue::is_strictly_equal`

### DIFF
--- a/crates/oxc_ecmascript/src/value.rs
+++ b/crates/oxc_ecmascript/src/value.rs
@@ -51,6 +51,14 @@ impl<'a> ConstantValue<'a> {
         }
     }
 
+    /// <https://tc39.es/ecma262/#sec-isstrictlyequal>
+    ///
+    /// The derived `PartialEq` already has the spec semantics: `NaN` is not equal to
+    /// itself, `+0` equals `-0`, and values of different types are never equal.
+    pub fn is_strictly_equal(&self, other: &Self) -> bool {
+        self == other
+    }
+
     pub fn into_string(self) -> Option<Cow<'a, str>> {
         match self {
             Self::String(s) => Some(s),
@@ -120,5 +128,40 @@ impl<'a> ToBoolean<'a> for ConstantValue<'a> {
             Self::Boolean(b) => Some(*b),
             Self::Null | Self::Undefined => Some(false),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn is_strictly_equal() {
+        use ConstantValue::{BigInt as Big, Boolean, Null, Number, String, Undefined};
+
+        assert!(Number(1.0).is_strictly_equal(&Number(1.0)));
+        assert!(Number(0.0).is_strictly_equal(&Number(-0.0)));
+        assert!(!Number(f64::NAN).is_strictly_equal(&Number(f64::NAN)));
+        assert!(!Number(1.0).is_strictly_equal(&Number(2.0)));
+
+        assert!(Big(1.into()).is_strictly_equal(&Big(1.into())));
+        assert!(!Big(1.into()).is_strictly_equal(&Big(2.into())));
+
+        assert!(String("a".into()).is_strictly_equal(&String(Cow::Owned("a".to_string()))));
+        assert!(!String("a".into()).is_strictly_equal(&String("b".into())));
+
+        assert!(Boolean(true).is_strictly_equal(&Boolean(true)));
+        assert!(!Boolean(true).is_strictly_equal(&Boolean(false)));
+
+        assert!(Undefined.is_strictly_equal(&Undefined));
+        assert!(Null.is_strictly_equal(&Null));
+
+        // Values of different types are never strictly equal.
+        assert!(!Number(1.0).is_strictly_equal(&String("1".into())));
+        assert!(!Number(1.0).is_strictly_equal(&Boolean(true)));
+        assert!(!Number(1.0).is_strictly_equal(&Big(1.into())));
+        assert!(!Number(0.0).is_strictly_equal(&Null));
+        assert!(!Undefined.is_strictly_equal(&Null));
+        assert!(!String("".into()).is_strictly_equal(&Boolean(false)));
     }
 }


### PR DESCRIPTION
Folding a `switch` whose discriminant is a constant (#26141) needs to compare the discriminant's value against each case test. `oxc_ecmascript` only exposes strict equality through `binary_operation_evaluate_value(StrictEquality, left, right)` and the private `strict_equality_comparison`, both of which take expressions and re-evaluate the discriminant for every case. The minifier wants to evaluate it once and compare the resulting `ConstantValue`s.

`ConstantValue` already derives `PartialEq`, and that derived equality is exactly the spec's IsStrictlyEqual: `f64 ==` makes `NaN` unequal to itself and `+0` equal to `-0`, `BigInt`/`String`/`Boolean` compare by value, and different variants never compare equal. `is_strictly_equal` names that fact so call sites don't have to re-derive it or hand-roll a match over the variants. The unit test pins the cases that matter (`NaN`, `-0`, bigint, and every cross-type pair).
