### PR TITLE
refactor(oxlint/lsp): delay `String` Conversion for `FixedContent` to `CodeAction` properties

### DIFF
--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -24,14 +24,17 @@ fn fix_content_to_code_action(
     is_preferred: bool,
 ) -> CodeAction {
     CodeAction {
-        title: fixed_content.message,
+        title: fixed_content.message.into_owned(),
         kind: Some(CodeActionKind::QUICKFIX),
         is_preferred: Some(is_preferred),
         edit: Some(WorkspaceEdit {
             #[expect(clippy::disallowed_types)]
             changes: Some(std::collections::HashMap::from([(
                 uri,
-                vec![TextEdit { range: fixed_content.range, new_text: fixed_content.code }],
+                vec![TextEdit {
+                    range: fixed_content.range,
+                    new_text: fixed_content.code.into_owned(),
+                }],
             )])),
             ..WorkspaceEdit::default()
         }),
@@ -167,7 +170,10 @@ pub fn fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) -> Vec
             continue;
         }
 
-        text_edits.push(TextEdit { range: fixed_content.range, new_text: fixed_content.code });
+        text_edits.push(TextEdit {
+            range: fixed_content.range,
+            new_text: fixed_content.code.into_owned(),
+        });
     }
 
     remove_overlapping_edits(text_edits)
@@ -187,7 +193,10 @@ fn dangerous_fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) 
             continue;
         }
 
-        text_edits.push(TextEdit { range: fixed_content.range, new_text: fixed_content.code });
+        text_edits.push(TextEdit {
+            range: fixed_content.range,
+            new_text: fixed_content.code.into_owned(),
+        });
     }
 
     remove_overlapping_edits(text_edits)
@@ -241,8 +250,8 @@ mod tests {
         LinterCodeAction {
             range,
             fixed_content: vec![FixedContent {
-                message: "fix".to_string(),
-                code: String::new(),
+                message: "fix".into(),
+                code: "".into(),
                 range,
                 kind: FixKind::SafeFix,
                 lsp_kind: FixedContentKind::LintRule(OxcCode { scope: None, number: None }),
@@ -284,8 +293,8 @@ mod tests {
         LinterCodeAction {
             range: Range::default(),
             fixed_content: vec![FixedContent {
-                message: "remove unused import".to_string(),
-                code: String::new(),
+                message: "remove unused import".into(),
+                code: "".into(),
                 range: Range::new(Position::new(0, 0), Position::new(0, 10)),
                 kind,
                 lsp_kind: FixedContentKind::LintRule(OxcCode { scope: None, number: None }),

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -31,8 +31,8 @@ pub struct LinterCodeAction {
 
 #[derive(Debug, Clone)]
 pub struct FixedContent {
-    pub message: String,
-    pub code: String,
+    pub message: Cow<'static, str>,
+    pub code: Cow<'static, str>,
     pub range: Range,
     pub kind: FixKind,
     pub lsp_kind: FixedContentKind,
@@ -179,7 +179,7 @@ pub fn message_to_lsp_diagnostic(
                 fix.message = Some(alternative_fix_title);
             }
             fixed_content.push(fix_to_fixed_content(
-                &fix,
+                fix,
                 source_text,
                 FixedContentKind::LintRule(message.error.code.clone()),
             ));
@@ -190,7 +190,7 @@ pub fn message_to_lsp_diagnostic(
                     fix.message = Some(alternative_fix_title.clone());
                 }
                 fix_to_fixed_content(
-                    &fix,
+                    fix,
                     source_text,
                     FixedContentKind::LintRule(message.error.code.clone()),
                 )
@@ -207,18 +207,14 @@ pub fn message_to_lsp_diagnostic(
     Some(DiagnosticReport { diagnostic, code_action })
 }
 
-fn fix_to_fixed_content(fix: &Fix, source_text: &str, fix_kind: FixedContentKind) -> FixedContent {
+fn fix_to_fixed_content(fix: Fix, source_text: &str, fix_kind: FixedContentKind) -> FixedContent {
     let start_position = offset_to_position(fix.span.start, source_text);
     let end_position = offset_to_position(fix.span.end, source_text);
 
-    debug_assert!(
-        fix.message.is_some(),
-        "Fix message should be present. `message_to_lsp_diagnostic` should modify fixes to include messages."
-    );
-
     FixedContent {
-        message: fix.message.as_ref().map(std::string::ToString::to_string).unwrap_or_default(),
-        code: fix.content.to_string(),
+        message: fix.message.expect("Fix message should be present. `message_to_lsp_diagnostic` should modify lint fixes to include messages.
+        Unused Disable directives always calls `Fix.with_message`"),
+        code: fix.content,
         range: Range::new(start_position, end_position),
         kind: fix.kind,
         lsp_kind: fix_kind,
@@ -293,7 +289,7 @@ pub fn create_unused_directives_report(
                     span,
                     severity,
                     source_text,
-                    Some(&Fix::delete(fix_span).with_message(fix_message)),
+                    Some(Fix::delete(fix_span).with_message(fix_message)),
                 ));
             }
             RuleCommentType::Single(rules) => {
@@ -303,7 +299,7 @@ pub fn create_unused_directives_report(
                         rule.name_span,
                         severity,
                         source_text,
-                        Some(&rule.create_fix(source_text, span).with_message(fix_message)),
+                        Some(rule.create_fix(source_text, span).with_message(fix_message)),
                     ));
                 }
             }
@@ -337,7 +333,7 @@ fn build_unused_disable_diagnostic_report(
     span: Span,
     severity: DiagnosticSeverity,
     source_text: &str,
-    fix: Option<&Fix>,
+    fix: Option<Fix>,
 ) -> DiagnosticReport {
     let start_position = offset_to_position(span.start, source_text);
     let end_position = offset_to_position(span.end, source_text);

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -799,7 +799,6 @@ impl ServerLinter {
         // - inverted diagnostics (related spans for the diagnostics)
         // - diagnostics with span(0,0) and no fixes
         // - tsgolint internal diagnostics
-        // - unused directives diagnostics
         let mut code_actions = vec![];
         for report in reports {
             diagnostics.push(report.diagnostic);


### PR DESCRIPTION
**Before:**
Converting `Fix` to `FixContent` did convert `Cow` into `String` and stored into the `ServerLinter.code_action` Map, to get requested later by the client, where we convert `FixContent` to `CodeAction` (where we need the `String` format)

**After:**
Consume directly `Fix` `Cow` fields, and delay to conversion to `String` until the `CodeAction` is requested to be converted.
So only downside I see, is that `textDocument/codeAction` is requested more times than a `textDocument/diagnostic` request. So the conversion does happen more times, but get released quickly.