### PR TITLE
docs(linter): support a shared short description for jest/vitest rules

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::expect_expect::{DOCUMENTATION, ExpectExpectConfig},
+    rules::shared::expect_expect::{DOCUMENTATION, ExpectExpectConfig, SHORT_DESCRIPTION},
     utils::PossibleJestNode,
 };
 
@@ -17,6 +17,7 @@ declare_oxc_lint!(
     config = ExpectExpectConfig,
     docs = DOCUMENTATION,
     version = "0.0.12",
+    short_description = SHORT_DESCRIPTION,
 );
 
 impl Rule for ExpectExpect {

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -3,14 +3,21 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::no_disabled_tests::{DOCUMENTATION, run_on_jest_node},
+    rules::shared::no_disabled_tests::{DOCUMENTATION, SHORT_DESCRIPTION, run_on_jest_node},
     utils::PossibleJestNode,
 };
 
 #[derive(Debug, Default, Clone)]
 pub struct NoDisabledTests;
 
-declare_oxc_lint!(NoDisabledTests, jest, correctness, docs = DOCUMENTATION, version = "0.0.7",);
+declare_oxc_lint!(
+    NoDisabledTests,
+    jest,
+    correctness,
+    docs = DOCUMENTATION,
+    version = "0.0.7",
+    short_description = SHORT_DESCRIPTION,
+);
 
 impl Rule for NoDisabledTests {
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::valid_expect::{DOCUMENTATION, ValidExpectConfig},
+    rules::shared::valid_expect::{DOCUMENTATION, SHORT_DESCRIPTION, ValidExpectConfig},
 };
 
 #[derive(Debug, Default, Clone)]
@@ -17,6 +17,7 @@ declare_oxc_lint!(
     config = ValidExpectConfig,
     docs = DOCUMENTATION,
     version = "0.0.14",
+    short_description = SHORT_DESCRIPTION,
 );
 
 impl Rule for ValidExpect {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -28,6 +28,8 @@ fn expect_expect_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
+pub const SHORT_DESCRIPTION: &str = "Enforce that each test has at least one `expect()` call.";
+
 pub const DOCUMENTATION: &str = r"### What it does
 
 This rule triggers when there is no call made to `expect` in a test, ensure that there is at least one `expect` call made in a test.

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 
+pub const SHORT_DESCRIPTION: &str = "Disallow disabled tests.";
+
 pub const DOCUMENTATION: &str = r"### What it does
 
 This rule raises a warning about disabled tests.

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
@@ -23,6 +23,8 @@ fn valid_expect_diagnostic<S: Into<Cow<'static, str>>>(
     OxcDiagnostic::warn(x1).with_help(x2).with_label(span3)
 }
 
+pub const SHORT_DESCRIPTION: &str = "Enforce valid `expect()` usage.";
+
 pub const DOCUMENTATION: &str = r"### What it does
 
 Checks that `expect()` is called correctly.

--- a/crates/oxc_linter/src/rules/vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/expect_expect.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::expect_expect::{DOCUMENTATION, ExpectExpectConfig},
+    rules::shared::expect_expect::{DOCUMENTATION, ExpectExpectConfig, SHORT_DESCRIPTION},
     utils::PossibleJestNode,
 };
 
@@ -17,6 +17,7 @@ declare_oxc_lint!(
     config = ExpectExpectConfig,
     docs = DOCUMENTATION,
     version = "0.0.12",
+    short_description = SHORT_DESCRIPTION,
 );
 
 impl Rule for ExpectExpect {

--- a/crates/oxc_linter/src/rules/vitest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_disabled_tests.rs
@@ -3,14 +3,21 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::no_disabled_tests::{DOCUMENTATION, run_on_jest_node},
+    rules::shared::no_disabled_tests::{DOCUMENTATION, SHORT_DESCRIPTION, run_on_jest_node},
     utils::PossibleJestNode,
 };
 
 #[derive(Debug, Default, Clone)]
 pub struct NoDisabledTests;
 
-declare_oxc_lint!(NoDisabledTests, vitest, correctness, docs = DOCUMENTATION, version = "0.0.7",);
+declare_oxc_lint!(
+    NoDisabledTests,
+    vitest,
+    correctness,
+    docs = DOCUMENTATION,
+    version = "0.0.7",
+    short_description = SHORT_DESCRIPTION,
+);
 
 impl Rule for NoDisabledTests {
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/valid_expect.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::valid_expect::{DOCUMENTATION, ValidExpectConfig},
+    rules::shared::valid_expect::{DOCUMENTATION, SHORT_DESCRIPTION, ValidExpectConfig},
 };
 
 #[derive(Debug, Clone)]
