### PR TITLE
chore(oxlint): regenerate config types by `cargo lintgen`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4,7 +4,7 @@
  */
 
 export type AllowWarnDeny = ("allow" | "off" | "warn" | "error" | "deny") | number;
-export type GlobalValue = ("readonly" | "writable" | "off") | undefined;
+export type GlobalValue = "readonly" | "writable" | "off";
 export type ExternalPluginEntry =
   | string
   | {
@@ -94,7 +94,7 @@ export type ExtensionRule = "always" | "never" | "ignorePackages";
 export type ImportExtensionsObject =
   | ImportExtensionsConfig
   | {
-      [k: string]: ExtensionRule;
+      [k: string]: ExtensionRule | undefined;
     };
 /**
  * Action to take for path group overrides.
@@ -312,25 +312,22 @@ export type ChecksVoidReturn = boolean | ChecksVoidReturnOptions;
  * - An object with `message` and optional `fixWith` and `suggest`
  */
 export type BanConfigValue =
-  | (
-      | True
-      | string
-      | {
-          /**
-           * Replacement type for automatic fixing. Applied directly with `--fix`.
-           */
-          fixWith?: string;
-          /**
-           * Custom message explaining why the type is banned.
-           */
-          message?: string;
-          /**
-           * Suggested replacement types for manual review. Shown as editor suggestions.
-           */
-          suggest?: string[];
-        }
-    )
-  | undefined;
+  | True
+  | string
+  | {
+      /**
+       * Replacement type for automatic fixing. Applied directly with `--fix`.
+       */
+      fixWith?: string;
+      /**
+       * Custom message explaining why the type is banned.
+       */
+      message?: string;
+      /**
+       * Suggested replacement types for manual review. Shown as editor suggestions.
+       */
+      suggest?: string[];
+    };
 export type True = true;
 /**
  * Represents the different ways `allowConstantLoopConditions` can be specified in JSON.
@@ -358,48 +355,45 @@ export type BomOptionType = "always" | "never";
 export type NonZero = "greater-than" | "not-equal";
 export type ExplicitTimerDelayMode = "always" | "never";
 export type ModuleStylesOverride =
-  | (
-      | false
-      | {
-          /**
-           * Whether default imports or whole-module `require()` assignments are allowed for this module.
-           *
-           * With `{ "styles": { "chalk": { "default": true } } }`, this is valid:
-           * ```js
-           * import chalk from "chalk";
-           * ```
-           */
-          default?: boolean;
-          /**
-           * Whether named imports or destructured `require()` calls are allowed for this module.
-           *
-           * With `{ "styles": { "node:util": { "named": true } } }`, this is valid:
-           * ```js
-           * import {promisify} from "node:util";
-           * ```
-           */
-          named?: boolean;
-          /**
-           * Whether namespace imports or whole-module `require()` assignments are allowed for this module.
-           *
-           * With `{ "styles": { "node:fs": { "namespace": true } } }`, this is valid:
-           * ```js
-           * import * as fs from "node:fs";
-           * ```
-           */
-          namespace?: boolean;
-          /**
-           * Whether side-effect imports or unassigned dynamic imports/requires are allowed for this module.
-           *
-           * With `{ "styles": { "polyfill": { "unassigned": true } } }`, this is valid:
-           * ```js
-           * import "polyfill";
-           * ```
-           */
-          unassigned?: boolean;
-        }
-    )
-  | undefined;
+  | false
+  | {
+      /**
+       * Whether default imports or whole-module `require()` assignments are allowed for this module.
+       *
+       * With `{ "styles": { "chalk": { "default": true } } }`, this is valid:
+       * ```js
+       * import chalk from "chalk";
+       * ```
+       */
+      default?: boolean;
+      /**
+       * Whether named imports or destructured `require()` calls are allowed for this module.
+       *
+       * With `{ "styles": { "node:util": { "named": true } } }`, this is valid:
+       * ```js
+       * import {promisify} from "node:util";
+       * ```
+       */
+      named?: boolean;
+      /**
+       * Whether namespace imports or whole-module `require()` assignments are allowed for this module.
+       *
+       * With `{ "styles": { "node:fs": { "namespace": true } } }`, this is valid:
+       * ```js
+       * import * as fs from "node:fs";
+       * ```
+       */
+      namespace?: boolean;
+      /**
+       * Whether side-effect imports or unassigned dynamic imports/requires are allowed for this module.
+       *
+       * With `{ "styles": { "polyfill": { "unassigned": true } } }`, this is valid:
+       * ```js
+       * import "polyfill";
+       * ```
+       */
+      unassigned?: boolean;
+    };
 export type NoInstanceofBuiltinsStrategy = "strict" | "loose";
 export type PreferTernaryOption = "always" | "only-single-line";
 export type RelativeUrlStyleConfig = "never" | "always";
