### PR TITLE
feat(minifier): drop recursive function-valued declarator cycles

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1332,6 +1332,10 @@ impl<'a> PeepholeOptimizations {
             // consult the shared metadata explicitly for consistency with the
             // other count-based consumers.
             if ctx.state.symbols.is_implicitly_observable(prev_decl_id.symbol_id())
+                // Function-valued declarators remain graph owners until their
+                // references prove them dead. Inlining one would move its
+                // function scope without rebuilding the owner map.
+                || ctx.state.symbols.is_function_declarator_candidate(prev_decl_id.symbol_id())
                 || symbol_value.references.has_multiple_reads()
                 || symbol_value.references.has_writes()
             {

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -122,6 +122,17 @@ impl<'a> Traverse<'a> for Normalize {
         }
     }
 
+    fn exit_variable_declarator(
+        &mut self,
+        decl: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        // This runs after `exit_expression` has stripped parenthesized
+        // wrappers, so only exact function-valued initializers enter the
+        // focused recursive-declarator analysis.
+        symbol_liveness::register_function_declarator(decl, ctx);
+    }
+
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         match stmt {
             Statement::WhileStatement(_) if self.options.convert_while_to_fors => {

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -1,5 +1,5 @@
 use super::{PeepholeOptimizations, remove_unused_expression::ClassRemovability};
-use crate::{CompressOptionsUnused, TraverseCtx};
+use crate::{CompressOptionsUnused, TraverseCtx, symbol_liveness};
 use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::{DetermineValueType, ValueType};
 use oxc_syntax::symbol::SymbolId;
@@ -33,22 +33,17 @@ impl<'a> PeepholeOptimizations {
     /// effects, and without a reference from outside that function it can
     /// never be called.
     ///
-    /// This check deliberately runs at the declarator removal site instead of
-    /// registering declarators in the recursive-function graph. That keeps
-    /// mutual declarator cycles unsupported, but also means statement
-    /// relocation cannot leave a dead candidate in a non-removable AST slot.
-    /// For example, `const f = () => f()` is removable, while adding `use(f)`
-    /// supplies an outside reference and keeps it.
+    /// This remains a cheap local fallback for function initializers that
+    /// become exact only during peephole optimization and therefore were not
+    /// registered during Normalize. For example, `const f = () => f()` is
+    /// removable, while adding `use(f)` supplies an outside reference and
+    /// keeps it.
     fn self_recursive_function_declarator_is_unused(
         decl: &VariableDeclarator<'a>,
         symbol_id: SymbolId,
         ctx: &TraverseCtx<'a>,
     ) -> bool {
-        let Some(function_scope_id) = decl.init.as_ref().and_then(|init| match init {
-            Expression::FunctionExpression(function) => function.scope_id.get(),
-            Expression::ArrowFunctionExpression(arrow) => arrow.scope_id.get(),
-            _ => None,
-        }) else {
+        let Some(function_scope_id) = symbol_liveness::function_declarator_scope_id(decl) else {
             return false;
         };
 
@@ -119,7 +114,12 @@ impl<'a> PeepholeOptimizations {
             BindingPattern::BindingIdentifier(ident) => {
                 if let Some(symbol_id) = ident.symbol_id.get() {
                     let is_unused = Self::symbol_is_unused_by_count(symbol_id, ctx)
-                        || Self::self_recursive_function_declarator_is_unused(decl, symbol_id, ctx);
+                        || Self::self_recursive_function_declarator_is_unused(decl, symbol_id, ctx)
+                        || symbol_liveness::function_declarator_scope_id(decl).is_some_and(
+                            |scope_id| {
+                                ctx.state.symbols.function_declarator_is_dead(symbol_id, scope_id)
+                            },
+                        );
                     return is_unused && !Self::class_initializer_name_needs_to_be_kept(decl, ctx);
                 }
                 false

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -5,22 +5,26 @@
 //! reference disappears, but it cannot remove `function a() { b() }
 //! function b() { a() }`: each function keeps the other's count non-zero.
 //! This module adds the missing reachability question: can executing code
-//! reach a candidate function declaration?
+//! reach a candidate function declaration or function-valued declarator?
 //!
 //! Four concepts define the analysis:
 //!
-//! 1. **Candidates** are eligible function declarations whose deadness may
-//!    require graph reachability. Normalize initially registers every eligible
-//!    declaration. Analysis permanently untracks a non-dead candidate once no
-//!    current reference has a registered function owner; it no longer needs
-//!    graph reachability, so ordinary removal checks handle it from then on.
-//!    Published-dead candidates remain tracked to enforce monotonicity. Other
-//!    declaration kinds continue to use reference counts.
-//!    Self-recursive function and arrow expressions in declarator initializers
-//!    are handled by a local check at their removal site
-//!    (`self_recursive_function_declarator_is_unused`) and need no graph state.
+//! 1. **Candidates** are eligible function declarations and exact
+//!    function-valued declarators whose deadness may require graph reachability.
+//!    Normalize initially registers every eligible declaration. Function
+//!    declarations and registered declarators participate in later analyses.
+//!    A live declarator whose body has no graph edge is unregistered and its
+//!    scope owner mapping is cleared before normal inlining can relocate it;
+//!    declarators that do own graph edges remain registered so later dead-code
+//!    elimination can safely recompute their reachability. Published-dead
+//!    candidates remain tracked as tombstones after their declarations are
+//!    removed.
+//!    Other declaration kinds continue to use reference counts. The local
+//!    self-recursive declarator check remains as a fallback for exact shapes
+//!    created after Normalize.
 //! 2. **Ownership** comes from semantic scopes. The nearest registered function
-//!    declaration is a reference's owner. A reference from a candidate that is
+//!    declaration or active declarator initializer is a reference's owner. A
+//!    reference from a candidate that is
 //!    not implicitly observable is stored as `(owner, target)` and propagates
 //!    when the owner becomes live. Implicitly observable owners and references
 //!    outside registered functions make their targets live immediately. A
@@ -45,7 +49,10 @@
 //!
 //! 1. **Do not create function declarations.** A new declaration would have no
 //!    entry in `function_by_scope` and therefore could not own references or
-//!    become a candidate. Removing an existing declaration is supported.
+//!    become a candidate. Removing an existing declaration is supported. Exact
+//!    declarators are registered only during Normalize. A declarator that owns
+//!    a graph edge cannot be single-use inlined until the graph untracks or
+//!    removes it.
 //! 2. **Do not move an existing reference across function owners.** Ownership
 //!    comes from `Reference::scope_id()` and the registered function-scope
 //!    ancestors. A transform that changes the nearest owning function must
@@ -79,12 +86,12 @@
 //!
 //! ## Current limitations
 //!
-//! - Only function declarations are candidates. Mutual declarator cycles
-//!   (`const a = () => b(); const b = () => a();`) and class cycles are kept.
-//!   Making them candidates measured zero output bytes on real bundles but
-//!   caused most of the wrong-code hazards, and class removal has no stable
-//!   proof (`remove_unused_class` extracts static values, and heritage
-//!   classification can change between passes).
+//! - Only exact function-valued declarators in statement lists (and their
+//!   direct classic `for` initializers) participate. Wrapped initializers and
+//!   declaration positions without a stable removal site are kept.
+//! - Class cycles are kept. Class removal has no stable proof
+//!   (`remove_unused_class` extracts static values, and heritage classification
+//!   can change between passes).
 //! - Any direct eval propagates to the root scope and disables the analysis for
 //!   the whole program. There is no per-scope granularity.
 //! - Sloppy unhoisted Annex B block functions are always kept, even when
@@ -94,13 +101,16 @@
 use oxc_allocator::{Allocator, ArenaVec, BitSet, GetAllocator};
 use oxc_ast::ast::*;
 #[cfg(debug_assertions)]
-use oxc_ast_visit::{VisitJs, walk_js::walk_function};
+use oxc_ast_visit::{
+    VisitJs,
+    walk_js::{walk_function, walk_variable_declarator},
+};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::Scoping;
 use oxc_span::SourceType;
 use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
-use crate::{CompressOptions, CompressOptionsUnused, TraverseCtx};
+use crate::{CompressOptions, CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor};
 
 /// Stable program-wide symbol facts plus the optional recursive-function graph.
 ///
@@ -156,6 +166,20 @@ impl<'a> SymbolLiveness<'a> {
         self.recursive_functions.as_ref().is_some_and(|graph| graph.is_dead(symbol_id))
     }
 
+    #[inline]
+    pub fn function_declarator_is_dead(&self, symbol_id: SymbolId, scope_id: ScopeId) -> bool {
+        self.recursive_functions
+            .as_ref()
+            .is_some_and(|graph| graph.is_declarator_dead(symbol_id, scope_id))
+    }
+
+    #[inline]
+    pub fn is_function_declarator_candidate(&self, symbol_id: SymbolId) -> bool {
+        self.recursive_functions
+            .as_ref()
+            .is_some_and(|graph| graph.is_function_declarator_candidate(symbol_id))
+    }
+
     fn mark_implicitly_observable(&mut self, symbol_id: SymbolId) {
         self.implicitly_observable.set_bit(symbol_id.index());
     }
@@ -207,7 +231,27 @@ impl<'a> SymbolLiveness<'a> {
 
         let graph =
             self.recursive_functions.get_or_insert_with(|| FunctionGraph::new(scoping, allocator));
-        graph.register(scope_id, symbol_id);
+        graph.register_function_declaration(scope_id, symbol_id);
+    }
+
+    fn register_function_declarator(
+        &mut self,
+        decl: &VariableDeclarator<'_>,
+        allocator: &'a Allocator,
+        scoping: &Scoping,
+    ) {
+        let BindingPattern::BindingIdentifier(id) = &decl.id else { return };
+        let Some(symbol_id) = id.symbol_id.get() else { return };
+        let Some(scope_id) = function_declarator_scope_id(decl) else { return };
+        if self.is_implicitly_observable(symbol_id)
+            || scoping.root_scope_flags().contains_direct_eval()
+        {
+            return;
+        }
+
+        let graph =
+            self.recursive_functions.get_or_insert_with(|| FunctionGraph::new(scoping, allocator));
+        graph.register_function_declarator(scope_id, symbol_id);
     }
 
     fn analyze(&mut self, scoping: &Scoping) -> bool {
@@ -216,8 +260,10 @@ impl<'a> SymbolLiveness<'a> {
     }
 
     #[cfg(debug_assertions)]
-    fn dead_functions(&self) -> Option<&BitSet<'a>> {
-        self.recursive_functions.as_ref().map(|graph| &graph.dead)
+    fn dead_declarations(&self) -> Option<(&BitSet<'a>, Option<&BitSet<'a>>)> {
+        self.recursive_functions.as_ref().map(|graph| {
+            (&graph.dead, graph.declarators.as_ref().map(|declarators| &declarators.scopes))
+        })
     }
 }
 
@@ -229,6 +275,11 @@ struct FunctionGraph<'a> {
     /// reachability. Graph-independent removal checks then handle it. Untracked
     /// functions stay in `function_by_scope` and can still own references.
     candidates: BitSet<'a>,
+    /// Declarator-specific source metadata. It is allocated only after an
+    /// eligible function-valued declarator appears, keeping the longstanding
+    /// function-declaration-only path allocation-free.
+    declarators: Option<FunctionDeclaratorCandidates<'a>>,
+    allocator: &'a Allocator,
     /// Maps each registered function declaration's own scope to its symbol.
     /// Owner lookup walks the current semantic parent chain, so scopes inserted
     /// or reparented after Normalize remain correct.
@@ -247,15 +298,39 @@ impl<'a> FunctionGraph<'a> {
             ArenaVec::from_iter_in(std::iter::repeat_n(None, scoping.scopes_len()), &allocator);
         Self {
             candidates: BitSet::new_in(symbols_len, allocator),
+            declarators: None,
+            allocator,
             function_by_scope,
             dead: BitSet::new_in(symbols_len, allocator),
             scratch: GraphScratch::new(symbols_len, allocator),
         }
     }
 
-    fn register(&mut self, scope_id: ScopeId, symbol_id: SymbolId) {
+    fn register_function_declaration(&mut self, scope_id: ScopeId, symbol_id: SymbolId) {
         self.function_by_scope[scope_id.index()] = Some(symbol_id);
         self.candidates.set_bit(symbol_id.index());
+        if let Some(declarators) = &mut self.declarators {
+            declarators.function_declarations.set_bit(symbol_id.index());
+        }
+    }
+
+    fn register_function_declarator(&mut self, scope_id: ScopeId, symbol_id: SymbolId) {
+        if self.declarators.is_none() {
+            let mut declarators = FunctionDeclaratorCandidates::new(
+                self.candidates.capacity(),
+                self.function_by_scope.len(),
+                self.allocator,
+            );
+            for bit in self.candidates.ones() {
+                declarators.function_declarations.set_bit(bit);
+            }
+            self.declarators = Some(declarators);
+        }
+        self.function_by_scope[scope_id.index()] = Some(symbol_id);
+        self.candidates.set_bit(symbol_id.index());
+        let declarators = self.declarators.as_mut().unwrap();
+        declarators.function_declarators.set_bit(symbol_id.index());
+        declarators.scopes.set_bit(scope_id.index());
     }
 
     #[inline]
@@ -263,14 +338,34 @@ impl<'a> FunctionGraph<'a> {
         self.dead.contains(symbol_id.index())
     }
 
+    #[inline]
+    fn is_declarator_dead(&self, symbol_id: SymbolId, scope_id: ScopeId) -> bool {
+        self.dead.contains(symbol_id.index())
+            && self.declarators.as_ref().is_some_and(|declarators| {
+                declarators.function_declarators.contains(symbol_id.index())
+                    && declarators.scopes.contains(scope_id.index())
+            })
+    }
+
+    #[inline]
+    fn is_function_declarator_candidate(&self, symbol_id: SymbolId) -> bool {
+        self.declarators
+            .as_ref()
+            .is_some_and(|declarators| declarators.function_declarators.contains(symbol_id.index()))
+    }
+
     /// Returns the nearest registered function whose body contains
     /// `scope_id`. Code there only runs when that function is called. `None`
     /// means the scope is not inside any registered function, so references
     /// there make their target unconditionally live.
-    fn owner(&self, scoping: &Scoping, scope_id: ScopeId) -> Option<SymbolId> {
-        scoping
-            .scope_ancestors(scope_id)
-            .find_map(|scope_id| self.function_by_scope.get(scope_id.index()).copied().flatten())
+    fn owner(&self, scoping: &Scoping, scope_id: ScopeId) -> Option<(SymbolId, ScopeId)> {
+        scoping.scope_ancestors(scope_id).find_map(|scope_id| {
+            self.function_by_scope
+                .get(scope_id.index())
+                .copied()
+                .flatten()
+                .map(|symbol_id| (symbol_id, scope_id))
+        })
     }
 
     /// Rebuild current reachability and report whether this run published any
@@ -289,6 +384,9 @@ impl<'a> FunctionGraph<'a> {
         }
 
         self.scratch.reset();
+        if let Some(declarators) = &mut self.declarators {
+            declarators.reset();
+        }
 
         // Phase 1: classify every current reference to a candidate. Seed
         // unconditional liveness, store candidate-owned dependencies, and
@@ -303,7 +401,8 @@ impl<'a> FunctionGraph<'a> {
             let mut has_registered_function_owner = false;
             for &reference_id in scoping.get_resolved_reference_ids(target) {
                 let reference = scoping.get_reference(reference_id);
-                let Some(owner) = self.owner(scoping, reference.scope_id()) else {
+                let Some((owner, owner_scope_id)) = self.owner(scoping, reference.scope_id())
+                else {
                     self.scratch.mark_live(target);
                     continue;
                 };
@@ -319,14 +418,36 @@ impl<'a> FunctionGraph<'a> {
                 }
                 if self.candidates.contains(owner.index()) {
                     self.scratch.owned_references.push((owner, target));
+                    if let Some(declarators) = &mut self.declarators
+                        && declarators.scopes.contains(owner_scope_id.index())
+                    {
+                        declarators.scratch.with_graph_dependencies.set_bit(owner.index());
+                    }
                 } else if !scoping.symbol_is_unused(owner) {
                     // A registered non-candidate owner keeps the target live
                     // only while its body can still execute.
                     self.scratch.mark_live(target);
                 }
             }
-            if !has_registered_function_owner && !self.dead.contains(bit) {
+            if !has_registered_function_owner
+                && !self.dead.contains(bit)
+                && self
+                    .declarators
+                    .as_ref()
+                    .is_none_or(|declarators| declarators.function_declarations.contains(bit))
+            {
                 self.scratch.candidates_to_untrack.set_bit(bit);
+            }
+        }
+        for bit in self.candidates.ones() {
+            if self.dead.contains(bit) {
+                continue;
+            }
+            if let Some(declarators) = &mut self.declarators
+                && declarators.function_declarators.contains(bit)
+                && !declarators.scratch.with_graph_dependencies.contains(bit)
+            {
+                declarators.scratch.to_untrack.set_bit(bit);
             }
         }
 
@@ -337,17 +458,13 @@ impl<'a> FunctionGraph<'a> {
         // executable.
         for index in 0..self.scratch.owned_references.len() {
             let (owner, target) = self.scratch.owned_references[index];
-            let owner_leaves_graph = self.scratch.candidates_to_untrack.contains(owner.index());
+            let owner_leaves_graph = self.owner_leaves_graph_after_untracking(owner);
             let owner_stays_live_by_count = !scoping.symbol_is_unused(owner);
             if owner_leaves_graph && owner_stays_live_by_count {
                 self.scratch.mark_live(target);
             }
         }
-        // Future analyses treat these functions as registered non-candidate
-        // owners.
-        for bit in self.scratch.candidates_to_untrack.ones() {
-            self.candidates.unset_bit(bit);
-        }
+        self.untrack_sources();
 
         #[cfg(debug_assertions)]
         for bit in self.dead.ones() {
@@ -380,7 +497,117 @@ impl<'a> FunctionGraph<'a> {
                 published_new_dead = true;
             }
         }
+
         published_new_dead
+    }
+
+    fn owner_leaves_graph_after_untracking(&self, symbol_id: SymbolId) -> bool {
+        let bit = symbol_id.index();
+        let Some(declarators) = &self.declarators else {
+            return self.scratch.candidates_to_untrack.contains(bit);
+        };
+        (!declarators.function_declarations.contains(bit)
+            || self.scratch.candidates_to_untrack.contains(bit))
+            && (!declarators.function_declarators.contains(bit)
+                || declarators.scratch.to_untrack.contains(bit))
+    }
+
+    /// Apply source-specific untracking using sparse bitset iteration. Function
+    /// declaration scopes remain conservative non-candidate owners. Declarator
+    /// scopes are cleared in one batched sparse sweep before later transforms
+    /// can move their function expressions.
+    fn untrack_sources(&mut self) {
+        let Some(declarators) = &mut self.declarators else {
+            for bit in self.scratch.candidates_to_untrack.ones() {
+                self.candidates.unset_bit(bit);
+            }
+            return;
+        };
+
+        for bit in self.scratch.candidates_to_untrack.ones() {
+            declarators.function_declarations.unset_bit(bit);
+            if !declarators.function_declarators.contains(bit) {
+                self.candidates.unset_bit(bit);
+            }
+        }
+        for bit in declarators.scratch.to_untrack.ones() {
+            declarators.function_declarators.unset_bit(bit);
+            if !declarators.function_declarations.contains(bit) {
+                self.candidates.unset_bit(bit);
+            }
+        }
+
+        for scope_index in declarators.scopes.ones() {
+            let Some(symbol_id) = self.function_by_scope[scope_index] else {
+                debug_assert!(false, "registered declarator scope has no owner");
+                declarators.scratch.scopes_to_untrack.set_bit(scope_index);
+                continue;
+            };
+            if !declarators.function_declarators.contains(symbol_id.index()) {
+                declarators.scratch.scopes_to_untrack.set_bit(scope_index);
+            }
+        }
+        for scope_index in declarators.scratch.scopes_to_untrack.ones() {
+            self.function_by_scope[scope_index] = None;
+            declarators.scopes.unset_bit(scope_index);
+        }
+    }
+}
+
+/// Source-specific metadata required only when exact function-valued
+/// declarators participate in the graph.
+struct FunctionDeclaratorCandidates<'a> {
+    /// Candidate symbols with at least one active function declaration source.
+    function_declarations: BitSet<'a>,
+    /// Candidate symbols whose graph ownership originates from an exact
+    /// function-valued variable declarator.
+    function_declarators: BitSet<'a>,
+    /// Function scopes owned by still-active declarator candidates. This
+    /// makes graph deadness specific to an initializer site rather than every
+    /// declaration that happens to share the same binding symbol.
+    scopes: BitSet<'a>,
+    scratch: FunctionDeclaratorScratch<'a>,
+}
+
+impl<'a> FunctionDeclaratorCandidates<'a> {
+    fn new(symbols_len: usize, scopes_len: usize, allocator: &'a Allocator) -> Self {
+        Self {
+            function_declarations: BitSet::new_in(symbols_len, allocator),
+            function_declarators: BitSet::new_in(symbols_len, allocator),
+            scopes: BitSet::new_in(scopes_len, allocator),
+            scratch: FunctionDeclaratorScratch::new(symbols_len, scopes_len, allocator),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.scratch.reset();
+    }
+}
+
+struct FunctionDeclaratorScratch<'a> {
+    /// Declarators whose bodies have references to another candidate, so their
+    /// scopes must remain graph owners.
+    with_graph_dependencies: BitSet<'a>,
+    /// Declarator sources whose scopes no longer own graph edges and can be
+    /// unregistered before their expressions are inlined.
+    to_untrack: BitSet<'a>,
+    /// Declarator scope owners to clear after source untracking is settled.
+    scopes_to_untrack: BitSet<'a>,
+}
+
+impl<'a> FunctionDeclaratorScratch<'a> {
+    fn new(symbols_len: usize, scopes_len: usize, allocator: &'a Allocator) -> Self {
+        Self {
+            with_graph_dependencies: BitSet::new_in(symbols_len, allocator),
+            to_untrack: BitSet::new_in(symbols_len, allocator),
+            scopes_to_untrack: BitSet::new_in(scopes_len, allocator),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.with_graph_dependencies.clear();
+        self.to_untrack.clear();
+        self.scopes_to_untrack.clear();
     }
 }
 
@@ -467,6 +694,57 @@ pub fn register_function(function: &Function<'_>, ctx: &mut TraverseCtx<'_>) {
     let TraverseCtx { state, scoping, .. } = ctx;
     if let Some(liveness) = state.symbols.liveness_mut() {
         liveness.register_function(function, source_type, scoping.scoping(), allocator);
+    }
+}
+
+/// Normalize hook: register an exact function-valued declarator that has a
+/// guaranteed removal site. This intentionally excludes declarations in bare
+/// statement slots and loop heads whose binding is part of the loop's runtime
+/// semantics.
+pub fn register_function_declarator(decl: &VariableDeclarator<'_>, ctx: &mut TraverseCtx<'_>) {
+    if ctx.options().unused == CompressOptionsUnused::Keep {
+        return;
+    }
+    let Ancestor::VariableDeclarationDeclarations(declaration) = ctx.parent() else {
+        unreachable!("variable declarator must have a variable declaration parent");
+    };
+    if declaration.kind().is_using() || !declarator_has_removal_site(ctx) {
+        return;
+    }
+
+    let allocator = ctx.allocator();
+    let TraverseCtx { state, scoping, .. } = ctx;
+    if let Some(liveness) = state.symbols.liveness_mut() {
+        liveness.register_function_declarator(decl, allocator, scoping.scoping());
+    }
+}
+
+/// Return the scope that owns references in an exact function-valued
+/// declarator initializer.
+pub fn function_declarator_scope_id(decl: &VariableDeclarator<'_>) -> Option<ScopeId> {
+    decl.init.as_ref().and_then(|init| match init {
+        Expression::FunctionExpression(function) => function.scope_id.get(),
+        Expression::ArrowFunctionExpression(arrow) => arrow.scope_id.get(),
+        _ => None,
+    })
+}
+fn declarator_has_removal_site(ctx: &TraverseCtx<'_>) -> bool {
+    let parent_is_statement_list = |ancestor: Ancestor<'_, '_>| {
+        matches!(
+            ancestor,
+            Ancestor::ProgramBody(_)
+                | Ancestor::FunctionBodyStatements(_)
+                | Ancestor::BlockStatementBody(_)
+                | Ancestor::SwitchCaseConsequent(_)
+                | Ancestor::StaticBlockBody(_)
+                | Ancestor::TSModuleBlockBody(_)
+        )
+    };
+
+    match ctx.ancestor(1) {
+        ancestor if parent_is_statement_list(ancestor) => true,
+        Ancestor::ForStatementInit(_) => parent_is_statement_list(ctx.ancestor(2)),
+        _ => false,
     }
 }
 
@@ -584,8 +862,15 @@ pub fn analyze<'a>(program: &Program<'a>, ctx: &mut TraverseCtx<'a>, recompute: 
     let _ = program;
 
     #[cfg(debug_assertions)]
-    if let Some(dead) = ctx.state.symbols.liveness().and_then(SymbolLiveness::dead_functions) {
-        debug_assert_dead_function_declarations_removed(program, ctx.scoping(), dead);
+    if let Some((dead, declarator_scopes)) =
+        ctx.state.symbols.liveness().and_then(SymbolLiveness::dead_declarations)
+    {
+        debug_assert_dead_function_declarations_removed(
+            program,
+            ctx.scoping(),
+            dead,
+            declarator_scopes,
+        );
     }
 
     if !recompute {
@@ -603,17 +888,19 @@ fn debug_assert_dead_function_declarations_removed(
     program: &Program<'_>,
     scoping: &Scoping,
     dead: &BitSet<'_>,
+    declarator_scopes: Option<&BitSet<'_>>,
 ) {
     if dead.is_empty() {
         return;
     }
-    DeadFunctionSweep { scoping, dead }.visit_program(program);
+    DeadFunctionSweep { scoping, dead, declarator_scopes }.visit_program(program);
 }
 
 #[cfg(debug_assertions)]
 struct DeadFunctionSweep<'s, 'd, 'a> {
     scoping: &'s Scoping,
     dead: &'d BitSet<'a>,
+    declarator_scopes: Option<&'d BitSet<'a>>,
 }
 
 #[cfg(debug_assertions)]
@@ -629,5 +916,23 @@ impl<'a> VisitJs<'a> for DeadFunctionSweep<'_, '_, '_> {
             );
         }
         walk_function(self, function, flags);
+    }
+
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        if let BindingPattern::BindingIdentifier(id) = &decl.id
+            && let Some(symbol_id) = id.symbol_id.get()
+            && let Some(scope_id) = function_declarator_scope_id(decl)
+        {
+            assert!(
+                !self.dead.contains(symbol_id.index())
+                    || !self.declarator_scopes.is_some_and(
+                        |declarator_scopes| declarator_scopes.contains(scope_id.index())
+                    ),
+                "dead function-valued declarator `{}` survived the pass after its deadness was \
+                 published",
+                self.scoping.symbol_name(symbol_id),
+            );
+        }
+        walk_variable_declarator(self, decl);
     }
 }

--- a/crates/oxc_minifier/src/symbol_state.rs
+++ b/crates/oxc_minifier/src/symbol_state.rs
@@ -6,7 +6,7 @@ use oxc_allocator::Allocator;
 use oxc_index::IndexVec;
 use oxc_semantic::Scoping;
 use oxc_span::SourceType;
-use oxc_syntax::symbol::SymbolId;
+use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 
 use crate::{
     CompressOptions,
@@ -108,6 +108,23 @@ impl<'a> SymbolState<'a> {
     /// absent because deadness was not proved.
     pub fn function_is_dead(&self, symbol_id: SymbolId) -> bool {
         self.liveness.as_ref().is_some_and(|liveness| liveness.function_is_dead(symbol_id))
+    }
+
+    /// Whether reachability analysis proved this exact function-valued
+    /// declarator unreachable. The scope is part of the query so an unrelated
+    /// same-symbol redeclaration cannot consume graph deadness.
+    pub fn function_declarator_is_dead(&self, symbol_id: SymbolId, scope_id: ScopeId) -> bool {
+        self.liveness
+            .as_ref()
+            .is_some_and(|liveness| liveness.function_declarator_is_dead(symbol_id, scope_id))
+    }
+
+    /// A graph-owning function-valued declarator must not be single-use
+    /// inlined while its stable function scope is needed by reachability.
+    pub fn is_function_declarator_candidate(&self, symbol_id: SymbolId) -> bool {
+        self.liveness
+            .as_ref()
+            .is_some_and(|liveness| liveness.is_function_declarator_candidate(symbol_id))
     }
 
     pub fn liveness(&self) -> Option<&SymbolLiveness<'a>> {

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -987,10 +987,9 @@ fn dce_remove_unreachable_after_terminating_statement() {
 }
 
 // #13105: dead recursive/cyclic function declarations must also drop in
-// dce-only mode (rolldown's per-module treeshake preprocess). Self-recursive
-// function-valued declarators use a local removal-site check; mutual
-// declarator and class cycles are kept because graph candidacy is function
-// declarations only.
+// dce-only mode (rolldown's per-module treeshake preprocess) shares the
+// initial graph analysis for exact function-valued declarators. Class cycles
+// remain count-managed.
 #[test]
 fn dce_recursive_unused_functions() {
     test("function f() { f() }", "");
@@ -1000,8 +999,12 @@ fn dce_recursive_unused_functions() {
     // Cycle whose only external reference sits in dead code: needs the mid-loop
     // recompute trigger (pass 2), not just the initial compute.
     test("if (false) c(); function c() { d() } function d() { c() }", "");
-    // Declarator and class cycles are kept (functions-only candidacy).
-    test_same("const a = () => b();\nconst b = () => a();");
+    test("const a = () => b();\nconst b = () => a();", "");
+    test(
+        "let HANDLERS; const a = () => { HANDLERS.push(1); b() }; const b = () => { HANDLERS.push(2); a() }; export {};",
+        "export {};",
+    );
+    // Class cycles remain count-managed.
     test_same("class A {\n\tm() {\n\t\tnew B();\n\t}\n}\nclass B {\n\tm() {\n\t\tnew A();\n\t}\n}");
     // Live references keep the cycle live.
     test_same("function f() {\n\tf();\n}\nconsole.log(f);");
@@ -1043,9 +1046,8 @@ fn dce_keeps_inferred_class_name_for_executing_class() {
 }
 
 #[test]
-#[ignore = "TODO: extend recursive reachability to mutual declarators and classes"]
-fn dce_recursive_unused_mutual_declarators_and_classes() {
-    test("const a = () => b(); const b = () => a();", "");
+#[ignore = "TODO: extend recursive reachability to class declarations"]
+fn dce_recursive_unused_classes() {
     test("class A { m() { new B() } } class B { m() { new A() } }", "");
 }
 

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -429,7 +429,7 @@ fn remove_recursive_unused_nested_in_live_function() {
     );
 }
 
-// ---- Site-local self-recursive declarators ----
+// ---- Exact function-valued declarators ----
 
 #[test]
 fn remove_self_recursive_function_valued_declarators() {
@@ -456,25 +456,81 @@ fn keep_reachable_self_recursive_function_valued_declarators() {
     );
 }
 
-// A for initializer is an actual declarator removal site, so it can use the
-// same local self-reference check without becoming a graph candidate.
+#[test]
+fn keep_reachable_recursive_function_valued_declarators() {
+    test_smallest(
+        "const a = () => b(); const b = () => a(); use(a);",
+        "const a = () => b(), b = () => a(); use(a);",
+    );
+    test_smallest(
+        "export const a = () => b(); const b = () => a();",
+        "export const a = () => b(); const b = () => a();",
+    );
+    test_smallest(
+        "let a = () => b(); const b = () => a(); a = other;",
+        "let a = () => b(); const b = () => a(); a = other;",
+    );
+    test_smallest(
+        "eval('a()'); const a = () => b(); const b = () => a();",
+        "eval('a()'); const a = () => b(), b = () => a();",
+    );
+
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "const a = () => b(); const b = () => a();",
+        "const a = () => b(), b = () => a();",
+        SourceType::script(),
+        &options,
+    );
+
+    // Keeping `a` graph-owned prevents a single-use substitution from moving
+    // its arrow scope out of the declarator and making `b` appear unreachable.
+    test_smallest(
+        "function b() { side() } const a = () => b(); use(a);",
+        "function b() { side() } const a = () => b(); use(a);",
+    );
+
+    let options =
+        CompressOptions { unused: CompressOptionsUnused::Keep, ..CompressOptions::smallest() };
+    test_options(
+        "const a = () => b(); const b = () => a();",
+        "const a = () => b(), b = () => a();",
+        &options,
+    );
+}
+
+// A for initializer is an actual declarator removal site, so exact
+// function-valued declarators can participate in the initial graph analysis.
 #[test]
 fn remove_self_recursive_for_init_declarator() {
     test_smallest("for (let f = () => f();;) break;", "for (;;) break;");
 }
 
-// ---- Non-candidates: declarator and class cycles ----
+// ---- Recursive declarator and class cycles ----
 
-// Mutual declarator and class cycles are deliberately kept because only
-// function declarations participate in graph reachability. These tests pin
-// the currently unsupported shapes.
 #[test]
-fn keep_recursive_declarator_and_class_cycles() {
-    // const arrow cycle.
+fn remove_recursive_unused_function_valued_declarators() {
+    test_smallest("const a = () => b(); const b = () => a();", "");
+    test_smallest("const a = function() { b() }; const b = function() { a() };", "");
+    test_smallest("const a = (() => b()); const b = () => a();", "");
+    test_smallest("for (let a = () => b(), b = () => a();;) break;", "for (;;) break;");
+    test_smallest("{ const a = () => b(); const b = () => a(); side(); }", "side();");
     test_smallest(
-        "const a = () => b(); const b = () => a();",
-        "const a = () => b(), b = () => a();",
+        "switch (x) { case 0: const a = () => b(); const b = () => a(); side(); }",
+        "x === 0 && side();",
     );
+    test_smallest(
+        "class C { static { const a = () => b(); const b = () => a(); side(); } }",
+        "class C { static { side(); } }",
+    );
+    test_smallest(
+        "function outer() { const a = () => b(); const b = () => a(); return 1 } g(outer());",
+        "function outer() { return 1 } g(outer());",
+    );
+}
+
+#[test]
+fn keep_recursive_class_cycles() {
     // Class cycle with side-effect-free evaluation.
     test_same_smallest(
         "class A {\n\tm() {\n\t\tnew B();\n\t}\n}\nclass B {\n\tm() {\n\t\tnew A();\n\t}\n}",
@@ -488,12 +544,28 @@ fn keep_recursive_declarator_and_class_cycles() {
 }
 
 #[test]
-fn keep_recursive_multi_declarator_cycle() {
-    // The declarator member of the cycle keeps the function member live, so
-    // the cycle survives even after the used sibling declarator is inlined.
+fn remove_recursive_multi_declarator_cycle() {
     test_smallest(
         "const a = () => b(), keep = 1; function b() { a() } console.log(keep);",
-        "const a = () => b();\nfunction b() {\n\ta();\n}\nconsole.log(1);",
+        "console.log(1);",
+    );
+}
+
+#[test]
+fn remove_recursive_same_symbol_function_sources() {
+    // A symbol can have both a function-declaration and a declarator source.
+    // Source-kind bookkeeping must not let untracking one hide the other.
+    test_smallest("function a() { b() } var a = () => b(); function b() { a() }", "");
+}
+
+#[test]
+fn remove_recursive_declarator_with_side_effectful_redeclaration() {
+    test_smallest("var a = () => b(); var a = effect(); const b = () => a();", "effect();");
+    // The wrapper prevents `a` from becoming an exact graph candidate, so the
+    // mutually-referential declarations remain conservatively retained.
+    test_smallest(
+        "const a = (effect(), () => b()); const b = () => a();",
+        "const a = (effect(), () => b()), b = () => a();",
     );
 }
 
@@ -503,18 +575,34 @@ fn keep_recursive_multi_declarator_cycle() {
 #[test]
 fn keep_declarator_cycle_in_bare_statement_slot() {
     test_same_smallest("function a() {\n\tb();\n}\nif (g) var b = a;");
+    test_same_smallest("if (g) var a = () => b(); const b = () => a();");
 }
 
-// Future extension: mutual declarator cycles need graph participation rather
-// than the removal-site-local check used for self-recursive initializers.
 #[test]
-#[ignore = "TODO: extend recursive reachability to mutual variable declarators"]
 fn remove_recursive_unused_mutual_declarator_cycles() {
-    test_smallest("const a = () => b(); const b = () => a();", "");
     test_smallest(
-        "const a = () => b(), keep = 1; function b() { a() } console.log(keep);",
+        "const a = () => b(), b = () => a(), keep = 1; console.log(keep);",
         "console.log(1);",
     );
+}
+
+#[test]
+fn remove_issue_26117_recursive_arrow_functions() {
+    let source = "let HANDLERS;\nconst connect_node_compile_to_regexp = (connectNode) => {\n\tHANDLERS.push(connectNode[0]);\n\tnode_compile_to_regexp(connectNode[1]);\n};\nconst node_compile_to_regexp = (node) => {\n\tHANDLERS.push(node[0]);\n\tconnect_node_compile_to_regexp(node[1]);\n};\nexport {};";
+    test_smallest(source, "export {};");
+
+    // The first pass removes the functions and flushes their body references;
+    // the unused outer binding disappears in the following pass.
+    let options = CompressOptions { max_iterations: Some(0), ..CompressOptions::smallest() };
+    test_options_once_with_iterations(source, "let HANDLERS; export {};", 0, &options);
+}
+
+#[test]
+fn remove_declarator_cycles_that_become_unreachable_later() {
+    // A registered candidate is not single-use inlined while its function
+    // scope owns graph references, so a later dead-code pass can safely
+    // recompute its reachability.
+    test_smallest("if (false) a(); const a = () => b(); const b = () => a();", "");
 }
 
 // Future extension: class evaluation needs a stable removability proof before

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,11 +5,11 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 173.90 kB  | 55.50 kB   | 59.82 kB   | 18.77 kB   | 19.33 kB   |          2 | moment.js
 
-287.63 kB  | 89.01 kB   | 90.07 kB   | 30.85 kB   | 31.95 kB   |          2 | jquery.js
+287.63 kB  | 89.01 kB   | 90.07 kB   | 30.86 kB   | 31.95 kB   |          2 | jquery.js
 
 342.15 kB  | 114.81 kB  | 118.14 kB  | 42.71 kB   | 44.37 kB   |          2 | vue.js
 
-544.10 kB  | 69.88 kB   | 72.48 kB   | 25.58 kB   | 26.20 kB   |          2 | lodash.js
+544.10 kB  | 69.88 kB   | 72.48 kB   | 25.59 kB   | 26.20 kB   |          2 | lodash.js
 
 555.77 kB  | 262.75 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
@@ -17,11 +17,11 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
 
-2.14 MB    | 707.63 kB  | 724.14 kB  | 160.08 kB  | 181.07 kB  |          2 | victory.js
+2.14 MB    | 707.70 kB  | 724.14 kB  | 160.10 kB  | 181.07 kB  |          2 | victory.js
 
 3.20 MB    | 958.92 kB  | 1.01 MB    | 317.07 kB  | 331.56 kB  |          2 | echarts.js
 
-6.69 MB    | 2.12 MB    | 2.31 MB    | 453.44 kB  | 488.28 kB  |          5 | antd.js
+6.69 MB    | 2.12 MB    | 2.31 MB    | 453.59 kB  | 488.28 kB  |          5 | antd.js
 
-10.95 MB   | 3.31 MB    | 3.49 MB    | 850.04 kB  | 915.50 kB  |          4 | typescript.js
+10.95 MB   | 3.31 MB    | 3.49 MB    | 850.05 kB  | 915.50 kB  |          4 | typescript.js
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 144024
-  arena reallocs: 28468
-  arena size: 19127248 # 19.13 MB
+  arena allocs: 144045
+  arena reallocs: 28480
+  arena size: 19139648 # 19.14 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15675
-  arena reallocs: 2721
-  arena size: 2880752 # 2.88 MB
+  arena allocs: 15688
+  arena reallocs: 2726
+  arena size: 2888848 # 2.89 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 44801
-  arena reallocs: 7718
-  arena size: 6306768 # 6.31 MB
+  arena allocs: 44807
+  arena reallocs: 7720
+  arena size: 6311120 # 6.31 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 351645
-  arena reallocs: 76248
-  arena size: 48770232 # 48.77 MB
+  arena allocs: 351793
+  arena reallocs: 76369
+  arena size: 48829816 # 48.83 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64956
-  arena reallocs: 12252
-  arena size: 9393120 # 9.39 MB
+  arena allocs: 64950
+  arena reallocs: 12259
+  arena size: 9400272 # 9.40 MB


### PR DESCRIPTION
## Context

Closes #26117.

Reference counting cannot remove mutually recursive bindings because each function keeps the other binding’s reference count non-zero. `symbol_liveness` already uses graph reachability to handle this for function declarations. This extends that analysis to declarators initialized with exact arrow or function expressions.

The reported case now minifies to:

```js
export {};
```

This matches Rollup’s result while preserving the module marker at the minifier level.

The PR was done with the help of OpenAI's Codex. I reviewed the resulting changes and take responsibility for them.