### PR TITLE
docs(linter): add short description to `vue/no-dupe-keys`

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -84,6 +84,7 @@ declare_oxc_lint!(
     correctness,
     version = "1.70.0",
     config = NoDupeKeys,
+    short_description = "Disallow duplication of field names.",
 );
 
 impl Rule for NoDupeKeys {


### PR DESCRIPTION
This rule was the only Vue rule missing a short description, so this fixes that.
