### PR TITLE
fix(minifier): do not inline switch-case lexical bindings across cases

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -21,15 +21,25 @@ impl<'a> PeepholeOptimizations {
         // constant and the boolean-falsy fact below. `None` for a non-constant or
         // absent initializer.
         let init_constant = decl.init.as_ref().and_then(|e| e.evaluate_value(ctx));
+        // Switch cases share one lexical environment. Jumping to a later case
+        // skips this initializer, so later reads can observe TDZ (#26174).
+        // Withhold every declaration-derived fact: the constant, freshness,
+        // and boolean-falsy (a withheld falsy constant would otherwise fold
+        // `if (x)` on the skipped-init path).
+        let lexical_in_switch_case =
+            declaration_kind.is_lexical() && Self::is_lexical_declaration_in_switch_case(ctx);
         // Whether the initializer is an explicit falsy constant (not the implicit
         // `undefined` of `var x;`, which `init_constant` leaves `None`). Fed to
         // `init_value`, which turns it into the `boolean_falsy` fact (see
         // `SymbolValue::boolean_falsy`).
-        let falsy_init = init_constant.as_ref().is_some_and(Self::is_falsy_constant);
-        let declaration_in_body_statement_list =
-            !declaration_kind.is_var() || Self::is_declaration_in_body_statement_list(ctx);
+        let falsy_init =
+            !lexical_in_switch_case && init_constant.as_ref().is_some_and(Self::is_falsy_constant);
+        let declaration_in_body_statement_list = !lexical_in_switch_case
+            && (!declaration_kind.is_var() || Self::is_declaration_in_body_statement_list(ctx));
         let value = if Self::is_for_statement_init(ctx) {
             // for-statement initializers have their value set by the for statement itself.
+            None
+        } else if lexical_in_switch_case {
             None
         } else if declaration_kind.is_var()
             && decl.init.is_some()
@@ -95,6 +105,26 @@ impl<'a> PeepholeOptimizations {
                 Ancestor::VariableDeclarationDeclarations(_)
                 | Ancestor::ExportDeclarationDeclaration(_) => {}
                 Ancestor::ProgramBody(_) | Ancestor::FunctionBodyStatements(_) => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    /// Whether a lexical declaration is a direct item of a switch-case
+    /// consequent, not nested in an inner block that would give it its own
+    /// scope.
+    ///
+    /// Switch cases share the switch's lexical environment, but initialization
+    /// only runs when that case is reached. Jumping to a later case therefore
+    /// skips the initializer and later reads observe TDZ (#26174):
+    /// `switch (a) { case 2: let x = 1; case 1: console.log(x) }`.
+    fn is_lexical_declaration_in_switch_case(ctx: &TraverseCtx<'a>) -> bool {
+        for ancestor in ctx.ancestors() {
+            match ancestor {
+                Ancestor::VariableDeclarationDeclarations(_)
+                | Ancestor::ExportDeclarationDeclaration(_) => {}
+                Ancestor::SwitchCaseConsequent(_) => return true,
                 _ => return false,
             }
         }

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -1,7 +1,8 @@
 use oxc_span::SourceType;
 
 use crate::{
-    CompressOptions, test_options, test_options_source_type, test_same_options, test_smallest,
+    CompressOptions, test_options, test_options_source_type, test_same_options, test_same_smallest,
+    test_smallest,
 };
 
 // https://github.com/oxc-project/oxc/issues/24531
@@ -403,6 +404,53 @@ fn r#const() {
 
     test_options("let foo = 1; log(foo)", "log(1)", &options);
     test_options("export let foo = 1; log(foo)", "export let foo = 1; log(1)", &options);
+}
+
+// https://github.com/oxc-project/oxc/issues/26174
+// Switch cases share one lexical environment, but jumping to a later case
+// skips a `let`/`const` initializer. Inlining that value into other cases
+// would replace a TDZ ReferenceError with the initialized value.
+#[test]
+fn switch_case_lexical_not_inlined_into_other_cases() {
+    // Exact reproduction: entering at `case 1` must throw, not log `1`.
+    test_same_smallest("switch (a) { case 2: let x = 1; case 1: console.log(x); }");
+    // `const` is normalized to `let`; the value still must not leak across cases.
+    test_smallest(
+        "switch (a) { case 2: const x = 1; case 1: console.log(x); }",
+        "switch (a) { case 2: let x = 1; case 1: console.log(x); }",
+    );
+    // A falsy initializer must not fold `if (x)` on the skipped-init path.
+    test_smallest(
+        "export function f(a) { switch (a) { case 2: let x = false; case 1: return x ? 'T' : 'F'; } }",
+        "export function f(a) { switch (a) { case 2: let x = !1; case 1: return x ? 'T' : 'F'; } }",
+    );
+    // An uninitialized `let` is still TDZ until the declaration executes.
+    test_same_smallest("export function f(a) { switch (a) { case 2: let x; case 1: return x; } }");
+    // A skipped object initializer is not a fresh value; dropping `x.p = 1`
+    // would turn a TDZ throw into a no-op.
+    test_same_smallest(
+        "export function f(a) { switch (a) { case 2: let x = {}; case 1: x.p = 1; } }",
+    );
+}
+
+#[test]
+fn switch_case_block_scoped_lexical_still_inlined() {
+    // A nested block gives the binding its own scope, so inlining inside that
+    // block cannot leak into other cases.
+    test_smallest(
+        "switch (a) { case 2: { let x = 1; console.log(x); } case 1: foo(); }",
+        "switch (a) { case 2: console.log(1); case 1: foo(); }",
+    );
+}
+
+#[test]
+fn switch_single_case_lexical_still_inlined() {
+    // A one-case switch is rewritten to an `if` whose block always runs the
+    // initializer, so same-body inlining remains valid.
+    test_smallest(
+        "switch (a) { case 2: let x = 1; console.log(x); }",
+        "a === 2 && console.log(1);",
+    );
 }
 
 // https://github.com/oxc-project/oxc/issues/20282


### PR DESCRIPTION
fixes #26174

switch cases share one lexical environment, but a let initializer only runs if you enter that case. the minifier inlined it into later cases, so a TDZ throw became the initialized value.

We stop recording those declaration facts for lexical bindings sitting directly in a case.

the peephole inline tests cover the reported case, const, and nested blocks.

I used AI to investigate this. I read the compressor path and the new tests. I am responsible for the patch.