### PR TITLE
fix(oxlint/lsp): provide `source.fixAll.oxc` code actions when requesting `source` code action

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -606,9 +606,9 @@ impl Tool for ServerLinter {
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
         let applying_kinds = match &params.context.only {
             Some(only) => {
-                // `source.fixAll.oxc` is a subset of `source.fixAll` and `source`.
-                // Remap `source` and `source.fixAll` to `source.fixAll.oxc` to avoid duplicate code actions.
-                // We ignore `source.fixAllDangerous.oxc` remap to `source` because it can break the user document.
+                // `source.fixAll.oxc` is a subset of `source.fixAll` (and therefore `source`).
+                // Remap `source`, `source.fixAll`, and `source.fixAll.oxc` to `source.fixAll` to avoid duplicate code actions.
+                // We intentionally do not remap `source.fixAllDangerous.oxc` because it can break the user document.
                 // Only provide `source.fixAllDangerous.oxc` if the client specifically requests it.
                 let mut seen = FxHashSet::default();
                 only.iter()

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -606,12 +606,16 @@ impl Tool for ServerLinter {
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
         let applying_kinds = match &params.context.only {
             Some(only) => {
-                // `source.fixAll` and `source.fixAll.oxc` should behave the same, filter duplicate out
+                // `source.fixAll.oxc` is a subset of `source.fixAll` and `source`.
+                // Remap `source` and `source.fixAll` to `source.fixAll.oxc` to avoid duplicate code actions.
+                // We ignore `source.fixAllDangerous.oxc` remap to `source` because it can break the user document.
+                // Only provide `source.fixAllDangerous.oxc` if the client specifically requests it.
                 let mut seen = FxHashSet::default();
                 only.iter()
                     .filter_map(|kind| {
                         if kind == &CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC
                             || kind == &CodeActionKind::SOURCE_FIX_ALL
+                            || kind == &CodeActionKind::SOURCE
                         {
                             if seen.contains(&CodeActionKind::SOURCE_FIX_ALL) {
                                 None
@@ -625,7 +629,10 @@ impl Tool for ServerLinter {
                     })
                     .collect::<Vec<_>>()
             }
-            // if `only` is not provided, only return quickfixes
+            // In version 1.0 of the protocol, there weren't any source or refactoring code actions.
+            // Code actions were solely used to (quick) fix code, not to write / rewrite code.
+            // So if a client asks for code actions without any kind, the standard quick fix code actions should be returned.
+            // https://github.com/microsoft/language-server-protocol/blob/8c26a839f86296448692b414cb35c0a8fbabe0e5/_specifications/lsp/3.18/language/codeAction.md
             None => vec![CodeActionKind::QUICKFIX],
         };
 

--- a/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
+++ b/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
@@ -263,6 +263,22 @@ if (bar == NaN) {}
 --------------------"
 `;
 
+exports[`LSP code actions > with code action only context > should handle source 1`] = `
+"--- FILE -----------
+context_only/test.ts
+--- Original Content ---------
+if (foo == NaN) {}
+if (bar == NaN) {}
+--- Code Actions ---------
+
+Title : fix all safe fixable oxlint issues
+Preferred: Yes
+Resulting Content:
+if (isNaN(foo)) {}
+if (isNaN(bar)) {}
+--------------------"
+`;
+
 exports[`LSP code actions > with code action only context > should handle source.fixAll 1`] = `
 "--- FILE -----------
 context_only/test.ts

--- a/apps/oxlint/test/lsp/code_action/code_action.test.ts
+++ b/apps/oxlint/test/lsp/code_action/code_action.test.ts
@@ -35,6 +35,7 @@ describe("LSP code actions", () => {
   describe("with code action only context", () => {
     it.each([
       ["quickfix"],
+      ["source"],
       ["source.fixAll"],
       ["source.fixAll.oxc"],
       ["source.fixAllDangerous.oxc"],


### PR DESCRIPTION
CodeActions kinds are hierarchical, so `source.fixAll` should call `source.fixAll.*` code actions, which are already done.
`oxlint --lsp` did miss that `source` should trigger `source.fixAll`, which should trigger `source.fixAll.oxc`.

We specially skip `source.fixAllDangerous` trigger for `source`, because this can break users text document. 
We do not pronounce a general `source` support, because there are many other `source.*` actions which could be expected by the client to be supported. 
We do not remove the `source.fixAll` in `initizilize` `codeActionProvider` result, to be compatibly with older clients which do not support the hierarchical search.

Documentation:
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionKind

Found by reviewing https://github.com/oxc-project/oxc-vscode/pull/310 with @kurtextrem