@@ -23,6 +23,7 @@ declare_oxc_lint!(
     config = ValidExpectConfig,
     docs = DOCUMENTATION,
     version = "0.0.14",
+    short_description = SHORT_DESCRIPTION,
 );
 
 impl Rule for ValidExpect {

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -17,6 +17,15 @@ pub enum DocumentationSource {
     Path(syn::Path),
 }
 
+/// Short description source for a lint rule
+#[cfg(feature = "ruledocs")]
+pub enum ShortDescriptionSource {
+    /// Inline string literal
+    Inline(LitStr),
+    /// Reference to a shared short description constant
+    Path(syn::Path),
+}
+
 pub struct LintRuleMeta {
     name: Ident,
     // Whether this rule should be exposed to tsgolint integration
@@ -35,7 +44,8 @@ pub struct LintRuleMeta {
     /// The version of oxlint in which this rule was first available.
     version: LitStr,
     /// A short, one-line summary of what the rule does.
-    short_description: Option<LitStr>,
+    #[cfg(feature = "ruledocs")]
+    short_description: Option<ShortDescriptionSource>,
 }
 
 impl Parse for LintRuleMeta {
@@ -108,7 +118,8 @@ impl Parse for LintRuleMeta {
         let mut fix: Option<Ident> = None;
         let mut config: Option<Path> = None;
         let mut version: Option<LitStr> = None;
-        let mut short_description: Option<LitStr> = None;
+        #[cfg(feature = "ruledocs")]
+        let mut short_description: Option<ShortDescriptionSource> = None;
 
         // remaining options are `key = value` pairs, with the exception of
         // fix kinds. Those can be short-handed to just the fix kind
@@ -155,9 +166,18 @@ impl Parse for LintRuleMeta {
                     version.replace(input.parse()?);
                 }
                 // short_description = "One-line summary."
+                // or short_description = path::to::SHARED_SHORT_DESCRIPTION_CONSTANT
                 "short_description" => {
-                    input.parse::<Token!(=)>()?;
-                    short_description.replace(input.parse()?);
+                    #[cfg(feature = "ruledocs")]
+                    {
+                        input.parse::<Token!(=)>()?;
+                        if input.peek(LitStr) {
+                            short_description
+                                .replace(ShortDescriptionSource::Inline(input.parse()?));
+                        } else {
+                            short_description.replace(ShortDescriptionSource::Path(input.parse()?));
+                        }
+                    }
                 }
                 _ => {
                     if input.peek(Token!(=)) || fix.is_some() {
@@ -212,6 +232,7 @@ impl Parse for LintRuleMeta {
             used_in_test: false,
             config,
             version,
+            #[cfg(feature = "ruledocs")]
             short_description,
         })
     }
@@ -233,6 +254,7 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
         used_in_test,
         config,
         version,
+        #[cfg(feature = "ruledocs")]
         short_description,
     } = metadata;
 
@@ -313,7 +335,15 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
         }
     };
 
+    #[cfg(not(feature = "ruledocs"))]
+    let info_const: Option<proc_macro2::TokenStream> = None;
+
+    #[cfg(feature = "ruledocs")]
     let info_const = short_description.map(|short_description| {
+        let short_description = match short_description {
+            ShortDescriptionSource::Inline(lit) => quote! { #lit },
+            ShortDescriptionSource::Path(path) => quote! { #path },
+        };
         quote! {
             const INFO: RuleInfo = RuleInfo {
                 short_description: #short_description,


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Fable 5. Reviewed by me. This sets up the short_description to be added to the various rules shared between jest and vitest.

`declare_oxc_lint!` now accepts a path to a shared constant for `short_description`, mirroring how `docs = SHARED_DOCUMENTATION` works. Like `documentation`, the handling is gated behind the `ruledocs` feature.

A shared short description is added to `expect-expect`, `no-disabled-tests`, and `valid-expect`.

Rules where the wording legitimately differs per framework (e.g. `no-alias-methods`) can keep per-plugin string literals, which remain supported. Or we can opt to add the raw strings on every one of these rules and drop the shared short desc idea, I don't have a strong preference either way.

Once we decide and merge this, we can add the short descriptions for all the other remaining shared rules. We'll also need to split up the two remaining rules that are problematic (https://github.com/oxc-project/oxc/issues/23186), then we can expose the `short_description` field in the JSON rules formatter for use on the website's rules list view.