@@ -416,20 +410,17 @@ export type AllowYoda = "never" | "always";
 export type OxlintOverrides = OxlintOverride[];
 export type JestVersionSchema = number | string;
 export type TagNamePreference =
-  | (
-      | string
-      | {
-          message: string;
-          replacement: string;
-          [k: string]: unknown | undefined;
-        }
-      | {
-          message: string;
-          [k: string]: unknown | undefined;
-        }
-      | boolean
-    )
-  | undefined;
+  | string
+  | {
+      message: string;
+      replacement: string;
+      [k: string]: unknown | undefined;
+    }
+  | {
+      message: string;
+      [k: string]: unknown | undefined;
+    }
+  | boolean;
 export type OneOrManyFor_String = string | string[];
 export type CustomComponent =
   | string
@@ -1805,7 +1796,352 @@ export interface DummyRuleMap {
   "vue/valid-define-props"?: RuleNoConfig;
   "vue/valid-next-tick"?: RuleNoConfig;
   yoda?: RuleNoConfig | [AllowWarnDeny, AllowYoda] | [AllowWarnDeny, AllowYoda, YodaOptions];
-  [k: string]: DummyRule | undefined;
+  [k: string]:
+    | DummyRule
+    | RuleNoConfig
+    | [AllowWarnDeny, AccessorPairsConfig]
+    | [AllowWarnDeny, ArrayCallbackReturn]
+    | [AllowWarnDeny, Mode2]
+    | [AllowWarnDeny, Mode2, ArrowBodyStyleConfig]
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum]
+    | [AllowWarnDeny, ClassMethodsUseThisConfig]
+    | [AllowWarnDeny, ComplexityConfigEnum]
+    | [AllowWarnDeny, CurlyType]
+    | [AllowWarnDeny, CurlyType, CurlyConsistent]
+    | [AllowWarnDeny, DefaultCaseConfig]
+    | [AllowWarnDeny, CompareType]
+    | [AllowWarnDeny, CompareType, EqeqeqOptions]
+    | [AllowWarnDeny, FuncNameMatchingMode]
+    | [AllowWarnDeny, FuncNameMatchingMode, FuncNameMatchingConfig]
+    | [AllowWarnDeny, FuncNameMatchingMode]
+    | [AllowWarnDeny, FuncNameMatchingConfig]
+    | [AllowWarnDeny, FuncNamesConfigType]
+    | [AllowWarnDeny, FuncNamesConfigType, FuncNamesGeneratorsConfig]
+    | [AllowWarnDeny, Style]
+    | [AllowWarnDeny, Style, FuncStyleConfig]
+    | [AllowWarnDeny, GetterReturn]
+    | [AllowWarnDeny, PairOrder]
+    | [AllowWarnDeny, PairOrder, GroupedAccessorPairsConfig]
+    | [AllowWarnDeny, ...string[]]
+    | [AllowWarnDeny, IdLengthConfig]
+    | [AllowWarnDeny, string]
+    | [AllowWarnDeny, string, IdMatchOptions]
+    | [AllowWarnDeny, Mode]
+    | [AllowWarnDeny, ExtensionRule]
+    | [AllowWarnDeny, ExtensionRule, ImportExtensionsObject]
+    | [AllowWarnDeny, ExtensionRule]
+    | [AllowWarnDeny, ImportExtensionsObject]
+    | [AllowWarnDeny, AbsoluteFirst]
+    | [AllowWarnDeny, MaxDependenciesConfigJson]
+    | [AllowWarnDeny, Namespace]
+    | [AllowWarnDeny, NewlineAfterImport]
+    | [AllowWarnDeny, NoAbsolutePath]
+    | [AllowWarnDeny, NoAnonymousDefaultExport]
+    | [AllowWarnDeny, NoCommonjs]
+    | [AllowWarnDeny, NoCycle]
+    | [AllowWarnDeny, NoDuplicates]
+    | [AllowWarnDeny, NoDynamicRequire]
+    | [AllowWarnDeny, NoNamespaceConfig]
+    | [AllowWarnDeny, NoNodejsModulesConfig]
+    | [AllowWarnDeny, NoUnassignedImportConfig]
+    | [AllowWarnDeny, PreferDefaultExport]
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, InitDeclarationsConfig]
+    | [AllowWarnDeny, ConsistentTestItConfig]
+    | [AllowWarnDeny, ExpectExpectConfig]
+    | [AllowWarnDeny, MaxExpectsConfig]
+    | [AllowWarnDeny, MaxNestedDescribeConfig]
+    | [AllowWarnDeny, NoDeprecatedFunctionsConfig]
+    | [AllowWarnDeny, NoHooksConfig]
+    | [AllowWarnDeny, NoLargeSnapshotsConfig]
+    | [AllowWarnDeny, NoRestrictedTestMethodsConfig]
+    | [AllowWarnDeny, NoRestrictedMatchersConfig]
+    | [AllowWarnDeny, NoStandaloneExpectConfig]
+    | [AllowWarnDeny, PreferEndingWithAnExpectConfig]
+    | [AllowWarnDeny, PreferExpectAssertionsConfig]
+    | [AllowWarnDeny, PreferImportingJestGlobalsConfig]
+    | [AllowWarnDeny, PreferLowercaseTitleConfig]
+    | [AllowWarnDeny, SnapshotHintMode]
+    | [AllowWarnDeny, RequireHookConfig]
+    | [AllowWarnDeny, RequireTopLevelDescribeConfig]
+    | [AllowWarnDeny, ValidExpectConfig]
+    | [AllowWarnDeny, CheckTagNamesConfig]
+    | [AllowWarnDeny, EmptyTagsConfig]
+    | [AllowWarnDeny, NoBlankBlocks]
+    | [AllowWarnDeny, NoDefaultsConfig]
+    | [AllowWarnDeny, RequireParamConfig]
+    | [AllowWarnDeny, RequireParamDescriptionConfig]
+    | [AllowWarnDeny, RequireParamTypeConfig]
+    | [AllowWarnDeny, RequireReturnsConfig]
+    | [AllowWarnDeny, RequireYieldsConfig]
+    | [AllowWarnDeny, AltTextConfigSchema]
+    | [AllowWarnDeny, AnchorAmbiguousTextConfig]
+    | [AllowWarnDeny, AnchorHasContentConfig]
+    | [AllowWarnDeny, AnchorIsValidConfig]
+    | [AllowWarnDeny, AriaRoleConfig]
+    | [AllowWarnDeny, AutocompleteValidConfig]
+    | [AllowWarnDeny, ControlHasAssociatedLabelConfig]
+    | [AllowWarnDeny, HeadingHasContentConfig]
+    | [AllowWarnDeny, ImgRedundantAltConfig]
+    | [AllowWarnDeny, InteractiveSupportsFocusConfig]
+    | [AllowWarnDeny, LabelHasAssociatedControlConfig]
+    | [AllowWarnDeny, MediaHasCaptionConfig]
+    | [AllowWarnDeny, MouseEventsHaveKeyEventsConfig]
+    | [AllowWarnDeny, NoAutofocus]
+    | [AllowWarnDeny, NoDistractingElementsConfig]
+    | [AllowWarnDeny, NoInteractiveElementToNoninteractiveRoleConfig]
+    | [AllowWarnDeny, NoNoninteractiveElementInteractionsConfig]
+    | [AllowWarnDeny, NoNoninteractiveElementToInteractiveRoleConfig]
+    | [AllowWarnDeny, NoNoninteractiveTabindexConfig]
+    | [AllowWarnDeny, NoRedundantRolesConfig]
+    | [AllowWarnDeny, NoStaticElementInteractionsConfig]
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig]
+    | [AllowWarnDeny, MaxClassesPerFileConfigEnum]
+    | [AllowWarnDeny, MaxDepthConfigEnum]
+    | [AllowWarnDeny, MaxLinesConfigEnum]
+    | [AllowWarnDeny, MaxLinesPerFunctionConfigEnum]
+    | [AllowWarnDeny, MaxNestedCallbacksConfigEnum]
+    | [AllowWarnDeny, MaxParamsConfigEnum]
+    | [AllowWarnDeny, MaxStatementsConfigEnum]
+    | [AllowWarnDeny, NewCapConfig]
+    | [AllowWarnDeny, NoBitwiseConfig]
+    | [AllowWarnDeny, NoCondAssignConfig]
+    | [AllowWarnDeny, NoConsoleConfig]
+    | [AllowWarnDeny, NoConstantBinaryExpressionConfig]
+    | [AllowWarnDeny, NoConstantCondition]
+    | [AllowWarnDeny, NoDuplicateImports]
+    | [AllowWarnDeny, NoElseReturn]
+    | [AllowWarnDeny, NoEmpty]
+    | [AllowWarnDeny, NoEmptyFunctionConfig]
+    | [AllowWarnDeny, NoEmptyPattern]
+    | [AllowWarnDeny, NoEval]
+    | [AllowWarnDeny, NoExtendNativeConfig]
+    | [AllowWarnDeny, NoExtraBooleanCast]
+    | [AllowWarnDeny, NoFallthroughConfig]
+    | [AllowWarnDeny, NoGlobalAssignConfig]
+    | [AllowWarnDeny, NoImplicitCoercionConfig]
+    | [AllowWarnDeny, NoImplicitGlobalsConfig]
+    | [AllowWarnDeny, NoInlineCommentsConfig]
+    | [AllowWarnDeny, NoInnerDeclarationsConfig]
+    | [AllowWarnDeny, NoInnerDeclarationsConfig, NoInnerDeclarationsOptions]
+    | [AllowWarnDeny, NoInvalidRegexpConfig]
+    | [AllowWarnDeny, NoIrregularWhitespaceConfig]
+    | [AllowWarnDeny, NoLabels]
+    | [AllowWarnDeny, NoMagicNumbersConfig]
+    | [AllowWarnDeny, NoMisleadingCharacterClass]
+    | [AllowWarnDeny, NoMultiAssign]
+    | [AllowWarnDeny, NoParamReassignConfig]
+    | [AllowWarnDeny, NoPlusplus]
+    | [AllowWarnDeny, NoPromiseExecutorReturnConfig]
+    | [AllowWarnDeny, NoRedeclare]
+    | [AllowWarnDeny, NoRestrictedExportsConfig]
+    | [AllowWarnDeny, ...NoRestrictedGlobalsConfigEnum[]]
+    | [AllowWarnDeny, ...NoRestrictedImportsConfigEnum[]]
+    | [AllowWarnDeny, ...PropertyDetails[]]
+    | [AllowWarnDeny, NoReturnAssignMode]
+    | [AllowWarnDeny, NoSelfAssign]
+    | [AllowWarnDeny, NoSequences]
+    | [AllowWarnDeny, NoShadowConfig]
+    | [AllowWarnDeny, NoShadowRestrictedNamesConfig]
+    | [AllowWarnDeny, NoUndef]
+    | [AllowWarnDeny, NoUnderscoreDangleConfig]
+    | [AllowWarnDeny, NoUnneededTernary]
+    | [AllowWarnDeny, NoUnreachableLoopConfig]
+    | [AllowWarnDeny, NoUnsafeNegation]
+    | [AllowWarnDeny, NoUnsafeOptionalChaining]
+    | [AllowWarnDeny, NoUnusedExpressionsConfig]
+    | [AllowWarnDeny, NoUnusedVarsConfig]
+    | [AllowWarnDeny, NoUseBeforeDefineConfigJson]
+    | [AllowWarnDeny, NoUselessComputedKey]
+    | [AllowWarnDeny, NoUselessEscapeConfig]
+    | [AllowWarnDeny, NoUselessRenameConfig]
+    | [AllowWarnDeny, NoVoid]
+    | [AllowWarnDeny, NoWarningCommentsConfig]
+    | [AllowWarnDeny, CallbackReturn]
+    | [AllowWarnDeny, ExportsStyleMode]
+    | [AllowWarnDeny, ExportsStyleMode, ExportsStyleOptions]
+    | [AllowWarnDeny, HandleCallbackErrConfig]
+    | [AllowWarnDeny, NoMixedRequiresConfig]
+    | [AllowWarnDeny, NoProcessEnvConfig]
+    | [AllowWarnDeny, NoSyncConfig]
+    | [AllowWarnDeny, NoTopLevelAwaitConfig]
+    | [AllowWarnDeny, ShorthandType]
+    | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions]
+    | [AllowWarnDeny, OneVar]
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, NoAsyncEndpointHandlersConfig]
+    | [AllowWarnDeny, NoBarrelFile]
+    | [AllowWarnDeny, NoMapSpreadConfig]
+    | [AllowWarnDeny, NoOptionalChainingConfig]
+    | [AllowWarnDeny, NoRestSpreadPropertiesOptions]
+    | [AllowWarnDeny, PreferArrowCallbackConfig]
+    | [AllowWarnDeny, PreferConstConfig]
+    | [AllowWarnDeny, PreferDestructuringOption]
+    | [AllowWarnDeny, PreferDestructuringOption, PreferDestructuringEnforcementConfig]
+    | [AllowWarnDeny, PreferPromiseRejectErrors]
+    | [AllowWarnDeny, PreferRegexLiteralsConfig]
+    | [AllowWarnDeny, PreserveCaughtErrorOptions]
+    | [AllowWarnDeny, AlwaysReturnConfig]
+    | [AllowWarnDeny, CatchOrReturnConfig]
+    | [AllowWarnDeny, NoCallbackInPromiseConfig]
+    | [AllowWarnDeny, NoPromiseInCallbackConfig]
+    | [AllowWarnDeny, NoReturnWrap]
+    | [AllowWarnDeny, ParamNamesConfig]
+    | [AllowWarnDeny, PreferAwaitToThenConfig]
+    | [AllowWarnDeny, SpecOnlyConfig]
+    | [AllowWarnDeny, RadixType]
+    | [AllowWarnDeny, ReactPerfConfig]
+    | [AllowWarnDeny, ButtonHasType]
+    | [AllowWarnDeny, CheckedRequiresOnchangeOrReadonly]
+    | [AllowWarnDeny, DisplayNameConfig]
+    | [AllowWarnDeny, ExhaustiveDepsConfig]
+    | [AllowWarnDeny, ForbidComponentPropsConfig]
+    | [AllowWarnDeny, ForbidDomPropsConfig]
+    | [AllowWarnDeny, ForbidElementsConfig]
+    | [AllowWarnDeny, FunctionComponentDefinitionConfig]
+    | [AllowWarnDeny, HookUseStateConfig]
+    | [AllowWarnDeny, EnforceBooleanAttribute]
+    | [AllowWarnDeny, EnforceBooleanAttribute, JsxBooleanValueOptions]
+    | [AllowWarnDeny, JsxCurlyBracePresenceConfig]
+    | [AllowWarnDeny, JsxFilenameExtensionConfig]
+    | [AllowWarnDeny, FragmentMode]
+    | [AllowWarnDeny, JsxHandlerNamesConfig]
+    | [AllowWarnDeny, JsxKeyConfig]
+    | [AllowWarnDeny, JsxMaxDepthConfig]
+    | [AllowWarnDeny, JsxNoLiteralsConfig]
+    | [AllowWarnDeny, JsxNoScriptUrlComponent[]]
+    | [AllowWarnDeny, JsxNoScriptUrlComponent[], JsxNoScriptUrlOptions]
+    | [AllowWarnDeny, JsxNoScriptUrlOptions]
+    | [AllowWarnDeny, JsxNoTargetBlank]
+    | [AllowWarnDeny, JsxNoUselessFragment]
+    | [AllowWarnDeny, JsxPascalCaseConfig]
+    | [AllowWarnDeny, JsxPropsNoSpreadingConfig]
+    | [AllowWarnDeny, AllowedOrDisallowInFunc]
+    | [AllowWarnDeny, NoMultiCompConfig]
+    | [AllowWarnDeny, NoStringRefs]
+    | [AllowWarnDeny, NoUnknownPropertyConfig]
+    | [AllowWarnDeny, NoUnsafeConfig]
+    | [AllowWarnDeny, NoUnstableNestedComponentsConfig]
+    | [AllowWarnDeny, OnlyExportComponentsConfig]
+    | [AllowWarnDeny, PreferFunctionComponent]
+    | [AllowWarnDeny, SelfClosingComp]
+    | [AllowWarnDeny, StylePropObjectConfig]
+    | [AllowWarnDeny, RequireUnicodeRegexpConfig]
+    | [AllowWarnDeny, SortImportsOptions]
+    | [AllowWarnDeny, SortOrder]
+    | [AllowWarnDeny, SortOrder, SortKeysOptions]
+    | [AllowWarnDeny, SortVars]
+    | [AllowWarnDeny, ArrayTypeConfig]
+    | [AllowWarnDeny, BanTsCommentConfig]
+    | [AllowWarnDeny, ClassLiteralPropertyStyleOption]
+    | [AllowWarnDeny, PreferGenericType]
+    | [AllowWarnDeny, ConsistentIndexedObjectStyleConfig]
+    | [AllowWarnDeny, ConsistentReturnConfig]
+    | [AllowWarnDeny, ConsistentTypeAssertionsConfig]
+    | [AllowWarnDeny, ConsistentTypeDefinitionsConfig]
+    | [AllowWarnDeny, ConsistentTypeExportsConfig]
+    | [AllowWarnDeny, ConsistentTypeImportsConfig]
+    | [AllowWarnDeny, DotNotationConfig]
+    | [AllowWarnDeny, ExplicitFunctionReturnTypeConfig]
+    | [AllowWarnDeny, ExplicitMemberAccessibilityConfig]
+    | [AllowWarnDeny, ExplicitModuleBoundaryTypesConfig]
+    | [AllowWarnDeny, MethodSignatureStyleConfig]
+    | [AllowWarnDeny, NoBaseToStringConfig]
+    | [AllowWarnDeny, NoConfusingVoidExpressionConfig]
+    | [AllowWarnDeny, NoDeprecatedConfig]
+    | [AllowWarnDeny, NoDuplicateTypeConstituentsConfig]
+    | [AllowWarnDeny, NoEmptyInterface]
+    | [AllowWarnDeny, NoEmptyObjectTypeConfig]
+    | [AllowWarnDeny, NoExplicitAny]
+    | [AllowWarnDeny, NoExtraneousClass]
+    | [AllowWarnDeny, NoFloatingPromisesConfig]
+    | [AllowWarnDeny, NoInferrableTypes]
+    | [AllowWarnDeny, NoInvalidVoidTypeConfig]
+    | [AllowWarnDeny, NoMeaninglessVoidOperatorConfig]
+    | [AllowWarnDeny, NoMisusedPromisesConfig]
+    | [AllowWarnDeny, NoMisusedSpreadConfig]
+    | [AllowWarnDeny, NoNamespace]
+    | [AllowWarnDeny, NoRequireImportsConfig]
+    | [AllowWarnDeny, NoRestrictedTypesConfig]
+    | [AllowWarnDeny, NoThisAliasConfig]
+    | [AllowWarnDeny, NoUnnecessaryBooleanLiteralCompareConfig]
+    | [AllowWarnDeny, NoUnnecessaryConditionConfig]
+    | [AllowWarnDeny, NoUnnecessaryTypeAssertionConfig]
+    | [AllowWarnDeny, NoUnsafeMemberAccessConfig]
+    | [AllowWarnDeny, OnlyThrowErrorConfig]
+    | [AllowWarnDeny, ParameterPropertiesConfig]
+    | [AllowWarnDeny, PreferLiteralEnumMember]
+    | [AllowWarnDeny, PreferNullishCoalescingConfig]
+    | [AllowWarnDeny, PreferOptionalChainConfig]
+    | [AllowWarnDeny, PreferPromiseRejectErrorsConfig]
+    | [AllowWarnDeny, PreferReadonlyConfig]
+    | [AllowWarnDeny, PreferReadonlyParameterTypesConfig]
+    | [AllowWarnDeny, PreferStringStartsEndsWithConfig]
+    | [AllowWarnDeny, PromiseFunctionAsyncConfig]
+    | [AllowWarnDeny, RequireArraySortCompareConfig]
+    | [AllowWarnDeny, RestrictPlusOperandsConfig]
+    | [AllowWarnDeny, RestrictTemplateExpressionsConfig]
+    | [AllowWarnDeny, ReturnAwaitOption]
+    | [AllowWarnDeny, StrictBooleanExpressionsConfig]
+    | [AllowWarnDeny, StrictVoidReturnConfig]
+    | [AllowWarnDeny, SwitchExhaustivenessCheckConfig]
+    | [AllowWarnDeny, TripleSlashReferenceConfig]
+    | [AllowWarnDeny, UnboundMethodConfig]
+    | [AllowWarnDeny, UnifiedSignaturesOptions]
+    | [AllowWarnDeny, BomOptionType]
+    | [AllowWarnDeny, CatchErrorNameConfig]
+    | [AllowWarnDeny, ConsistentFunctionScoping]
+    | [AllowWarnDeny, ExplicitLengthCheck]
+    | [AllowWarnDeny, ExplicitTimerDelayMode]
+    | [AllowWarnDeny, ImportStyleConfig]
+    | [AllowWarnDeny, MaxNestedCalls]
+    | [AllowWarnDeny, NoArrayReduce]
+    | [AllowWarnDeny, NoArrayReverse]
+    | [AllowWarnDeny, NoArraySort]
+    | [AllowWarnDeny, NoInstanceofBuiltinsConfig]
+    | [AllowWarnDeny, NoNull]
+    | [AllowWarnDeny, NoTypeofUndefined]
+    | [AllowWarnDeny, NoUselessPromiseResolveRejectOptions]
+    | [AllowWarnDeny, NoUselessUndefined]
+    | [AllowWarnDeny, NumericSeparatorsStyleConfig]
+    | [AllowWarnDeny, PreferAtConfig]
+    | [AllowWarnDeny, PreferExportFrom]
+    | [AllowWarnDeny, PreferNumberPropertiesConfig]
+    | [AllowWarnDeny, PreferObjectFromEntriesConfig]
+    | [AllowWarnDeny, PreferSingleCallConfig]
+    | [AllowWarnDeny, PreferStructuredCloneConfig]
+    | [AllowWarnDeny, PreferTernaryOption]
+    | [AllowWarnDeny, RelativeUrlStyleConfig]
+    | [AllowWarnDeny, SwitchCaseBracesConfig]
+    | [AllowWarnDeny, TextEncodingIdentifierCase]
+    | [AllowWarnDeny, UseIsnan]
+    | [AllowWarnDeny, ValidTypeof]
+    | [AllowWarnDeny, ConsistentEachForJson]
+    | [AllowWarnDeny, ConsistentTestFilenameConfig]
+    | [AllowWarnDeny, ConsistentVitestConfig]
+    | [AllowWarnDeny, PreferImportInMockConfig]
+    | [AllowWarnDeny, RequireMockTypeParametersConfig]
+    | [AllowWarnDeny, CaseType]
+    | [AllowWarnDeny, DeclarationStyle]
+    | [AllowWarnDeny, DeclarationStyle2]
+    | [AllowWarnDeny, DefinePropsDestructuring]
+    | [AllowWarnDeny, MaxProps]
+    | [AllowWarnDeny, NextTickOption]
+    | [AllowWarnDeny, NoAsyncInComputedPropertiesConfig]
+    | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig]
+    | [AllowWarnDeny, NoDupeKeysConfig]
+    | [AllowWarnDeny, NoReservedComponentNames]
+    | [AllowWarnDeny, NoReservedKeysConfig]
+    | [AllowWarnDeny, NoReservedPropsConfig]
+    | [AllowWarnDeny, CaseType2]
+    | [AllowWarnDeny, CaseType2, Options]
+    | [AllowWarnDeny, RequireDirectExport]
+    | [AllowWarnDeny, ReturnInComputedPropertyConfig]
+    | [AllowWarnDeny, AllowYoda]
+    | [AllowWarnDeny, AllowYoda, YodaOptions]
+    | undefined;
 }
 export interface AccessorPairsConfig {
   /**
@@ -2084,7 +2420,7 @@ export interface ImportExtensionsConfig {
    * Per-extension rules.
    */
   pattern?: {
-    [k: string]: ExtensionRule;
+    [k: string]: ExtensionRule | undefined;
   };
 }
 export interface PathGroupOverrideConfig {
@@ -2419,10 +2755,10 @@ export interface NoLargeSnapshotsConfig {
   maxSize?: number;
 }
 export interface NoRestrictedTestMethodsConfig {
-  [k: string]: (string | null) | undefined;
+  [k: string]: string | null | undefined;
 }
 export interface NoRestrictedMatchersConfig {
-  [k: string]: (string | null) | undefined;
+  [k: string]: string | null | undefined;
 }
 export interface NoStandaloneExpectConfig {
   /**


### PR DESCRIPTION
Follow up on #26193. (Also fixes main CI failures)

`json-schema-to-typescript`: `^15.0.4` → `^16.0.0` changed the output.
