### PR TITLE
chore(oxlint/generate-config-types): remove unneeded DummyRule tsType mapping

### DIFF
--- a/apps/oxlint/scripts/generate-config-types.ts
+++ b/apps/oxlint/scripts/generate-config-types.ts
@@ -252,19 +252,6 @@ function collapseEnumPrimitiveIntersections(
   return result;
 }
 
-const dummyRuleMap = schema.definitions?.DummyRuleMap;
-const dummyRuleMapAdditionalProperties = dummyRuleMap?.additionalProperties;
-if (
-  typeof dummyRuleMapAdditionalProperties !== "object"
-  || dummyRuleMapAdditionalProperties === null
-) {
-  throw new Error("Expected DummyRuleMap.additionalProperties in the oxlint config schema.");
-}
-// Named rule properties are optional, so the string index signature must
-// accept `undefined` to keep the generated declaration internally valid.
-// Set the type manually, so `strictIndexSignatures` will append `| undefined` to it.
-dummyRuleMapAdditionalProperties.tsType = "DummyRule";
-
 const bannerComment =
   "/*\n"
   + " * This file is generated from npm/oxlint/configuration_schema.json.\n"


### PR DESCRIPTION
With the major update in https://github.com/oxc-project/oxc/pull/26193, this code does not do anything.
Removing it.