### PR TITLE
feat(linter/unicorn): implement no-exports-in-scripts

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1577,6 +1577,7 @@ export interface DummyRuleMap {
   "unicorn/no-console-spaces"?: RuleNoConfig;
   "unicorn/no-document-cookie"?: RuleNoConfig;
   "unicorn/no-empty-file"?: RuleNoConfig;
+  "unicorn/no-exports-in-scripts"?: RuleNoConfig;
   "unicorn/no-hex-escape"?: RuleNoConfig;
   "unicorn/no-immediate-mutation"?: RuleNoConfig;
   "unicorn/no-instanceof-array"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3309,6 +3309,17 @@ impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_exports_in_scripts::NoExportsInScripts {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportAllDeclaration,
+        AstType::ExportDeclaration,
+        AstType::ExportDefaultDeclaration,
+        AstType::ExportFromDeclaration,
+        AstType::ExportNamedDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_hex_escape::NoHexEscape {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::RegExpLiteral,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -656,6 +656,7 @@ pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as 
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
+pub use crate::rules::unicorn::no_exports_in_scripts::NoExportsInScripts as UnicornNoExportsInScripts;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
 pub use crate::rules::unicorn::no_instanceof_array::NoInstanceofArray as UnicornNoInstanceofArray;
@@ -1404,6 +1405,7 @@ pub enum RuleEnum {
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
+    UnicornNoExportsInScripts(UnicornNoExportsInScripts),
     UnicornNoHexEscape(UnicornNoHexEscape),
     UnicornNoImmediateMutation(UnicornNoImmediateMutation),
     UnicornNoInstanceofArray(UnicornNoInstanceofArray),
@@ -2340,7 +2342,8 @@ const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_ME
 const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_CONFUSING_ARRAY_WITH_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
 const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
-const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_EXPORTS_IN_SCRIPTS_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EXPORTS_IN_SCRIPTS_ID + 1usize;
 const UNICORN_NO_IMMEDIATE_MUTATION_ID: usize = UNICORN_NO_HEX_ESCAPE_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_ARRAY_ID: usize = UNICORN_NO_IMMEDIATE_MUTATION_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_BUILTINS_ID: usize = UNICORN_NO_INSTANCEOF_ARRAY_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3261,6 +3264,7 @@ static RULE_NAMES: [&str; 870usize] = [
     UnicornNoConsoleSpaces::NAME,
     UnicornNoDocumentCookie::NAME,
     UnicornNoEmptyFile::NAME,
+    UnicornNoExportsInScripts::NAME,
     UnicornNoHexEscape::NAME,
     UnicornNoImmediateMutation::NAME,
     UnicornNoInstanceofArray::NAME,
@@ -4217,6 +4221,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
+            Self::UnicornNoExportsInScripts(_) => UNICORN_NO_EXPORTS_IN_SCRIPTS_ID,
             Self::UnicornNoHexEscape(_) => UNICORN_NO_HEX_ESCAPE_ID,
             Self::UnicornNoImmediateMutation(_) => UNICORN_NO_IMMEDIATE_MUTATION_ID,
             Self::UnicornNoInstanceofArray(_) => UNICORN_NO_INSTANCEOF_ARRAY_ID,
@@ -5248,6 +5253,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::CATEGORY,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::CATEGORY,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::CATEGORY,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::CATEGORY,
@@ -6267,6 +6273,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::FIX,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::FIX,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::FIX,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::FIX,
@@ -7398,6 +7405,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::documentation(),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::documentation(),
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::documentation(),
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::documentation(),
@@ -9382,6 +9390,10 @@ impl RuleEnum {
                 .or_else(|| UnicornNoDocumentCookie::schema(generator)),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::config_schema(generator)
                 .or_else(|| UnicornNoEmptyFile::schema(generator)),
+            Self::UnicornNoExportsInScripts(_) => {
+                UnicornNoExportsInScripts::config_schema(generator)
+                    .or_else(|| UnicornNoExportsInScripts::schema(generator))
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::config_schema(generator)
                 .or_else(|| UnicornNoHexEscape::schema(generator)),
             Self::UnicornNoImmediateMutation(_) => {
@@ -10941,6 +10953,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
+            Self::UnicornNoExportsInScripts(_) => "unicorn",
             Self::UnicornNoHexEscape(_) => "unicorn",
             Self::UnicornNoImmediateMutation(_) => "unicorn",
             Self::UnicornNoInstanceofArray(_) => "unicorn",
@@ -12946,6 +12959,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
+            Self::UnicornNoExportsInScripts(rule) => rule.run(node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run(node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run(node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run(node, ctx),
@@ -13833,6 +13847,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
+            Self::UnicornNoExportsInScripts(rule) => rule.run_once(ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_once(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_once(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_once(ctx),
@@ -14799,6 +14814,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoExportsInScripts(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15725,6 +15741,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
+            Self::UnicornNoExportsInScripts(rule) => rule.should_run(ctx),
             Self::UnicornNoHexEscape(rule) => rule.should_run(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.should_run(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.should_run(ctx),
@@ -16817,6 +16834,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::IS_TSGOLINT_RULE,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::IS_TSGOLINT_RULE,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::IS_TSGOLINT_RULE,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::IS_TSGOLINT_RULE,
@@ -17969,6 +17987,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::VERSION,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::VERSION,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::VERSION,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::VERSION,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::VERSION,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::VERSION,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::VERSION,
@@ -19040,6 +19059,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::HAS_CONFIG,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::HAS_CONFIG,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::HAS_CONFIG,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::HAS_CONFIG,
@@ -20078,6 +20098,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::INFO,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::INFO,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::INFO,
+            Self::UnicornNoExportsInScripts(_) => UnicornNoExportsInScripts::INFO,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::INFO,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::INFO,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::INFO,
@@ -20995,6 +21016,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
+            Self::UnicornNoExportsInScripts(rule) => rule.types_info(),
             Self::UnicornNoHexEscape(rule) => rule.types_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.types_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.types_info(),
@@ -21869,6 +21891,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
+            Self::UnicornNoExportsInScripts(rule) => rule.run_info(),
             Self::UnicornNoHexEscape(rule) => rule.run_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.run_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.run_info(),
@@ -22841,6 +22864,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),
+        RuleEnum::UnicornNoExportsInScripts(UnicornNoExportsInScripts::default()),
         RuleEnum::UnicornNoHexEscape(UnicornNoHexEscape::default()),
         RuleEnum::UnicornNoImmediateMutation(UnicornNoImmediateMutation::default()),
         RuleEnum::UnicornNoInstanceofArray(UnicornNoInstanceofArray::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -592,6 +592,7 @@ pub(crate) mod unicorn {
     pub mod no_console_spaces;
     pub mod no_document_cookie;
     pub mod no_empty_file;
+    pub mod no_exports_in_scripts;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;
     pub mod no_instanceof_array;

--- a/crates/oxc_linter/src/rules/unicorn/no_exports_in_scripts.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_exports_in_scripts.rs
@@ -1,0 +1,125 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::Rule,
+};
+
+fn no_exports_in_scripts_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use exports in scripts.")
+        .with_help("Remove the export or the hashbang so the file has a single purpose.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoExportsInScripts;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows ECMAScript module exports in files that start with a hashbang.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A hashbang marks a file as a script intended to be executed directly. Adding exports mixes
+    /// script and module boundaries and makes the file's intended use unclear.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// #!/usr/bin/env node
+    /// export const value = 1;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// #!/usr/bin/env node
+    /// const value = 1;
+    /// console.log(value);
+    /// ```
+    NoExportsInScripts,
+    unicorn,
+    restriction,
+    none,
+    version = "next",
+    short_description = "Disallow exports in scripts.",
+);
+
+impl Rule for NoExportsInScripts {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let span = match node.kind() {
+            AstKind::ExportAllDeclaration(declaration) => declaration.span,
+            AstKind::ExportDeclaration(declaration) => declaration.span,
+            AstKind::ExportDefaultDeclaration(declaration) => declaration.span,
+            AstKind::ExportFromDeclaration(declaration) => declaration.span,
+            AstKind::ExportNamedDeclaration(declaration) => declaration.span,
+            _ => return,
+        };
+
+        ctx.diagnostic(no_exports_in_scripts_diagnostic(span));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_text().starts_with("#!")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "export const foo = 1;",
+        "export default foo;",
+        r#"export * from "./foo.js";"#,
+        "const foo = 1;
+            export {foo};",
+        "export {};",
+        "export type Foo = string;",
+        "export interface Foo {}",
+        "#!/usr/bin/env node
+            import process from 'node:process';
+            console.log(process.argv);",
+        "#!/usr/bin/env node
+            const foo = 1;
+            module.exports = foo;",
+        "// #!/usr/bin/env node
+            export const foo = 1;",
+        "console.log('#!/usr/bin/env node');
+            export const foo = 1;",
+    ];
+
+    let fail = vec![
+        "#!/usr/bin/env node
+            export const foo = 1;",
+        "#!/usr/bin/env node
+            export default foo;",
+        "#!/usr/bin/env node
+            export * from './foo.js';",
+        "#!/usr/bin/env node
+            export * as foo from './foo.js';",
+        "#!/usr/bin/env node
+            const foo = 1;
+            export {foo};",
+        "#!/usr/bin/env node
+            export {foo} from './foo.js';",
+        "#!/usr/bin/env node
+            export {};",
+        "#!/usr/bin/env node
+            export const foo = 1;
+            export const bar = 2;",
+        "#!/usr/bin/env node
+            export type Foo = string;",
+        "#!/usr/bin/env node
+            export interface Foo {}",
+    ];
+
+    Tester::new(NoExportsInScripts::NAME, NoExportsInScripts::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_exports_in_scripts.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_exports_in_scripts.snap
@@ -1,0 +1,92 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export const foo = 1;
+   ·             ─────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export default foo;
+   ·             ───────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export * from './foo.js';
+   ·             ─────────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export * as foo from './foo.js';
+   ·             ────────────────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:3:13]
+ 2 │             const foo = 1;
+ 3 │             export {foo};
+   ·             ─────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export {foo} from './foo.js';
+   ·             ─────────────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export {};
+   ·             ──────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export const foo = 1;
+   ·             ─────────────────────
+ 3 │             export const bar = 2;
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:3:13]
+ 2 │             export const foo = 1;
+ 3 │             export const bar = 2;
+   ·             ─────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export type Foo = string;
+   ·             ─────────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.
+
+  ⚠ unicorn(no-exports-in-scripts): Do not use exports in scripts.
+   ╭─[no_exports_in_scripts.tsx:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │             export interface Foo {}
+   ·             ───────────────────────
+   ╰────
+  help: Remove the export or the hashbang so the file has a single purpose.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9086,6 +9086,9 @@
         "unicorn/no-empty-file": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-exports-in-scripts": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-hex-escape": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -579,6 +579,7 @@ unicorn/no-confusing-array-with                            |  62606
 unicorn/no-console-spaces                                  |  62606
 unicorn/no-document-cookie                                 |  13005
 unicorn/no-empty-file                                      |      7
+unicorn/no-exports-in-scripts                              |     28
 unicorn/no-hex-escape                                      |  63282
 unicorn/no-immediate-mutation                              |  24802
 unicorn/no-instanceof-array                                |  20604


### PR DESCRIPTION
## AI assistance disclosure

Codex was used to implement and validate this contribution. The diff was reviewed against the upstream `eslint-plugin-unicorn` rule behavior and kept scoped to the rule, its tests, and required generated artifacts.

## Summary

- implement `unicorn/no-exports-in-scripts` as part of #684
- enable the rule only for files that begin with a hashbang
- report all five Oxc AST forms that represent ECMAScript exports
- port the upstream JavaScript and TypeScript test cases and add the diagnostic snapshot
- regenerate rule registration, configuration schema/types, and linter timing data

## Validation

- `just ready`
- `cargo test -p oxc_linter --all-features`
- `CARGO_BUILD_WARNINGS=deny cargo lint -p oxc_linter`
- `cargo test -p website_linter`
- manual Oxlint CLI check: a hashbang file with an export fails; the same export without a hashbang passes
