### PR TITLE
fix(formatter): preserve comment for statement terminators and binary casts

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -42,6 +42,8 @@ After changing AST shapes or the generators, regenerate with `just ast`, never h
 ### Format JSDoc (`formatter/jsdoc/`)
 
 - Derived from `prettier-plugin-jsdoc`, but not fully compatible
+- Covered by plain fixture-pair tests (`--test jsdoc`, committed input/expected pairs);
+  a mismatch is a failing test, not a tracked conformance-report entry
 - See `tests/jsdoc/fixtures` for the covered behavior
   - See also `tests/jsdoc/upstream-jsdoc-bugs.md`
 
@@ -75,9 +77,6 @@ Two directions: xxx-in-js (css/graphql/html in template literals) and js-in-xxx 
 The shared two-layer split (invariants vs compat tables) and the base invariants live in FORMATTER_POLICY.md "Comment placement invariants";
 this section records their JS/TS translation and the measured compat tables.
 
-Repositioning a comment is allowed only relative to formatter-owned punctuation
-(e.g. printing `;` before a same-line trailing comment, see `FormatContentWithSemicolon`).
-
 Four token classes decide a comment's freedom of movement.
 Replaceability does not separate them (only the separator is replaceable); the guaranteed flush point does:
 a delimiter flushes on the comment's own side, a terminator only right BEHIND itself, so a riding line comment lands just past it and nothing else:
@@ -97,9 +96,9 @@ a delimiter flushes on the comment's own side, a terminator only right BEHIND it
 Known gap, intentionally not covered: TS-only statements
 (`import A = B;` / `export = x;` / `export as namespace X;` / `declare function f(): void;` / `declare module "m";`).
 
-They are terminators by the rule above, but Prettier does not move their comments (yet);
-we follow Prettier for now. If Prettier extends the rule to them, follow;
-each is a small mechanical `FormatContentWithSemicolon` adoption.
+They are terminators by the rule above, but their comments currently stay in place (coinciding with Prettier).
+Uniformizing them is OUR call, deferred for impact:
+each is a small mechanical `FormatContentWithSemicolon` adoption plus a fixture pin and a DIVERGENCES entry.
 
 When the content's source parentheses survive in the output (return/throw arguments, sequence/assignment in the prettier#19263 positions), comments inside them belong to the content and stay there;
 only comments after the closing paren may move behind the terminator (see `Comments::end_including_source_parens`).
@@ -112,22 +111,33 @@ The "which positions keep their parens" table is intentionally encoded twice:
 The statement side promises not to hide/move the comment; the expression side actually prints it.
 Change them together: if they drift, the comment silently lands elsewhere (no assert catches it), so pin every position change in a fixture.
 
-The move-behind-the-terminator policy has four deliberate variants.
-When extending to a new node, pick by measuring Prettier, not by analogy:
+One rule decides WHAT moves, at every semicolon-terminated site:
+trailing is the same-line run only. A comment preceded by a newline is never trailing, it defers (stays unprinted) to the next node's leading pass, which keeps it own-line with its blank lines.
+The leading/trailing vocabulary itself (the newline as the semantic boundary, and why deferred comments belong to the NEXT node) is defined in `formatter/trivia.rs`'s module doc.
 
-| Site                                                        | Source `;` required?      | Own-line comment before `;`                                                           |
-| ----------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------- |
-| Statements (`FormatContentWithSemicolon`)                   | yes (ASI: no move)        | deferred to the next node's leading pass                                              |
-| return/throw (`ReturnAndThrowStatement`)                    | no (moves even under ASI) | deferred to the next node's leading pass (only the same-line prefix moves behind `;`) |
-| Class property/accessor (`FormatClassElementWithSemicolon`) | yes                       | cancels the move (stays own-line)                                                     |
-| Bodyless methods (`MethodDefinition`)                       | yes                       | cancels the move                                                                      |
+The defer contract: a deferred comment crosses only already-printed statement terminators.
+The terminator set (`;`, and the `)` of dropped or re-printed parens) is encoded twice.
+`Comments::has_semicolon_or_closing_paren_in_range` decides whether the same-line run moves, `lines_after_skipping_terminators` makes the same tokens transparent to the deferred comment's break measurement.
+So change them together, and pin any extension in a fixture. (`get_lines_before`'s `;` skip is a different token: the ASI-guard `;` the next statement's own format emitted, sitting immediately before it.)
+A downstream pass must exist to print a deferred comment. (the next sibling's leading pass or the container's dangling pass.)
+
+WHEN the same-line run moves is the per-site compat table (extend by measuring Prettier, not by analogy):
+
+| Site                                                                                                                                        | Source `;` required?             |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Statements, class property/accessor, bodyless methods (`FormatContentWithSemicolon`, `FormatClassElementWithSemicolon`, `MethodDefinition`) | `;` or a `)` (bare ASI: no move) |
+| return/throw (`ReturnAndThrowStatement`)                                                                                                    | no (moves even under ASI)        |
+
+A `)` in the gap counts as a terminator (dropped or re-printed parens; the rationale lives in `trailing_comments_to_move_behind_semicolon`'s rustdoc, prettier#19930 family).
+The chain-leaf walk (`assignment_chain_leaf_end`) bounds the content at every semicolon-terminated content site (expression statements, export defaults, variable declarations, class property values, return arguments);
+which arrow bodies stop it (and the flat-JSX-body known limitation) live in `arrow_body_keeps_trailing_comment_inside_parens` and DIVERGENCES.md#paren-comment-fixpoint.
 
 JS-side mechanics of the shared "never cross" invariants:
 
 - Line boundary: line comments are printed via `line_suffix`, and own-line comments stay own-line (they become the next node's leading comments)
   - Both are structural guarantees, keep them
   - One known violation, kept for Prettier compat: an own-line comment claimed mid-line inlines onto that line (`const // c` + break), see the NOTE in `FormatLeadingComments` (`formatter/trivia.rs`)
-- User content: e.g. Prettier relocates a comment after a trailing array hole backward across commas to the last real element — an attachment artifact, we keep the comment in place and diverge intentionally
+- User content: attachment artifacts that relocate a comment across tokens are divergences to pin, never rules to emulate (e.g. DIVERGENCES.md#array-hole-trailing-comment)
 - Suppression: when hiding comments from a node (`limit_comments_up_to`), check `has_trailing_suppression_comment` first, or the node loses its suppression
 
 Head-body comment policy ("never cross user content" applied to statement/declaration heads):
@@ -138,11 +148,18 @@ a body's `{` `}` and a head's `(` `)` are delimiters, and an empty-statement bod
 - own-line comment keeps its own line
 - comments before a `}`-to-keyword gap (`else`/`catch`/`finally`/`while`) split at the keyword and keep their side
 
+The `as`/`satisfies` operator gap follows the same policy (see `as_or_satisfies_expression.rs` and DIVERGENCES.md#binary-cast-own-line-comment), with two additions of its own:
+
+- the pre-operator slot is grammar-bounded (no line terminator may precede the operator, a multiline comment's interior counts), so once the expression's source parens are dropped, only same-line single-line block comments stay on the expression side;
+  - everything else normalizes to the type side so the output re-parses
+- paragraph-like promotion: a line-ending multiline block goes own-line above the type.
+  - `=`/`:` reach the same outputs through their own machinery (`AssignmentLike`, see DIVERGENCES.md#eol-comment-after-assign-colon for their line-comment glue);
+  - the head-body `write_*` helpers split on `preceded_by_newline` alone and do not have the promotion.
+
 Implemented by the `write_*` helpers in `utils/statement_body.rs` and `FormatParenHeadExpression` (`print/mod.rs`); their rustdocs cover the trailing-pass suppression mechanics.
 
-Prettier's comment _attachment_ is position-heuristic and sometimes asymmetric
-(e.g. it moves `export type T = string /* c */;`'s comment behind the semicolon but not the non-exported form).
-When that happens, prefer one uniform rule over emulating the asymmetry, and pin the intentional divergence in a fixture with a note.
+Prettier's comment attachment is position-heuristic and sometimes asymmetric;
+that is FORMATTER_POLICY's uniform-rule ground (reason 3): one rule over the emulated asymmetry, pinned as a divergence (e.g. DIVERGENCES.md#type-alias-trailing-comment-move).
 
 ### Statement terminators and suppression
 

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -212,30 +212,126 @@ type NestedParens =
 
 Prettier does the same normalization except for nested single-member paren sources and multiline block comments starting their line, where it keeps `/* c */ | A` — an output it then reformats into `| /* c */ A` itself for the first shape (not idempotent); we normalize directly.
 
+## deferred-own-line-comment-stays-own-line
+
+- Why: uniform-rule (the own-line invariant; Prettier's glue is an attachment artifact)
+- Pin: `tests/fixtures/ts/semicolons/trailing-comments.ts`
+
+An own-line comment deferred across a statement terminator (printed behind the previous node) stays own-line, with its blank lines preserved; the already-printed `;` is transparent to the break measurement (`lines_after_skipping_terminators`):
+
+```ts
+// input
+bar = 2
+/* own line */;
+
+quux();
+
+// ours
+bar = 2;
+/* own line */
+
+quux();
+
+// prettier (comment glued onto the next statement, the blank hoisted above it)
+bar = 2;
+
+/* own line */ quux();
+```
+
+Prettier attaches the comment as the next statement's leading and measures its break from the source `;`, gluing them; ours keeps the comment's own-line-ness and its distance to both neighbors as written.
+
 ## paren-comment-fixpoint
 
-- Why: prettier-bug (fixed upstream in prettier#19893 / prettier#19894)
-- Pin: `tests/fixtures/ts/semicolons/trailing-comments.ts`, `tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js`
-- Drop when: the pin catches up (converge on Prettier's now-fixed output)
+- Why: uniform-rule (upstream converging piecewise: prettier#19893 / prettier#19894 / prettier#19930 merged, prettier#19956 open)
+- Pin: `tests/fixtures/ts/semicolons/trailing-comments-parens.ts`, `tests/fixtures/ts/semicolons/trailing-comments-class-members.ts`, `tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js`
 
-Two comment placements print Prettier's second-pass fixpoint directly, where the pinned Prettier is not idempotent:
+Comment placements printing Prettier's second-pass fixpoint directly, where the pinned Prettier is not idempotent:
 
 ```js
 // input
 assigned = (a = c /* c1 */);
 ((/* c2 */ a), b);
+chained = (a) => ((b) => {
+  c();
+} /* c3 */)
+asiLeaf = (someValue /* c4 */)
 
 // ours
 assigned = a = c; /* c1 */
 /* c2 */ (a, b);
+chained = (a) => (b) => {
+  c();
+}; /* c3 */
+asiLeaf = someValue; /* c4 */
 
 // prettier (first pass; its second pass produces ours)
 assigned = a = c /* c1 */;
 (/* c2 */ a, b);
+chained = (a) => (b) => {
+  c();
+} /* c3 */;
+asiLeaf = someValue /* c4 */;
 ```
 
-- A trailing comment inside an expression statement's dropped parentheses moves behind the `;`, including the chain-leaf shapes prettier#19893 left out
+- A trailing comment inside a statement's dropped parentheses moves behind the `;`, including the chain-leaf shapes prettier#19893 left out
+- The chain passes through arrow expression bodies, and a dropped `)` counts as the terminator even without a source `;`
+  - prettier#19930 covers assignment/arrow links, the open prettier#19956 the rest; ours is one uniform rule
+- The walk stops where the comment stays inside re-added parens (sequence, assignment, JSX); conditional bodies move
+- Applied at every semicolon-terminated site: expression statements, export defaults, variable declarations, class property values, return arguments
+- A class member's same-line comment moves even when an own-line comment sits between it and the `;` (the pinned Prettier cancels the move on its first pass, then moves on its second — the `d = 4` and `dmixed` pins); the own-line one defers to the next element, like statements
 - A comment inside a sequence's parenthesized first element leads the sequence, outside the formatter-added parens
+
+Known limitation, shared with upstream: whether these parens survive is a group-fit decision, unknowable when the content end is chosen, so the comment settles only on the second pass when they end up dropped — a short JSX arrow body (`x = (a) => (<div /> /* c */)`), or a `;`-less return argument whose parenthesized binary fits flat (the `asiReturn` pin).
+
+## binary-cast-own-line-comment
+
+- Why: uniform-rule (upstream converging piecewise: prettier#19939 merged, prettier#19958 open)
+- Pin: `tests/fixtures/ts/comments/binary-cast-own-line-comment.ts`
+
+Comments around the operator keep their source side and their line-start side — the head-body comment policy applied to the operator gap, unifying it with `=`/`:` (`eol-comment-after-assign-colon`) and statement head-body gaps:
+
+- before the operator: trail the expression, never cross the operator — except what the grammar-defined slot cannot hold (no line terminator may precede the operator, a multiline comment's interior counts): those normalize to the type side so the output re-parses
+- glued after the operator: stay on the operator's line; a line comment forces the type onto the next line, a single-line block comment leaves the layout free to inline the type
+- own-line (and a line-ending multiline block, paragraph-like): lead the type on its own line, the type breaks under the operator
+
+```ts
+// input
+const t1 = {
+  prop1: 1,
+} satisfies
+// Comment
+Record<string, number>;
+const eolLine = 1 as // c
+Foo;
+const eolBlock = {} satisfies /* c */
+{};
+
+// ours
+const t1 = {
+  prop1: 1,
+} satisfies
+  // Comment
+  Record<string, number>;
+const eolLine = 1 as // c
+  Foo;
+const eolBlock = {} satisfies /* c */ {};
+
+// prettier (pinned): pulls the own-line comment beside the operator (three passes
+// to settle), relocates the line comment across the type and the `;`,
+// and the block comment backward across the operator
+const t1 = {
+  prop1: 1,
+} satisfies // Comment
+Record<string, number>;
+const eolLine = 1 as Foo; // c
+const eolBlock = {} /* c */ satisfies {};
+```
+
+Prettier is converging on its own piecewise fixes (own-line comments in prettier#19939, endOfLine comments reattached in the open prettier#19958, both normalizing toward own-line); we preserve the written position instead, so the entry outlives them.
+
+`as const` follows the same policy (`const` is a type like any other; the pinned Prettier relocates its comments across `const` and the `;`).
+The one exclusion, pinned in the fixture: union types defer to the union printer's own comment claiming (a same-line line comment before a union still moves behind the statement, crossing the type — an invariant violation tolerated only here) — that claiming is its own subsystem, see #union-leading-pipe-comment-normalization and #union-added-paren-comment-side.
+Drop when: the union printer's claiming is bounded to its own gap; this exclusion then collapses into the general slot rule above (the `unionEol` pin flips).
 
 ## head-body-comment-relocation
 

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -304,26 +304,28 @@ impl<'a> Comments<'a> {
             .then(|| &comments[..count])
     }
 
-    /// Whether the source has a `;` between the given positions,
-    /// ignoring `;` bytes inside comments (e.g. `foo /* ; */`).
-    /// `false` when the source relies on ASI.
+    /// Whether the range holds a `;` or a `)` outside comments (`foo /* ; */` doesn't count).
+    /// Why a `)` counts as a statement terminator: see `trailing_comments_to_move_behind_semicolon`.
     ///
     /// Lexical byte scan: the range must contain only trivia and punctuation.
     /// (e.g. a content end up to the statement end)
-    /// A range containing a string literal would false-match a `;` inside it.
-    pub(crate) fn has_semicolon_in_range(&self, start: u32, end: u32) -> bool {
+    /// A range containing a string literal would false-match a byte inside it.
+    pub(crate) fn has_semicolon_or_closing_paren_in_range(&self, start: u32, end: u32) -> bool {
+        let has_terminator = |from: u32, to: u32| {
+            self.source_text.bytes_range(from, to).iter().any(|&b| matches!(b, b';' | b')'))
+        };
         let mut pos = start;
         for comment in self.comments_in_range(start, end) {
             // A comment ending exactly at `start` lies before the range
             if comment.span.start < pos {
                 continue;
             }
-            if self.source_text.bytes_contain(pos, comment.span.start, b';') {
+            if has_terminator(pos, comment.span.start) {
                 return true;
             }
             pos = comment.span.end;
         }
-        self.source_text.bytes_contain(pos, end, b';')
+        has_terminator(pos, end)
     }
 
     /// End of the content including its source parentheses:

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -13,6 +13,24 @@
 //! 3. **Comments are formatted** with appropriate spacing and breaks
 //! 4. **The cursor is advanced** to mark comments as processed
 //!
+//! ## What is trailing, what is leading
+//!
+//! The newline is the semantic boundary, not the node's span:
+//!
+//! Trailing is the same-line run only.
+//! A comment starting on the line of the content it follows annotates THAT line.
+//!
+//! A comment preceded by a newline is never trailing, even when it sits inside the node's span (before its `;`):
+//! an own-line comment annotates what comes BELOW it, so it belongs to the next node's leading pass.
+//! Concretely: an own-line suppression comment must target the NEXT element,
+//! and the blank lines between the comment and that element can only be measured by the pass that prints the element.
+//! Such comments stay unprinted (defer) and the next leading pass claims them;
+//! the already-printed terminator left in the gap is transparent to their break measurement
+//! (`lines_after_skipping_terminators`).
+//!
+//! The per-site rules for WHEN a trailing run moves behind its terminator live in AGENTS.md,
+//! "Comment placement invariants" (the move-behind table).
+//!
 //! ## Comment Formatting Implementation
 //!
 //! ### Leading Comment Formatting ([`FormatLeadingComments`])
@@ -37,7 +55,7 @@
 //!
 //! **Implementation**:
 //! 1. Calls `get_trailing_comments()` with node context to determine ownership
-//! 2. Defers same-line trailing LINE comments via `line_suffix`
+//! 2. Rides same-line trailing LINE comments on `line_suffix`
 //!    (excluded from the printer's fits measurement, so they never count toward the print width);
 //!    same-line trailing BLOCK comments print inline and DO count
 //! 3. Handles complex spacing rules for different comment types
@@ -99,7 +117,13 @@ pub const fn format_leading_comments<'a>(span: Span) -> FormatLeadingComments<'a
 #[derive(Debug, Copy, Clone)]
 pub enum FormatLeadingComments<'a> {
     Node(Span),
+    /// For comment runs that are NOT a node's leading pass
+    /// (no already-printed terminator can sit between them and what follows);
+    /// a node's leading comments go through [`Self::Node`] / [`Self::CommentsOfNode`]
     Comments(&'a [Comment]),
+    /// Like [`Self::Comments`], claimed by the node starting at the given position
+    /// (see `lines_after_skipping_terminators`)
+    CommentsOfNode(&'a [Comment], u32),
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
@@ -120,6 +144,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
         // Kept for now: Prettier byte-compat outweighs the invariant.
         fn format_leading_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
+            // The claiming node's start (see `lines_after_skipping_terminators`)
+            terminator_limit: Option<u32>,
             f: &mut JsFormatter<'_, 'a>,
         ) {
             let mut leading_comments_iter = comments.into_iter().peekable();
@@ -127,50 +153,46 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
                 f.context_mut().comments_mut().increment_printed_count();
                 write!(f, comment);
 
-                match comment.kind {
-                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
-                        match f.source_text().lines_after(comment.span.end) {
-                            0 => {
-                                let should_nestle =
-                                    leading_comments_iter.peek().is_some_and(|next_comment| {
-                                        should_nestle_adjacent_doc_comments(comment, next_comment)
-                                    });
+                let lines_after = f
+                    .source_text()
+                    .lines_after_skipping_terminators(comment.span.end, terminator_limit);
+                let is_block = matches!(
+                    comment.kind,
+                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock
+                );
+                match lines_after {
+                    0 if is_block => {
+                        let should_nestle =
+                            leading_comments_iter.peek().is_some_and(|next_comment| {
+                                should_nestle_adjacent_doc_comments(comment, next_comment)
+                            });
 
-                                write!(f, [maybe_space(!should_nestle)]);
-                            }
-                            1 => {
-                                if f.lines_before(comment.span) == 0 {
-                                    write!(f, [soft_line_break_or_space()]);
-                                } else {
-                                    write!(f, [hard_line_break()]);
-                                }
-                            }
-                            _ => write!(f, [empty_line()]),
+                        write!(f, [maybe_space(!should_nestle)]);
+                    }
+                    1 if is_block => {
+                        if f.lines_before(comment.span) == 0 {
+                            write!(f, [soft_line_break_or_space()]);
+                        } else {
+                            write!(f, [hard_line_break()]);
                         }
                     }
-                    CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
-                        0 | 1 => write!(f, [hard_line_break()]),
-                        _ => write!(f, [empty_line()]),
-                    },
+                    0 | 1 => write!(f, [hard_line_break()]),
+                    _ => write!(f, [empty_line()]),
                 }
             }
         }
 
-        match self {
+        let (comments, terminator_limit) = match self {
             Self::Node(span) => {
-                let leading_comments = f.context().comments().comments_before(span.start);
-                if leading_comments.is_empty() {
-                    return;
-                }
-                format_leading_comments_impl(leading_comments, f);
+                (f.context().comments().comments_before(span.start), Some(span.start))
             }
-            Self::Comments(comments) => {
-                if comments.is_empty() {
-                    return;
-                }
-                format_leading_comments_impl(*comments, f);
-            }
+            Self::Comments(comments) => (*comments, None),
+            Self::CommentsOfNode(comments, node_start) => (*comments, Some(*node_start)),
+        };
+        if comments.is_empty() {
+            return;
         }
+        format_leading_comments_impl(comments, terminator_limit, f);
     }
 }
 
@@ -249,17 +271,15 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTrailingComments<'a> {
                     should_nestle_adjacent_doc_comments(previous_comment, comment)
                 });
 
-                // This allows comments at the end of nested structures:
+                // An own-line comment at the end of a nested structure:
                 // {
                 //   x: 1,
                 //   y: 2
-                //   // A comment
+                //   // comment
                 // }
-                // Those kinds of comments are almost always leading comments, but
-                // here it doesn't go "outside" the block and turns it into a
-                // trailing comment for `2`. We can simulate the above by checking
-                // if this a comment on its own line; normal trailing comments are
-                // always at the end of another expression.
+                // has no next sibling inside the block to defer to,
+                // so the last node's trailing pass RENDERS it (own-line style, detected by its lines-before)
+                // instead of letting it escape the block.
                 if total_lines_before > 0
                     || previous_comment.is_some_and(|comment| comment.is_line())
                 {

--- a/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
@@ -3,6 +3,7 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
+    format_args,
     formatter::{prelude::*, trivia::FormatTrailingComments},
     print::{FormatNodeWithoutTrailingComments, FormatWrite},
     write,
@@ -42,29 +43,93 @@ fn format_as_or_satisfies_expression<'a>(
     f: &mut JsFormatter<'_, 'a>,
 ) {
     let format_inner = format_with(|f| {
+        let expression_end = expression.span().end;
         let type_start = type_annotation.span().start;
 
-        // Check for block comments between expression and type.
-        // Prettier's `handleBinaryCastExpressionComment()` handles these specially.
-        // https://github.com/prettier/prettier/blob/fdfa6701767f5140a85902ecc9fb6444f5b4e3f8/src/language-js/comments/handle-comments.js#L1131
-        // See also https://github.com/prettier/prettier/blob/3.7.3/tests/format/typescript/as/comments/18160.ts
-        let comments = f.context().comments().comments_in_range(expression.span().end, type_start);
-        let multiline_comment_position = comments.iter().position(|c| c.is_multiline_block());
-        let block_comments =
-            if let Some(pos) = multiline_comment_position { &comments[..pos] } else { comments };
-
-        if !comments.is_empty()
-            && let AstNodes::TSTypeReference(reference) = type_annotation.as_ast_nodes()
-            && reference.type_name.is_const()
-        {
-            write!(f, [FormatNodeWithoutTrailingComments(expression)]);
-            write!(f, [FormatTrailingComments::Comments(block_comments)]);
-            write!(f, [space(), token(operation), space(), token("const")]);
-        } else if block_comments.is_empty() {
-            write!(f, [FormatNodeWithoutTrailingComments(expression)]);
+        if matches!(type_annotation.as_ref(), TSType::TSUnionType(_)) {
+            // The union printer claims its leading comments itself
+            // (its own subsystem, see DIVERGENCES.md#union-leading-pipe-comment-normalization);
+            // only a leading multiline block is kept from the expression's trailing claim,
+            // the rest follows the ordinary claiming rules.
+            let comments = f.context().comments().comments_in_range(expression_end, type_start);
+            if comments.first().is_some_and(|c| !c.is_multiline_block()) {
+                write!(f, [expression]);
+            } else {
+                write!(f, [FormatNodeWithoutTrailingComments(expression)]);
+            }
             write!(f, [space(), token(operation), space(), type_annotation]);
+            return;
+        }
+
+        // The operator gap's comment slots are grammar-defined:
+        // no line terminator may precede the operator (a multiline comment's interior counts),
+        // so once the expression's source parens are dropped,
+        // only same-line single-line block comments can stay on the expression side.
+        // Riding line comment flushes behind the operator, everything else normalizes to the type side.
+        // Within those slots, comments keep their source side and their line-start side,
+        // the head-body comment policy applied to the operator gap (see DIVERGENCES.md#binary-cast-own-line-comment).
+        let comments = f.context().comments().comments_in_range(expression_end, type_start);
+        // A suppression comment must stay visible to the type it targets:
+        // leave the whole gap to the type's leading pass instead of consuming it
+        // (the break decision below still applies, keeping own-line ones own-line)
+        let has_suppression_comment =
+            comments.iter().any(|c| f.context().comments().is_suppression_comment(c));
+        let before_operator_count = if comments.is_empty() {
+            0
         } else {
-            write!(f, [expression, space(), token(operation), space(), type_annotation]);
+            // The gap holds only trivia and `)`, so the operator's first byte splits the comments at the operator
+            f.context()
+                .comments()
+                .comments_before_character(expression_end, operation.as_bytes()[0])
+                .len()
+        };
+        // Both scans start from the unprinted cursor at `expression_end`, so the count indexes `comments`
+        debug_assert!(before_operator_count <= comments.len());
+        let pre_glued_count = comments[..before_operator_count]
+            .iter()
+            .take_while(|c| !c.preceded_by_newline() && !c.is_multiline_block())
+            .count();
+        // Comments the pre-operator slot cannot hold; they print on the type side
+        let pre_moved = &comments[pre_glued_count..before_operator_count];
+
+        let after_operator_comments = &comments[before_operator_count..];
+        // The run still on the operator's line;
+        // a line-ending multiline block is promoted out of it (printed own-line above the type).
+        // With unprinted pre-operator comments pending, nothing glues: everything leads the type in source order.
+        let glued_count = if pre_moved.is_empty() {
+            after_operator_comments
+                .iter()
+                .take_while(|c| {
+                    !(c.preceded_by_newline()
+                        || (c.is_multiline_block() && c.followed_by_newline()))
+                })
+                .count()
+        } else {
+            0
+        };
+        let promoted = |c: &Comment| {
+            c.followed_by_newline() && (c.preceded_by_newline() || c.is_multiline_block())
+        };
+        let type_on_own_line = comments[..pre_glued_count].iter().any(|c| c.is_line())
+            || pre_moved.iter().any(promoted)
+            || after_operator_comments[..glued_count].iter().any(|c| c.is_line())
+            || after_operator_comments[glued_count..].iter().any(promoted);
+
+        // The non-glued rest stays unprinted and leads the type;
+        // the expression must not claim the after-operator comments (it would pull them backward across the operator)
+        write!(f, [FormatNodeWithoutTrailingComments(expression)]);
+        if !has_suppression_comment {
+            write!(f, [FormatTrailingComments::Comments(&comments[..pre_glued_count])]);
+        }
+        write!(f, [space(), token(operation)]);
+        if !has_suppression_comment {
+            write!(f, [FormatTrailingComments::Comments(&after_operator_comments[..glued_count])]);
+        }
+        if type_on_own_line {
+            // The hard break also flushes a glued riding line comment
+            write!(f, [indent(&format_args!(hard_line_break(), type_annotation))]);
+        } else {
+            write!(f, [space(), type_annotation]);
         }
     });
 

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -17,7 +17,10 @@ use crate::{
     parentheses::NeedsParentheses,
     print::{
         function::should_group_function_parameters,
-        semicolon::{OptionalSemicolon, trailing_comments_to_move_behind_semicolon},
+        semicolon::{
+            OptionalSemicolon, assignment_chain_leaf_end,
+            trailing_comments_to_move_behind_semicolon,
+        },
     },
     utils::{
         assignment_like::AssignmentLike,
@@ -138,25 +141,23 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
         // (`FunctionType::TSEmptyBodyFunctionExpression` or an abstract method)
         // and always takes its semicolon.
         // Same-line comments between the signature and the source `;` move behind it
-        // like Prettier: `m(): void /* c */;` -> `m(): void; /* c */`
-        // An own-line comment stays in place, like class properties.
-        // Unlike statements, no later pass prints these comments, so all of them move.
+        // like Prettier (`m(): void /* c */;` -> `m(): void; /* c */`);
+        // own-line ones defer to the next element's leading pass, like every other semicolon-terminated site.
         let node_end = self.span.end;
         let comments = f.context().comments().comments_before(node_end);
-        let moves_comments = !comments.is_empty()
-            && !comments.iter().any(|comment| comment.preceded_by_newline())
-            && {
-                let content_end = f.comments().end_including_source_parens(
-                    value.return_type().map_or_else(|| value.params().span.end, |rt| rt.span.end),
-                    node_end,
-                );
-                trailing_comments_to_move_behind_semicolon(f, content_end, node_end).is_some()
-            };
-        if moves_comments {
-            write!(f, [OptionalSemicolon, FormatTrailingComments::Comments(comments)]);
-        } else {
-            write!(f, [FormatTrailingComments::Comments(comments), OptionalSemicolon]);
+        if !comments.is_empty() {
+            let content_end = f.comments().end_including_source_parens(
+                value.return_type().map_or_else(|| value.params().span.end, |rt| rt.span.end),
+                node_end,
+            );
+            if let Some(trailing_comments) =
+                trailing_comments_to_move_behind_semicolon(f, content_end, node_end)
+            {
+                write!(f, [OptionalSemicolon, FormatTrailingComments::Comments(trailing_comments)]);
+                return;
+            }
         }
+        write!(f, [FormatTrailingComments::Comments(comments), OptionalSemicolon]);
     }
 }
 
@@ -621,42 +622,36 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a,
             // (the class element owns its own semicolon machinery,
             // so this cannot go through `FormatContentWithSemicolon`)
             let node_end = self.element.span().end;
-            let (value_end, type_annotation_end, key_end) = match self.element.as_ref() {
-                ClassElement::PropertyDefinition(def) => (
-                    def.value.as_ref().map(|value| value.span().end),
-                    def.type_annotation.as_ref().map(|ta| ta.span.end),
-                    def.key.span().end,
-                ),
-                ClassElement::AccessorProperty(def) => (
-                    def.value.as_ref().map(|value| value.span().end),
-                    def.type_annotation.as_ref().map(|ta| ta.span.end),
-                    def.key.span().end,
-                ),
+            let (value, type_annotation, key) = match self.element.as_ref() {
+                ClassElement::PropertyDefinition(def) => {
+                    (&def.value, &def.type_annotation, &def.key)
+                }
+                ClassElement::AccessorProperty(def) => (&def.value, &def.type_annotation, &def.key),
                 _ => {
                     unreachable!("Only `PropertyDefinition` and `AccessorProperty` can reach here");
                 }
             };
+            // The value end is the chain leaf's, like an expression statement.
             // A definite/optional marker may sit between `content_end` and the `;`
             // (`z? /* e */;` -> `content_end` is after `z`);
             // the comment still ends up behind the semicolon like Prettier.
-            let content_end = value_end.or(type_annotation_end).unwrap_or(key_end);
-            // An own-line comment before the semicolon stays attached to the value
-            // (`x = 1 \n /* own */;` keeps the comment on its own line like Prettier),
-            // unlike statements, whose own-line comments always defer to the next node.
-            let trailing_comments =
-                trailing_comments_to_move_behind_semicolon(f, content_end, node_end).filter(|_| {
-                    !f.comments()
-                        .comments_before_character(content_end, b';')
-                        .iter()
-                        .any(|comment| comment.preceded_by_newline())
-                });
-            if let Some(trailing_comments) = trailing_comments {
+            let content_end = value
+                .as_ref()
+                .map(assignment_chain_leaf_end)
+                .or_else(|| type_annotation.as_ref().map(|ta| ta.span.end))
+                .unwrap_or_else(|| key.span().end);
+            // `node_end` bound: the element may have no source `;` at all
+            // (a dropped-paren terminator, `p = (q = 1 /* c */)`).
+            // The gate's same-line run moves behind the `;`,
+            // own-line comments defer to the next element's leading pass as like statements.
+            if let Some(trailing_comments) =
+                trailing_comments_to_move_behind_semicolon(f, content_end, node_end)
+            {
                 format_content_without_comments_after(self.element, content_end, f);
                 write!(f, [";", FormatTrailingComments::Comments(trailing_comments)]);
             } else {
                 write!(f, [FormatNodeWithoutTrailingComments(self.element), ";"]);
             }
-            // Print trailing comments after the semicolon
             match self.element.as_ast_nodes() {
                 AstNodes::PropertyDefinition(prop) => {
                     prop.format_trailing_comments(f);

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -14,7 +14,10 @@ use crate::{
     },
     print::{
         import_declaration::format_source_with_clause_and_semicolon,
-        semicolon::{FormatContentWithSemicolon, OptionalSemicolon},
+        semicolon::{
+            FormatContentWithSemicolon, OptionalSemicolon,
+            semicolon_terminated_expression_content_end,
+        },
     },
     utils::{
         decorators_before_export_start, export_declaration_span, export_default_declaration_span,
@@ -33,8 +36,10 @@ fn format_export_keyword_with_class_decorators<'a>(
     // `@decorator export class Cls {}`
     //            ^ print leading comments here
     let format_leading_comments = format_with(|f| {
+        // This IS the statement's leading pass (the generated one is skipped for the decorator interleaving),
+        // so deferred comments need the node bound.
         let comments = f.context().comments().comments_before(span.start);
-        FormatLeadingComments::Comments(comments).fmt(f);
+        FormatLeadingComments::CommentsOfNode(comments, span.start).fmt(f);
     });
 
     if let AstNodes::Class(class) = declaration
@@ -131,10 +136,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
         );
 
         if declaration.is_expression() {
-            write!(
+            let content_end = semicolon_terminated_expression_content_end(
                 f,
-                FormatContentWithSemicolon::new(declaration, declaration.span().end, self.span.end)
+                declaration.as_ref().to_expression(),
+                declaration.span().end,
+                self.span.end,
+                false,
             );
+            write!(f, FormatContentWithSemicolon::new(declaration, content_end, self.span.end));
         } else {
             write!(f, declaration);
         }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -40,7 +40,7 @@ pub use arrow_function_expression::{
 pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
 pub use union_type::{
-    alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
+    alias_union_breaks_after_operator, is_line_ending_trailing_jsdoc_comment, type_alias_left_end,
 };
 
 use cow_utils::CowUtils;
@@ -101,8 +101,8 @@ use self::{
     program::FormatStatementsWithImports,
     return_or_throw_statement::FormatAdjacentArgument,
     semicolon::{
-        FormatContentWithSemicolon, OptionalSemicolon, assignment_chain_leaf_end,
-        keeps_trailing_comment_inside_parens, write_trailing_comments_inside_parens,
+        FormatContentWithSemicolon, OptionalSemicolon, semicolon_terminated_expression_content_end,
+        write_trailing_comments_inside_parens,
     },
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
 };
@@ -666,11 +666,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
         } else {
             leading_comments.len()
         };
-        write!(f, FormatLeadingComments::Comments(&leading_comments[..split]));
+        write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[..split], span.start));
         if needs_semicolon {
             write!(f, ";");
         }
-        write!(f, FormatLeadingComments::Comments(&leading_comments[split..]));
+        write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[split..], span.start));
 
         if f.comments().has_trailing_suppression_comment(span.end) {
             // Preserve original text when the statement has an inline suppression comment:
@@ -680,15 +680,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
         }
 
         let expression = self.expression();
-        // A trailing comment right before the closing paren of the rightmost
-        // sequence/assignment stays inside the parentheses;
-        // extend the content past the closing paren so the comment is not moved behind the semicolon
-        // (the sub-expression prints it, see `keeps_trailing_comment_inside_parens`).
-        let content_end = if keeps_trailing_comment_inside_parens(expression.as_ref(), false) {
-            f.comments().end_including_source_parens(expression.span().end, self.span().end)
-        } else {
-            assignment_chain_leaf_end(expression.as_ref())
-        };
+        let content_end = semicolon_terminated_expression_content_end(
+            f,
+            expression.as_ref(),
+            expression.span().end,
+            self.span().end,
+            false,
+        );
         write!(f, FormatContentWithSemicolon::new(expression, content_end, self.span().end));
     }
 }

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -10,7 +10,8 @@ use crate::{
         trivia::{DanglingIndentMode, FormatDanglingComments},
     },
     print::{
-        ExpressionLeftSide, return_statement_content_end, semicolon::OptionalSemicolon,
+        ExpressionLeftSide, return_statement_content_end,
+        semicolon::{OptionalSemicolon, assignment_chain_leaf_end},
         semicolon_terminated_content_end, write_suppressed_statement,
     },
     utils::{
@@ -84,14 +85,20 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ReturnAndThrowStatement<'a, '_> {
 
         if let Some(argument) = self.argument() {
             write!(f, space());
-            if f.comments().has_comment_in_range(argument.span().end, self.span().end) {
+            let argument_leaf_end = assignment_chain_leaf_end(argument.as_ref());
+            if f.comments().has_comment_in_range(argument_leaf_end, self.span().end) {
                 // Comments inside the argument's source parentheses belong to the argument
                 // and stay in place (`return (\n  a && b // c\n);` keeps the comment inside, like Prettier);
                 // only comments after the closing paren are dangling comments.
                 // Unlike `FormatContentWithSemicolon` they move even without a source `;` (ASI),
                 // matching Prettier's dangling-comment handling for return/throw.
-                let argument_end =
-                    f.comments().end_including_source_parens(argument.span().end, self.span().end);
+                // ... except when the chain-leaf walk descended into the argument:
+                // the chain's inner parens are dropped, so comments inside them move too
+                let argument_end = if argument_leaf_end < argument.span().end {
+                    argument_leaf_end
+                } else {
+                    f.comments().end_including_source_parens(argument.span().end, self.span().end)
+                };
                 if f.comments().has_trailing_suppression_comment(argument_end) {
                     // Keep a trailing suppression comment visible to the argument,
                     // so it preserves its original text.

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -28,9 +28,13 @@ impl<'a> Format<'a, JsFormatContext<'a>> for OptionalSemicolon {
 /// Returns the comments to print after the semicolon,
 /// or `None` when the rule does not apply and the content prints as-is:
 /// - no comment between the content and the end of the node (the common case),
-/// - no actual `;` in the source (ASI) — there is nothing to move the comments across,
-/// - a trailing suppression comment (`content /* oxfmt-ignore */;`) must
-///   stay visible to the content so it preserves its original text.
+/// - no actual `;` and no dropped `)` in the source (ASI):
+///   there is nothing to move the comments across;
+///   a closing paren in the range counts because those parens are dropped
+///   (or re-printed on the statement's own terms),
+///   so the comment would trail the whole statement on the next format anyway (prettier#19930),
+/// - a trailing suppression comment (`content /* oxfmt-ignore */;`)
+///   must stay visible to the content so it preserves its original text.
 ///
 /// `Some` may hold an empty slice (e.g. own-line comments only); the caller
 /// still hides the comments from the content and a later pass prints them.
@@ -41,7 +45,7 @@ pub fn trailing_comments_to_move_behind_semicolon<'a>(
 ) -> Option<&'a [Comment]> {
     let comments = f.context().comments();
     if !comments.has_comment_in_range(content_end, node_end)
-        || !comments.has_semicolon_in_range(content_end, node_end)
+        || !comments.has_semicolon_or_closing_paren_in_range(content_end, node_end)
     {
         return None;
     }
@@ -63,6 +67,9 @@ pub fn trailing_comments_to_move_behind_semicolon<'a>(
 /// The sequence/assignment itself prints the comment before its closing paren.
 ///
 /// `gated` is `true` when `expr` itself sits in one of those positions.
+///
+/// [`arrow_body_keeps_trailing_comment_inside_parens`] encodes the arrow-body slice of this table (plus JSX)
+/// for the chain-leaf walk; change them together.
 pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) -> bool {
     match expr {
         Expression::SequenceExpression(_) => gated,
@@ -91,12 +98,65 @@ pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) 
 /// // ->
 /// assigned = a = c; /* c */
 /// ```
+///
+/// The chain also passes through arrow expression bodies (prettier#19930 family);
+/// bodies matching [`arrow_body_keeps_trailing_comment_inside_parens`] stop the walk.
 pub fn assignment_chain_leaf_end(expr: &Expression<'_>) -> u32 {
     let mut leaf = expr;
-    while let Expression::AssignmentExpression(assignment) = leaf {
-        leaf = &assignment.right;
+    loop {
+        match leaf {
+            Expression::AssignmentExpression(assignment) => leaf = &assignment.right,
+            Expression::ArrowFunctionExpression(arrow) => match arrow.get_expression() {
+                Some(body) if !arrow_body_keeps_trailing_comment_inside_parens(body) => {
+                    leaf = body;
+                }
+                _ => break,
+            },
+            _ => break,
+        }
     }
     leaf.span().end
+}
+
+/// Content end for a semicolon-terminated expression site, pairing the two functions above:
+/// past the closing source paren where the sub-expression keeps the comment inside, the chain leaf otherwise.
+///
+/// `paren_scan_start` bounds the paren scan on the keeps side
+/// (usually the expression end; a declaration passes its declarations end).
+pub fn semicolon_terminated_expression_content_end(
+    f: &JsFormatter<'_, '_>,
+    expr: &Expression<'_>,
+    paren_scan_start: u32,
+    node_end: u32,
+    gated: bool,
+) -> u32 {
+    if keeps_trailing_comment_inside_parens(expr, gated) {
+        f.context().comments().end_including_source_parens(paren_scan_start, node_end)
+    } else {
+        assignment_chain_leaf_end(expr)
+    }
+}
+
+/// Whether an arrow expression body's printer re-adds the parentheses
+/// AND keeps a trailing comment inside them, stopping the [`assignment_chain_leaf_end`] walk:
+///
+/// - sequence/assignment: the [`keeps_trailing_comment_inside_parens`] table
+///   (`write_trailing_comments_inside_parens` prints the comment inside)
+/// - JSX: the multiline form re-adds the parens with the `)` on its own line,
+///   so moving the comment would cross it and a line boundary;
+///   the flat form drops them (group-fit, unknowable here), the pinned known limitation
+///
+/// NOT conditional: its parens are formatter-owned (`should_add_parens`) and
+/// often absent (object leftmost, broken groups), and its `;` stays on the content's line,
+/// so its comments move uniformly.
+fn arrow_body_keeps_trailing_comment_inside_parens(body: &Expression<'_>) -> bool {
+    matches!(
+        body,
+        Expression::AssignmentExpression(_)
+            | Expression::SequenceExpression(_)
+            | Expression::JSXElement(_)
+            | Expression::JSXFragment(_)
+    )
 }
 
 /// The printing half of [`keeps_trailing_comment_inside_parens`]:

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -248,7 +248,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             let only_type = union_type_at_top.types.len() == 1;
             let has_own_line_comment = comment_info.has_own_line_comment
                 || (matches!(union_type_at_top.parent(), AstNodes::TSTypeAliasDeclaration(_))
-                    && comment_info.has_trailing_own_line_non_jsdoc_block_comment);
+                    && comment_info.has_line_ending_trailing_non_jsdoc_block_comment);
             // An own-line leading comment breaks BEFORE itself and stays above the first member
             // ```ts
             // type A =
@@ -284,8 +284,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
 struct LeadingCommentsInfo {
     has_own_line_comment: bool,
     has_end_of_line_comment: bool,
-    has_trailing_own_line_non_jsdoc_block_comment: bool,
-    has_trailing_own_line_jsdoc_comment: bool,
+    has_line_ending_trailing_non_jsdoc_block_comment: bool,
+    has_line_ending_trailing_jsdoc_comment: bool,
 }
 
 impl LeadingCommentsInfo {
@@ -294,17 +294,20 @@ impl LeadingCommentsInfo {
         for comment in comments {
             info.has_own_line_comment |= comment.preceded_by_newline();
             info.has_end_of_line_comment |= comment.followed_by_newline();
-            info.has_trailing_own_line_non_jsdoc_block_comment |= comment.is_block()
+            info.has_line_ending_trailing_non_jsdoc_block_comment |= comment.is_block()
                 && comment.is_trailing()
                 && comment.followed_by_newline()
                 && !matches!(comment.content, CommentContent::Jsdoc | CommentContent::JsdocLegal);
-            info.has_trailing_own_line_jsdoc_comment |= is_trailing_own_line_jsdoc_comment(comment);
+            info.has_line_ending_trailing_jsdoc_comment |=
+                is_line_ending_trailing_jsdoc_comment(comment);
         }
         info
     }
 }
 
-pub fn is_trailing_own_line_jsdoc_comment(comment: &Comment) -> bool {
+/// A trailing (same-line start) jsdoc comment that ends its source line;
+/// NOT own-line (that vocabulary means preceded by a newline, see `formatter/trivia.rs`)
+pub fn is_line_ending_trailing_jsdoc_comment(comment: &Comment) -> bool {
     matches!(comment.content, CommentContent::Jsdoc | CommentContent::JsdocLegal)
         && comment.is_trailing()
         && comment.followed_by_newline()
@@ -334,10 +337,10 @@ pub fn type_alias_left_end(decl: &TSTypeAliasDeclaration) -> u32 {
 ///   (`type A = // c` and `type A = /* c */ // c`)
 pub fn alias_union_breaks_after_operator(
     decl: &TSTypeAliasDeclaration,
-    has_trailing_own_line_jsdoc_comment: bool,
+    has_line_ending_trailing_jsdoc_comment: bool,
     comments: &Comments,
 ) -> bool {
-    has_trailing_own_line_jsdoc_comment
+    has_line_ending_trailing_jsdoc_comment
         || comments.printed_comments().last().is_some_and(|comment| {
             comment.span.start > type_alias_left_end(decl) && comment.followed_by_newline()
         })
@@ -350,7 +353,7 @@ fn should_indent_alias_union<'a>(
 ) -> bool {
     !alias_union_breaks_after_operator(
         alias,
-        comment_info.has_trailing_own_line_jsdoc_comment,
+        comment_info.has_line_ending_trailing_jsdoc_comment,
         f.comments(),
     )
 }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -3,7 +3,9 @@ use oxc_ast::ast::*;
 use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
-use crate::print::semicolon::{FormatContentWithSemicolon, keeps_trailing_comment_inside_parens};
+use crate::print::semicolon::{
+    FormatContentWithSemicolon, semicolon_terminated_expression_content_end,
+};
 use crate::utils::assignment_like::AssignmentLike;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -37,17 +39,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
             if semicolon {
                 let last_declarator = declarations.as_ref().last();
                 let declarations_end = last_declarator.map_or(self.span().end, |d| d.span().end);
-                // A trailing comment right before the closing paren of the last initializer stays inside the parentheses;
-                // extend the content past the closing paren so the comment is not moved behind the semicolon
-                // (the initializer prints it, see `keeps_trailing_comment_inside_parens`).
-                let keeps_comment_inside_parens = last_declarator
+                let content_end = last_declarator
                     .and_then(|declarator| declarator.init.as_ref())
-                    .is_some_and(|init| keeps_trailing_comment_inside_parens(init, true));
-                let content_end = if keeps_comment_inside_parens {
-                    f.comments().end_including_source_parens(declarations_end, self.span().end)
-                } else {
-                    declarations_end
-                };
+                    .map_or(declarations_end, |init| {
+                        semicolon_terminated_expression_content_end(
+                            f,
+                            init,
+                            declarations_end,
+                            self.span().end,
+                            true,
+                        )
+                    });
                 write!(
                     f,
                     FormatContentWithSemicolon::new(declarations, content_end, self.span().end)

--- a/crates/oxc_formatter/src/source_text.rs
+++ b/crates/oxc_formatter/src/source_text.rs
@@ -23,6 +23,17 @@ pub trait SourceTextExt {
     /// Count consecutive line breaks after position, returning `0` if only whitespace follows.
     fn lines_after(&self, end: u32) -> usize;
 
+    /// [`Self::lines_after`] for a deferred leading comment, bounded by the claiming node's start:
+    /// statement terminators in the gap were already printed behind the previous node,
+    /// so they are transparent to the comment's break measurement,
+    /// and a terminator alone on its line takes that line away with it.
+    ///
+    /// The terminator set (`;`, and the `)` of dropped or re-printed parens) is shared with
+    /// `Comments::has_semicolon_or_closing_paren_in_range` (whether the same-line run moves); change them together.
+    /// The bound makes an empty statement's `;` (a node, sitting AT the limit) stop the count as usual.
+    /// `None` is plain [`Self::lines_after`].
+    fn lines_after_skipping_terminators(&self, end: u32, limit: Option<u32>) -> usize;
+
     /// Count line breaks between syntax nodes, considering comments and parentheses.
     ///
     /// Encodes JS/TS leading-trivia rules:
@@ -57,16 +68,34 @@ impl SourceTextExt for SourceText<'_> {
     }
 
     fn lines_after(&self, end: u32) -> usize {
+        self.lines_after_skipping_terminators(end, None)
+    }
+
+    fn lines_after_skipping_terminators(&self, end: u32, limit: Option<u32>) -> usize {
         let text: &str = self;
+        // A skipping scan is bounded by the node start (a node begins with a real character);
+        // an unbounded one may reach end-of-text, where `0` avoids adding extra new lines
+        let slice_end = limit.map_or(text.len(), |limit| limit as usize);
         let mut count = 0;
-        let mut chars = text[end as usize..].chars().peekable();
+        // One newline behind a skipped terminator merges into the one before it
+        // (its line vanishes with it)
+        let mut discount_next_newline = false;
+        let mut chars = text[end as usize..slice_end].chars().peekable();
         while let Some(char) = chars.next() {
+            if matches!(char, ';' | ')') && limit.is_some() {
+                discount_next_newline = count > 0;
+                continue;
+            }
             if is_white_space_single_line(char) {
                 continue;
             }
 
             if is_line_terminator(char) {
-                count += 1;
+                if discount_next_newline {
+                    discount_next_newline = false;
+                } else {
+                    count += 1;
+                }
                 if char == CR && chars.peek() == Some(&LF) {
                     chars.next();
                 }
@@ -76,8 +105,7 @@ impl SourceTextExt for SourceText<'_> {
             return count;
         }
 
-        // No non-whitespace characters found after position, so return `0` to avoid adding extra new lines
-        0
+        if limit.is_some() { count } else { 0 }
     }
 
     fn get_lines_before(&self, span: Span, first_unprinted_comment: Option<Span>) -> usize {

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     print::{
         BinaryLikeExpression, FormatWrite, alias_union_breaks_after_operator,
-        is_trailing_own_line_jsdoc_comment, type_alias_left_end,
+        is_line_ending_trailing_jsdoc_comment, type_alias_left_end,
     },
     utils::{
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
@@ -654,7 +654,7 @@ impl<'a> AssignmentLike<'a, '_> {
                     decl,
                     comments
                         .comments_before_iter(annotation_start)
-                        .any(is_trailing_own_line_jsdoc_comment),
+                        .any(is_line_ending_trailing_jsdoc_comment),
                     comments,
                 ),
                 // For a single-member `TSIntersectionType`,

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-body-paren-comment.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-body-paren-comment.jsx
@@ -1,0 +1,9 @@
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (<div>
+  <span>very long content here to force multiline breaking of the jsx element</span>
+</div> /* stays */);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => (<div /> /* second pass */);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-body-paren-comment.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-body-paren-comment.jsx.snap
@@ -1,0 +1,77 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 43
+---
+==================== Input ====================
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (<div>
+  <span>very long content here to force multiline breaking of the jsx element</span>
+</div> /* stays */);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => (<div /> /* second pass */);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (
+  <div>
+    <span>
+      very long content here to force multiline breaking of the jsx element
+    </span>
+  </div> /* stays */
+);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => <div /> /* second pass */;
+
+---------- Not idempotent (second pass) ----------
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (
+  <div>
+    <span>
+      very long content here to force multiline breaking of the jsx element
+    </span>
+  </div> /* stays */
+);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => <div />; /* second pass */
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (
+  <div>
+    <span>very long content here to force multiline breaking of the jsx element</span>
+  </div> /* stays */
+);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => <div /> /* second pass */;
+
+---------- Not idempotent (second pass) ----------
+// A JSX arrow body keeps the walk out (`assignment_chain_leaf_end`):
+// when multiline, the parens are re-printed and the comment stays inside them
+multiline = (a) => (
+  <div>
+    <span>very long content here to force multiline breaking of the jsx element</span>
+  </div> /* stays */
+);
+// Known limitation (see DIVERGENCES.md#paren-comment-fixpoint): when the body
+// fits flat the parens are dropped and the comment settles only on the second
+// format; group-fit decides the parens, unknowable when the content end is chosen
+flat = (a) => <div />; /* second pass */
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/binary-cast-own-line-comment.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/binary-cast-own-line-comment.ts
@@ -1,0 +1,96 @@
+// Comments around the `satisfies` / `as` operator keep their source side and
+// their line-start side — the head-body comment policy applied to the operator
+// gap (see DIVERGENCES.md#binary-cast-own-line-comment).
+// An own-line comment leads the type on its own line, the type breaks
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+} satisfies
+// Comment
+Record<string, number>;
+const t2 = {
+  bar: 1,
+} as
+  // Comment
+  Record<string, number>;
+
+// A line-ending multiline block is paragraph-like and breaks too, jsdoc re-indented
+1 as
+/**
+ * jsdoc
+ */
+Foo;
+1 satisfies /*
+raw interior stays put
+*/
+Foo;
+
+// A glued line comment stays on the operator's line, the type breaks under it
+// (the pinned Prettier relocates it across the type and the semicolon)
+const eolLine = 1 as // c
+Foo;
+// A glued single-line block comment stays glued; the layout is free to inline
+// the type after it (the pinned Prettier relocates it backward across the operator)
+const eolBlock = {} satisfies /* c */
+{};
+
+// A suppression comment stays visible to the type it targets
+// (never consumed as a glued run); the break decision still applies
+const suppressGlued = 1 as /* oxfmt-ignore */ Foo<A,B>;
+const suppressOwnLine = 1 as
+// oxfmt-ignore
+Foo<A,B>;
+
+// A comment that does not end its line keeps the flat layout
+const flatInline = {} satisfies /* c */ {};
+const flatMultiline = 1 as /* multi
+line */ Foo;
+
+// Comments before the operator trail the expression and never cross the operator
+const preOp = {} /* t */ satisfies {};
+const preOpBreak = {} /* t */ satisfies
+// c
+Record<string, number>;
+// ... except what the grammar-defined slot cannot hold: no line terminator may
+// precede the operator (a multiline comment's interior counts), so once the
+// expression's source parens are dropped, only same-line single-line block
+// comments stay on the expression side — a riding line comment flushes behind
+// the operator, everything else normalizes to the type side (the output must
+// re-parse), where the usual layout rules apply
+const preOpLine = (foo // pre line
+) as Foo;
+const preOpOwnLine = (foo
+// pre own line
+) as Foo;
+const preOpOwnBlock = (foo
+/* pre own block */
+) as Foo;
+const preOpMultiInline = (1 /* m1
+i */) as Foo;
+const preOpMultiOwnLine = (1 /* m2
+i */
+) as Foo;
+
+// `as const` follows the same policy, `const` is a type like any other
+// (the pinned Prettier relocates all of these across `const` and the `;`)
+1 as /* c1 */ const;
+1 as // c2
+const;
+1 as
+// c3
+const;
+1 as
+/**
+ * jsdoc
+ */
+const;
+
+// A union's own-line leading comment is indented by the union printer itself;
+// no extra break on the operator.
+// Note: a same-line line comment before a union still moves behind the
+// statement (union comment claiming is its own subsystem)
+const union = 1 as
+// c
+A | B;
+const unionEol = 1 as // c
+A | B;

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/binary-cast-own-line-comment.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/binary-cast-own-line-comment.ts.snap
@@ -1,0 +1,304 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 43
+---
+==================== Input ====================
+// Comments around the `satisfies` / `as` operator keep their source side and
+// their line-start side — the head-body comment policy applied to the operator
+// gap (see DIVERGENCES.md#binary-cast-own-line-comment).
+// An own-line comment leads the type on its own line, the type breaks
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+} satisfies
+// Comment
+Record<string, number>;
+const t2 = {
+  bar: 1,
+} as
+  // Comment
+  Record<string, number>;
+
+// A line-ending multiline block is paragraph-like and breaks too, jsdoc re-indented
+1 as
+/**
+ * jsdoc
+ */
+Foo;
+1 satisfies /*
+raw interior stays put
+*/
+Foo;
+
+// A glued line comment stays on the operator's line, the type breaks under it
+// (the pinned Prettier relocates it across the type and the semicolon)
+const eolLine = 1 as // c
+Foo;
+// A glued single-line block comment stays glued; the layout is free to inline
+// the type after it (the pinned Prettier relocates it backward across the operator)
+const eolBlock = {} satisfies /* c */
+{};
+
+// A suppression comment stays visible to the type it targets
+// (never consumed as a glued run); the break decision still applies
+const suppressGlued = 1 as /* oxfmt-ignore */ Foo<A,B>;
+const suppressOwnLine = 1 as
+// oxfmt-ignore
+Foo<A,B>;
+
+// A comment that does not end its line keeps the flat layout
+const flatInline = {} satisfies /* c */ {};
+const flatMultiline = 1 as /* multi
+line */ Foo;
+
+// Comments before the operator trail the expression and never cross the operator
+const preOp = {} /* t */ satisfies {};
+const preOpBreak = {} /* t */ satisfies
+// c
+Record<string, number>;
+// ... except what the grammar-defined slot cannot hold: no line terminator may
+// precede the operator (a multiline comment's interior counts), so once the
+// expression's source parens are dropped, only same-line single-line block
+// comments stay on the expression side — a riding line comment flushes behind
+// the operator, everything else normalizes to the type side (the output must
+// re-parse), where the usual layout rules apply
+const preOpLine = (foo // pre line
+) as Foo;
+const preOpOwnLine = (foo
+// pre own line
+) as Foo;
+const preOpOwnBlock = (foo
+/* pre own block */
+) as Foo;
+const preOpMultiInline = (1 /* m1
+i */) as Foo;
+const preOpMultiOwnLine = (1 /* m2
+i */
+) as Foo;
+
+// `as const` follows the same policy, `const` is a type like any other
+// (the pinned Prettier relocates all of these across `const` and the `;`)
+1 as /* c1 */ const;
+1 as // c2
+const;
+1 as
+// c3
+const;
+1 as
+/**
+ * jsdoc
+ */
+const;
+
+// A union's own-line leading comment is indented by the union printer itself;
+// no extra break on the operator.
+// Note: a same-line line comment before a union still moves behind the
+// statement (union comment claiming is its own subsystem)
+const union = 1 as
+// c
+A | B;
+const unionEol = 1 as // c
+A | B;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments around the `satisfies` / `as` operator keep their source side and
+// their line-start side — the head-body comment policy applied to the operator
+// gap (see DIVERGENCES.md#binary-cast-own-line-comment).
+// An own-line comment leads the type on its own line, the type breaks
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+} satisfies
+  // Comment
+  Record<string, number>;
+const t2 = {
+  bar: 1,
+} as
+  // Comment
+  Record<string, number>;
+
+// A line-ending multiline block is paragraph-like and breaks too, jsdoc re-indented
+1 as
+  /**
+   * jsdoc
+   */
+  Foo;
+1 satisfies
+  /*
+raw interior stays put
+*/
+  Foo;
+
+// A glued line comment stays on the operator's line, the type breaks under it
+// (the pinned Prettier relocates it across the type and the semicolon)
+const eolLine = 1 as // c
+  Foo;
+// A glued single-line block comment stays glued; the layout is free to inline
+// the type after it (the pinned Prettier relocates it backward across the operator)
+const eolBlock = {} satisfies /* c */ {};
+
+// A suppression comment stays visible to the type it targets
+// (never consumed as a glued run); the break decision still applies
+const suppressGlued = 1 as /* oxfmt-ignore */ Foo<A,B>;
+const suppressOwnLine = 1 as
+  // oxfmt-ignore
+  Foo<A,B>;
+
+// A comment that does not end its line keeps the flat layout
+const flatInline = {} satisfies /* c */ {};
+const flatMultiline = 1 as /* multi
+line */ Foo;
+
+// Comments before the operator trail the expression and never cross the operator
+const preOp = {} /* t */ satisfies {};
+const preOpBreak = {} /* t */ satisfies
+  // c
+  Record<string, number>;
+// ... except what the grammar-defined slot cannot hold: no line terminator may
+// precede the operator (a multiline comment's interior counts), so once the
+// expression's source parens are dropped, only same-line single-line block
+// comments stay on the expression side — a riding line comment flushes behind
+// the operator, everything else normalizes to the type side (the output must
+// re-parse), where the usual layout rules apply
+const preOpLine = foo as // pre line
+  Foo;
+const preOpOwnLine = foo as
+  // pre own line
+  Foo;
+const preOpOwnBlock = foo as
+  /* pre own block */
+  Foo;
+const preOpMultiInline = 1 as /* m1
+i */ Foo;
+const preOpMultiOwnLine = 1 as
+  /* m2
+i */
+  Foo;
+
+// `as const` follows the same policy, `const` is a type like any other
+// (the pinned Prettier relocates all of these across `const` and the `;`)
+1 as /* c1 */ const;
+1 as // c2
+  const;
+1 as
+  // c3
+  const;
+1 as
+  /**
+   * jsdoc
+   */
+  const;
+
+// A union's own-line leading comment is indented by the union printer itself;
+// no extra break on the operator.
+// Note: a same-line line comment before a union still moves behind the
+// statement (union comment claiming is its own subsystem)
+const union = 1 as
+  // c
+  A | B;
+const unionEol = 1 as A | B; // c
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments around the `satisfies` / `as` operator keep their source side and
+// their line-start side — the head-body comment policy applied to the operator
+// gap (see DIVERGENCES.md#binary-cast-own-line-comment).
+// An own-line comment leads the type on its own line, the type breaks
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+} satisfies
+  // Comment
+  Record<string, number>;
+const t2 = {
+  bar: 1,
+} as
+  // Comment
+  Record<string, number>;
+
+// A line-ending multiline block is paragraph-like and breaks too, jsdoc re-indented
+1 as
+  /**
+   * jsdoc
+   */
+  Foo;
+1 satisfies
+  /*
+raw interior stays put
+*/
+  Foo;
+
+// A glued line comment stays on the operator's line, the type breaks under it
+// (the pinned Prettier relocates it across the type and the semicolon)
+const eolLine = 1 as // c
+  Foo;
+// A glued single-line block comment stays glued; the layout is free to inline
+// the type after it (the pinned Prettier relocates it backward across the operator)
+const eolBlock = {} satisfies /* c */ {};
+
+// A suppression comment stays visible to the type it targets
+// (never consumed as a glued run); the break decision still applies
+const suppressGlued = 1 as /* oxfmt-ignore */ Foo<A,B>;
+const suppressOwnLine = 1 as
+  // oxfmt-ignore
+  Foo<A,B>;
+
+// A comment that does not end its line keeps the flat layout
+const flatInline = {} satisfies /* c */ {};
+const flatMultiline = 1 as /* multi
+line */ Foo;
+
+// Comments before the operator trail the expression and never cross the operator
+const preOp = {} /* t */ satisfies {};
+const preOpBreak = {} /* t */ satisfies
+  // c
+  Record<string, number>;
+// ... except what the grammar-defined slot cannot hold: no line terminator may
+// precede the operator (a multiline comment's interior counts), so once the
+// expression's source parens are dropped, only same-line single-line block
+// comments stay on the expression side — a riding line comment flushes behind
+// the operator, everything else normalizes to the type side (the output must
+// re-parse), where the usual layout rules apply
+const preOpLine = foo as // pre line
+  Foo;
+const preOpOwnLine = foo as
+  // pre own line
+  Foo;
+const preOpOwnBlock = foo as
+  /* pre own block */
+  Foo;
+const preOpMultiInline = 1 as /* m1
+i */ Foo;
+const preOpMultiOwnLine = 1 as
+  /* m2
+i */
+  Foo;
+
+// `as const` follows the same policy, `const` is a type like any other
+// (the pinned Prettier relocates all of these across `const` and the `;`)
+1 as /* c1 */ const;
+1 as // c2
+  const;
+1 as
+  // c3
+  const;
+1 as
+  /**
+   * jsdoc
+   */
+  const;
+
+// A union's own-line leading comment is indented by the union printer itself;
+// no extra break on the operator.
+// Note: a same-line line comment before a union still moves behind the
+// statement (union comment claiming is its own subsystem)
+const union = 1 as
+  // c
+  A | B;
+const unionEol = 1 as A | B; // c
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-class-members.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-class-members.ts
@@ -1,0 +1,72 @@
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1 /* r */;
+  b = 2 // line r
+  ;
+  declare c: number /* s */;
+  d = 4 /* keeps */
+  /* own line */;
+  e = 5;
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6 /* moves */)
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1 /* r */
+  b = 2
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */;
+  z? /* m2 */;
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void /* w */;
+  m(): void {}
+  constructor(x: number) /* x */;
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void /* y */;
+}
+declare class Ambient {
+  dm(): void /* z */;
+  dl(): void // line z
+  ;
+  down(): void
+  /* own line */;
+  dmixed(): void /* w */
+  /* own2 */;
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */;
+  bar(): void /* u2 */;
+}
+type ObjType = {
+  foo: string /* v */;
+};
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[] // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */;
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-class-members.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-class-members.ts.snap
@@ -1,0 +1,376 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 43
+---
+==================== Input ====================
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1 /* r */;
+  b = 2 // line r
+  ;
+  declare c: number /* s */;
+  d = 4 /* keeps */
+  /* own line */;
+  e = 5;
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6 /* moves */)
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1 /* r */
+  b = 2
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */;
+  z? /* m2 */;
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void /* w */;
+  m(): void {}
+  constructor(x: number) /* x */;
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void /* y */;
+}
+declare class Ambient {
+  dm(): void /* z */;
+  dl(): void // line z
+  ;
+  down(): void
+  /* own line */;
+  dmixed(): void /* w */
+  /* own2 */;
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */;
+  bar(): void /* u2 */;
+}
+type ObjType = {
+  foo: string /* v */;
+};
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[] // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */;
+}
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1; /* r */
+  b = 2; // line r
+  declare c: number; /* s */
+  d = 4; /* keeps */
+  /* own line */
+  e = 5;
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6); /* moves */
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1; /* r */
+  b = 2;
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number; /* m1 */
+  z?; /* m2 */
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void; /* w */
+  m(): void {}
+  constructor(x: number); /* x */
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void; /* y */
+}
+declare class Ambient {
+  dm(): void; /* z */
+  dl(): void; // line z
+  down(): void;
+  /* own line */
+  dmixed(): void; /* w */
+  /* own2 */
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */;
+  bar(): void /* u2 */;
+}
+type ObjType = {
+  foo: string /* v */;
+};
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[]; // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */;
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1; /* r */
+  b = 2; // line r
+  declare c: number; /* s */
+  d = 4; /* keeps */
+  /* own line */
+  e = 5;
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6); /* moves */
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1; /* r */
+  b = 2;
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number; /* m1 */
+  z?; /* m2 */
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void; /* w */
+  m(): void {}
+  constructor(x: number); /* x */
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void; /* y */
+}
+declare class Ambient {
+  dm(): void; /* z */
+  dl(): void; // line z
+  down(): void;
+  /* own line */
+  dmixed(): void; /* w */
+  /* own2 */
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */;
+  bar(): void /* u2 */;
+}
+type ObjType = {
+  foo: string /* v */;
+};
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[]; // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */;
+}
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1 /* r */
+  b = 2 // line r
+  declare c: number /* s */
+  d = 4 /* keeps */
+  /* own line */
+  e = 5
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6) /* moves */
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1 /* r */
+  b = 2
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */
+  z? /* m2 */
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void /* w */
+  m(): void {}
+  constructor(x: number) /* x */
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void /* y */
+}
+declare class Ambient {
+  dm(): void /* z */
+  dl(): void // line z
+  down(): void
+  /* own line */
+  dmixed(): void /* w */
+  /* own2 */
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */
+  bar(): void /* u2 */
+}
+type ObjType = {
+  foo: string /* v */
+}
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[] // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// Trailing comments on class and interface members (the statement-level
+// basics: trailing-comments.ts).
+// Class properties move the same-line comment behind the semicolon;
+// an own-line comment before the `;` defers to the next element's leading pass
+// (Prettier's first pass cancels the same-line move in that case
+// and needs a second pass to settle — we print that fixpoint directly)
+class Cls {
+  a = 1 /* r */
+  b = 2 // line r
+  declare c: number /* s */
+  d = 4 /* keeps */
+  /* own line */
+  e = 5
+  // A comment inside the value's parentheses moves behind the added `;`
+  // even without a source `;`, like Prettier
+  f = (g = 6) /* moves */
+}
+
+// Under bare ASI a same-line comment sits past the member's span,
+// so it still moves behind the added `;` (like statements)
+class BareAsi {
+  a = 1 /* r */
+  b = 2
+}
+
+// A definite/optional marker between the content end and the `;`
+class Markers {
+  x!: number /* m1 */
+  z? /* m2 */
+}
+
+// Bodyless method signatures (overloads, abstract, ambient) move the
+// same-line comment behind the semicolon too; own-line ones defer to the
+// next element, like every other member
+class Overloads {
+  m(): void /* w */
+  m(): void {}
+  constructor(x: number) /* x */
+  constructor() {}
+}
+abstract class Abstract {
+  abstract am(): void /* y */
+}
+declare class Ambient {
+  dm(): void /* z */
+  dl(): void // line z
+  down(): void
+  /* own line */
+  dmixed(): void /* w */
+  /* own2 */
+}
+
+// Note: Prettier keeps interface / type literal member comments before the
+// semicolon (member separator, not a statement terminator); so do we,
+// also for index signatures — even in classes
+interface Iface {
+  foo: string /* u */
+  bar(): void /* u2 */
+}
+type ObjType = {
+  foo: string /* v */
+}
+// A LINE comment after a `;`-less member rides the line; the added separator
+// lands before it
+interface _KeywordDef {
+  type?: JSONType | JSONType[] // data types that keyword applies to
+}
+class WithIndexSignature {
+  [key: string]: unknown /* v2 */
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-parens.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-parens.ts
@@ -1,0 +1,97 @@
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  );
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  );
+}
+function afterCloseParenReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition
+  ) /* moves */;
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition /* stays */
+  )
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = (someValue /* moves */);
+parenthesizedChain = (inner = someValue /* moves */);
+parenthesizedNested = (inner = (someValue /* moves */));
+parenthesizedTernary = (cond ? someValue : other /* moves */);
+parenthesizedLine = (inner = someValue // moves
+);
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => ((b) => {
+  c();
+} /* moves */ // rides
+)
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = (inner = someValue /* moves */)
+asiParenLeaf = (someValue /* moves */)
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = (someValue
+// defers
+)
+
+afterAsiParen();
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a } /* moves */)
+arrowPlainBody = (a) => (b /* moves */)
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c /* moves */);
+arrowConditionalObjectLeftmost = (a) => (({}) ? b : c /* moves */);
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => ((b, c) /* stays */);
+arrowAssignmentBody = (a) => (b = c /* stays */);
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = (X /* moves */)
+var declaratorChain = (a) => ((b) => {
+  c();
+} /* moves */)
+class ValueChain {
+  p = (a) => (b /* moves */)
+}
+function returnChain() {
+  return (a) => ((b) => {
+    c();
+  } /* moves */);
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-parens.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments-parens.ts.snap
@@ -1,0 +1,563 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 43
+---
+==================== Input ====================
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  );
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  );
+}
+function afterCloseParenReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition
+  ) /* moves */;
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition /* stays */
+  )
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = (someValue /* moves */);
+parenthesizedChain = (inner = someValue /* moves */);
+parenthesizedNested = (inner = (someValue /* moves */));
+parenthesizedTernary = (cond ? someValue : other /* moves */);
+parenthesizedLine = (inner = someValue // moves
+);
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => ((b) => {
+  c();
+} /* moves */ // rides
+)
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = (inner = someValue /* moves */)
+asiParenLeaf = (someValue /* moves */)
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = (someValue
+// defers
+)
+
+afterAsiParen();
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a } /* moves */)
+arrowPlainBody = (a) => (b /* moves */)
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c /* moves */);
+arrowConditionalObjectLeftmost = (a) => (({}) ? b : c /* moves */);
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => ((b, c) /* stays */);
+arrowAssignmentBody = (a) => (b = c /* stays */);
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = (X /* moves */)
+var declaratorChain = (a) => ((b) => {
+  c();
+} /* moves */)
+class ValueChain {
+  p = (a) => (b /* moves */)
+}
+function returnChain() {
+  return (a) => ((b) => {
+    c();
+  } /* moves */);
+}
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  );
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  );
+}
+function afterCloseParenReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+  ); /* moves */
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition /* stays */
+  );
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => (b) => {
+  c();
+}; /* moves */ // rides
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = inner = someValue; /* moves */
+asiParenLeaf = someValue; /* moves */
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = someValue;
+// defers
+
+afterAsiParen();
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a }); /* moves */
+arrowPlainBody = (a) => b; /* moves */
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c); /* moves */
+arrowConditionalObjectLeftmost = (a) => ({}) ? b : c; /* moves */
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => (b, c /* stays */);
+arrowAssignmentBody = (a) => (b = c /* stays */);
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = X; /* moves */
+var declaratorChain = (a) => (b) => {
+  c();
+}; /* moves */
+class ValueChain {
+  p = (a) => b; /* moves */
+}
+function returnChain() {
+  return (a) => (b) => {
+    c();
+  }; /* moves */
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  );
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  );
+}
+function afterCloseParenReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* stays */;
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => (b) => {
+  c();
+}; /* moves */ // rides
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = inner = someValue; /* moves */
+asiParenLeaf = someValue; /* moves */
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = someValue;
+// defers
+
+afterAsiParen();
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a }); /* moves */
+arrowPlainBody = (a) => b; /* moves */
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c); /* moves */
+arrowConditionalObjectLeftmost = (a) => ({}) ? b : c; /* moves */
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => (b, c /* stays */);
+arrowAssignmentBody = (a) => (b = c /* stays */);
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = X; /* moves */
+var declaratorChain = (a) => (b) => {
+  c();
+}; /* moves */
+class ValueChain {
+  p = (a) => b; /* moves */
+}
+function returnChain() {
+  return (a) => (b) => {
+    c();
+  }; /* moves */
+}
+
+---------- Not idempotent (second pass) ----------
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  );
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  );
+}
+function afterCloseParenReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* stays */
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => (b) => {
+  c();
+}; /* moves */ // rides
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = inner = someValue; /* moves */
+asiParenLeaf = someValue; /* moves */
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = someValue;
+// defers
+
+afterAsiParen();
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a }); /* moves */
+arrowPlainBody = (a) => b; /* moves */
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c); /* moves */
+arrowConditionalObjectLeftmost = (a) => ({}) ? b : c; /* moves */
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => (b, c /* stays */);
+arrowAssignmentBody = (a) => (b = c /* stays */);
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = X; /* moves */
+var declaratorChain = (a) => (b) => {
+  c();
+}; /* moves */
+class ValueChain {
+  p = (a) => b; /* moves */
+}
+function returnChain() {
+  return (a) => (b) => {
+    c();
+  }; /* moves */
+}
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  )
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  )
+}
+function afterCloseParenReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+  ) /* moves */
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return (
+    aLongLongLongLongLongCondition &&
+    anotherLongLongLongLongCondition /* stays */
+  )
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue /* moves */
+parenthesizedChain = inner = someValue /* moves */
+parenthesizedNested = inner = someValue /* moves */
+parenthesizedTernary = cond ? someValue : other /* moves */
+parenthesizedLine = inner = someValue // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */)
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => (b) => {
+  c()
+} /* moves */ // rides
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = inner = someValue /* moves */
+asiParenLeaf = someValue /* moves */
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = someValue
+// defers
+
+afterAsiParen()
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a }) /* moves */
+arrowPlainBody = (a) => b /* moves */
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c) /* moves */
+arrowConditionalObjectLeftmost = (a) => ({}) ? b : c /* moves */
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => (b, c /* stays */)
+arrowAssignmentBody = (a) => (b = c /* stays */)
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = X /* moves */
+var declaratorChain = (a) => (b) => {
+  c()
+} /* moves */
+class ValueChain {
+  p = (a) => b /* moves */
+}
+function returnChain() {
+  return (a) => (b) => {
+    c()
+  } /* moves */
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// Trailing comments and parentheses (the statement-level basics:
+// trailing-comments.ts).
+// A return/throw argument's parentheses survive in the output, so comments
+// inside them stay there (moving them behind the `;` would cross the `)` and,
+// when the group breaks, a line boundary too — breaking line directives);
+// only comments after the closing paren move behind the semicolon
+function multiLineReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
+  )
+}
+function ownLineCommentReturn() {
+  return (
+    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
+    /* eslint-enable some-rule */
+  )
+}
+function afterCloseParenReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* moves */
+}
+// No source `;` at all (ASI): nothing to move the comment across while the
+// parens survive (group broken, printWidth 80); when the argument fits flat
+// (printWidth 100) the parens are dropped and the comment settles only on the
+// second format — the same group-fit limitation as a flat JSX arrow body
+function asiReturn() {
+  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* stays */
+}
+
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue /* moves */
+parenthesizedChain = inner = someValue /* moves */
+parenthesizedNested = inner = someValue /* moves */
+parenthesizedTernary = cond ? someValue : other /* moves */
+parenthesizedLine = inner = someValue // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */)
+
+// The chain also passes through arrow expression bodies (prettier#19930 family):
+// the body's parentheses are dropped, so its trailing comments
+// move behind the statement's semicolon
+chainedArrow = (a) => (b) => {
+  c()
+} /* moves */ // rides
+// A dropped `)` counts as the terminator even without a source `;` (ASI):
+// the next format would move the comment behind the added `;` anyway,
+// so print that fixpoint directly
+asiParenChain = inner = someValue /* moves */
+asiParenLeaf = someValue /* moves */
+// A deferred own-line comment measures its break past the dropped `)` too:
+// own-line and blank lines survive the vanished `)` line
+asiParenOwnLine = someValue
+// defers
+
+afterAsiParen()
+// ... uniformly for any dropped-paren body, object parens included
+// (the object's parens are re-printed on the statement's own terms)
+arrowObjectBody = () => ({ a }) /* moves */
+arrowPlainBody = (a) => b /* moves */
+// ... including conditional bodies, whose parens are formatter-owned and
+// often absent (object leftmost, broken groups)
+arrowConditionalBody = (a) => (a ? b : c) /* moves */
+arrowConditionalObjectLeftmost = (a) => ({}) ? b : c /* moves */
+// An arrow body whose printer re-adds the parens and keeps the comment
+// inside them stops the walk: sequence, assignment (JSX too, see the
+// jsx fixture)
+arrowSequenceBody = (a) => (b, c /* stays */)
+arrowAssignmentBody = (a) => (b = c /* stays */)
+// The same chain rule in a variable declaration, a class property value,
+// and a return argument (and export default, see trailing-comments.ts);
+// other sites join the dropped-paren terminator rule through the shared gate
+type ParenAlias = X /* moves */
+var declaratorChain = (a) => (b) => {
+  c()
+} /* moves */
+class ValueChain {
+  p = (a) => b /* moves */
+}
+function returnChain() {
+  return (a) => (b) => {
+    c()
+  } /* moves */
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts
@@ -1,6 +1,8 @@
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1 /* a */;
 const myVar = "asdf" /* b */;
 let noInit: string | number /* c */;
@@ -22,59 +24,37 @@ import x, { y } from "mod2" with { type: "json" } /* h */;
 export { b } from "mod" /* i */;
 export * from "mod" /* j */;
 export const exported = 1 /* k */;
-export default foo /* l */;
+export default ((a) => (foo /* l */));
 1 as const /* m */;
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3 /* n1 */ /* n2 */;
 qux = 4 /* o1 */; /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2
 /* own line */;
 quux();
+blankAfter = 3
+/* c-blank-after */;
+
+quux();
+blankBefore = 4
+
+/* c-blank-before */;
+quux();
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5
+/* own before export */;
+
+export default quux;
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1) // prettier-ignore
 ;
 notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition
-  ) /* moves */;
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = (someValue /* moves */);
-parenthesizedChain = (inner = someValue /* moves */);
-parenthesizedNested = (inner = (someValue /* moves */));
-parenthesizedTernary = (cond ? someValue : other /* moves */);
-parenthesizedLine = (inner = someValue // moves
-);
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -85,14 +65,6 @@ assigned =
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember /* moves */;
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition /* stays */
-  )
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -112,60 +84,4 @@ do {} while (foo) // line between
 labeled: for (;;) {
   break labeled /* p */;
   continue labeled /* q */;
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1 /* r */;
-  b = 2 // line r
-  ;
-  declare c: number /* s */;
-  d = 4 /* keeps */
-  /* own line */;
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number /* m1 */;
-  z? /* m2 */;
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void /* w */;
-  m(): void {}
-  constructor(x: number) /* x */;
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void /* y */;
-}
-declare class Ambient {
-  dm(): void /* z */;
-  dl(): void // line z
-  ;
-  down(): void
-  /* own line */;
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[] // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
 }

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 43
 ---
 ==================== Input ====================
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1 /* a */;
 const myVar = "asdf" /* b */;
 let noInit: string | number /* c */;
@@ -26,59 +29,37 @@ import x, { y } from "mod2" with { type: "json" } /* h */;
 export { b } from "mod" /* i */;
 export * from "mod" /* j */;
 export const exported = 1 /* k */;
-export default foo /* l */;
+export default ((a) => (foo /* l */));
 1 as const /* m */;
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3 /* n1 */ /* n2 */;
 qux = 4 /* o1 */; /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2
 /* own line */;
 quux();
+blankAfter = 3
+/* c-blank-after */;
+
+quux();
+blankBefore = 4
+
+/* c-blank-before */;
+quux();
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5
+/* own before export */;
+
+export default quux;
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1) // prettier-ignore
 ;
 notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition
-  ) /* moves */;
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = (someValue /* moves */);
-parenthesizedChain = (inner = someValue /* moves */);
-parenthesizedNested = (inner = (someValue /* moves */));
-parenthesizedTernary = (cond ? someValue : other /* moves */);
-parenthesizedLine = (inner = someValue // moves
-);
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -89,14 +70,6 @@ assigned =
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember /* moves */;
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition /* stays */
-  )
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -118,62 +91,6 @@ labeled: for (;;) {
   continue labeled /* q */;
 }
 
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1 /* r */;
-  b = 2 // line r
-  ;
-  declare c: number /* s */;
-  d = 4 /* keeps */
-  /* own line */;
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number /* m1 */;
-  z? /* m2 */;
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void /* w */;
-  m(): void {}
-  constructor(x: number) /* x */;
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void /* y */;
-}
-declare class Ambient {
-  dm(): void /* z */;
-  dl(): void // line z
-  ;
-  down(): void
-  /* own line */;
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[] // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
-}
-
 ==================== Output ====================
 ------------------------------
 { printWidth: 80, semi: true }
@@ -181,6 +98,8 @@ class WithIndexSignature {
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1; /* a */
 const myVar = "asdf"; /* b */
 let noInit: string | number; /* c */
@@ -202,53 +121,36 @@ import x, { y } from "mod2" with { type: "json" }; /* h */
 export { b } from "mod"; /* i */
 export * from "mod"; /* j */
 export const exported = 1; /* k */
-export default foo; /* l */
+export default (a) => foo; /* l */
 1 as const; /* m */
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3; /* n1 */ /* n2 */
 qux = 4; /* o1 */ /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2;
-/* own line */ quux();
+/* own line */
+quux();
+blankAfter = 3;
+/* c-blank-after */
+
+quux();
+blankBefore = 4;
+
+/* c-blank-before */
+quux();
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5;
+/* own before export */
+
+export default quux;
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1); // prettier-ignore
 notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-  ); /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue; /* moves */
-parenthesizedChain = inner = someValue; /* moves */
-parenthesizedNested = inner = someValue; /* moves */
-parenthesizedTernary = cond ? someValue : other; /* moves */
-parenthesizedLine = inner = someValue; // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -257,14 +159,6 @@ assigned = someValue; /* moves */
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember; /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition /* stays */
-  );
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -283,222 +177,6 @@ do {} while (foo); // line between
 labeled: for (;;) {
   break labeled; /* p */
   continue labeled; /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1; /* r */
-  b = 2; // line r
-  declare c: number; /* s */
-  d = 4 /* keeps */;
-  /* own line */
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number; /* m1 */
-  z?; /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void; /* w */
-  m(): void {}
-  constructor(x: number); /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void; /* y */
-}
-declare class Ambient {
-  dm(): void; /* z */
-  dl(): void; // line z
-  down(): void;
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
-}
-
----------- Not idempotent (second pass) ----------
-// https://github.com/oxc-project/oxc/issues/23110
-// A trailing comment between the statement content and its semicolon
-// is printed after the semicolon, like Prettier >= 3.9
-foo = 1; /* a */
-const myVar = "asdf"; /* b */
-let noInit: string | number; /* c */
-// Note: Prettier moves the comment only for an exported type alias and keeps
-// `type T = string /* t */;` as-is; oxfmt intentionally applies the rule uniformly
-type T = string; /* t */
-function f() {
-  return foo; /* d */
-}
-function g() {
-  return; /* no argument */
-}
-function h() {
-  throw foo; /* e */
-}
-import { a } from "mod"; /* f */
-import "side-effect"; /* g */
-import x, { y } from "mod2" with { type: "json" }; /* h */
-export { b } from "mod"; /* i */
-export * from "mod"; /* j */
-export const exported = 1; /* k */
-export default foo; /* l */
-1 as const; /* m */
-
-// Multiple comments move together, comments after the semicolon stay
-baz = 3; /* n1 */ /* n2 */
-qux = 4; /* o1 */ /* o2 */
-
-// An own-line comment becomes a leading comment of the next statement
-bar = 2;
-/* own line */ quux();
-
-// A trailing suppression comment keeps the statement's original text
-suppressed  =  ugly(   1); // prettier-ignore
-notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-  ); /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue; /* moves */
-parenthesizedChain = inner = someValue; /* moves */
-parenthesizedNested = inner = someValue; /* moves */
-parenthesizedTernary = cond ? someValue : other; /* moves */
-parenthesizedLine = inner = someValue; // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
-
-// The `;` on a later line still moves the comment: in the output the semicolon
-// directly follows the content, so nothing is crossed
-assigned = someValue; /* moves */
-// ... also when the content breaks
-export type Union =
-  | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
-  | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember; /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition /* stays */
-  );
-}
-
-// The declaration below is terminated by the `;` after the own-line comment;
-// the comment stays own-line and leads the next statement, not the declaration
-export let laterSemi: (callback: () => void, timeout?: number) => Disposable;
-
-// Self-invoking function comment
-(function () {})();
-
-// do-while: a comment between `)` and `;` moves behind the semicolon,
-// a comment inside the parens stays
-do {} while (foo /* in parens */);
-do {} while (foo); /* between */
-do {} while (foo); // line between
-
-// Labeled break/continue move the comment behind the semicolon
-labeled: for (;;) {
-  break labeled; /* p */
-  continue labeled; /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1; /* r */
-  b = 2; // line r
-  declare c: number; /* s */
-  d = 4; /* keeps */
-  /* own line */
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number; /* m1 */
-  z?; /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void; /* w */
-  m(): void {}
-  constructor(x: number); /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void; /* y */
-}
-declare class Ambient {
-  dm(): void; /* z */
-  dl(): void; // line z
-  down(): void;
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
 }
 
 -------------------------------
@@ -507,6 +185,8 @@ class WithIndexSignature {
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1; /* a */
 const myVar = "asdf"; /* b */
 let noInit: string | number; /* c */
@@ -528,51 +208,36 @@ import x, { y } from "mod2" with { type: "json" }; /* h */
 export { b } from "mod"; /* i */
 export * from "mod"; /* j */
 export const exported = 1; /* k */
-export default foo; /* l */
+export default (a) => foo; /* l */
 1 as const; /* m */
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3; /* n1 */ /* n2 */
 qux = 4; /* o1 */ /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2;
-/* own line */ quux();
+/* own line */
+quux();
+blankAfter = 3;
+/* c-blank-after */
+
+quux();
+blankBefore = 4;
+
+/* c-blank-before */
+quux();
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5;
+/* own before export */
+
+export default quux;
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1); // prettier-ignore
 notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue; /* moves */
-parenthesizedChain = inner = someValue; /* moves */
-parenthesizedNested = inner = someValue; /* moves */
-parenthesizedTernary = cond ? someValue : other; /* moves */
-parenthesizedLine = inner = someValue; // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -581,11 +246,6 @@ assigned = someValue; /* moves */
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember; /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* stays */;
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -604,217 +264,6 @@ do {} while (foo); // line between
 labeled: for (;;) {
   break labeled; /* p */
   continue labeled; /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1; /* r */
-  b = 2; // line r
-  declare c: number; /* s */
-  d = 4 /* keeps */;
-  /* own line */
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number; /* m1 */
-  z?; /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void; /* w */
-  m(): void {}
-  constructor(x: number); /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void; /* y */
-}
-declare class Ambient {
-  dm(): void; /* z */
-  dl(): void; // line z
-  down(): void;
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
-}
-
----------- Not idempotent (second pass) ----------
-// https://github.com/oxc-project/oxc/issues/23110
-// A trailing comment between the statement content and its semicolon
-// is printed after the semicolon, like Prettier >= 3.9
-foo = 1; /* a */
-const myVar = "asdf"; /* b */
-let noInit: string | number; /* c */
-// Note: Prettier moves the comment only for an exported type alias and keeps
-// `type T = string /* t */;` as-is; oxfmt intentionally applies the rule uniformly
-type T = string; /* t */
-function f() {
-  return foo; /* d */
-}
-function g() {
-  return; /* no argument */
-}
-function h() {
-  throw foo; /* e */
-}
-import { a } from "mod"; /* f */
-import "side-effect"; /* g */
-import x, { y } from "mod2" with { type: "json" }; /* h */
-export { b } from "mod"; /* i */
-export * from "mod"; /* j */
-export const exported = 1; /* k */
-export default foo; /* l */
-1 as const; /* m */
-
-// Multiple comments move together, comments after the semicolon stay
-baz = 3; /* n1 */ /* n2 */
-qux = 4; /* o1 */ /* o2 */
-
-// An own-line comment becomes a leading comment of the next statement
-bar = 2;
-/* own line */ quux();
-
-// A trailing suppression comment keeps the statement's original text
-suppressed  =  ugly(   1); // prettier-ignore
-notSuppressed3();
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  );
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  );
-}
-function afterCloseParenReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue; /* moves */
-parenthesizedChain = inner = someValue; /* moves */
-parenthesizedNested = inner = someValue; /* moves */
-parenthesizedTernary = cond ? someValue : other; /* moves */
-parenthesizedLine = inner = someValue; // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */);
-
-// The `;` on a later line still moves the comment: in the output the semicolon
-// directly follows the content, so nothing is crossed
-assigned = someValue; /* moves */
-// ... also when the content breaks
-export type Union =
-  | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
-  | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember; /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* stays */
-}
-
-// The declaration below is terminated by the `;` after the own-line comment;
-// the comment stays own-line and leads the next statement, not the declaration
-export let laterSemi: (callback: () => void, timeout?: number) => Disposable;
-
-// Self-invoking function comment
-(function () {})();
-
-// do-while: a comment between `)` and `;` moves behind the semicolon,
-// a comment inside the parens stays
-do {} while (foo /* in parens */);
-do {} while (foo); /* between */
-do {} while (foo); // line between
-
-// Labeled break/continue move the comment behind the semicolon
-labeled: for (;;) {
-  break labeled; /* p */
-  continue labeled; /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1; /* r */
-  b = 2; // line r
-  declare c: number; /* s */
-  d = 4; /* keeps */
-  /* own line */
-  e = 5;
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number; /* m1 */
-  z?; /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void; /* w */
-  m(): void {}
-  constructor(x: number); /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void; /* y */
-}
-declare class Ambient {
-  dm(): void; /* z */
-  dl(): void; // line z
-  down(): void;
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */;
-  bar(): void /* u2 */;
-}
-type ObjType = {
-  foo: string /* v */;
-};
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */;
 }
 
 -------------------------------
@@ -823,6 +272,8 @@ class WithIndexSignature {
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1 /* a */
 const myVar = "asdf" /* b */
 let noInit: string | number /* c */
@@ -844,53 +295,36 @@ import x, { y } from "mod2" with { type: "json" } /* h */
 export { b } from "mod" /* i */
 export * from "mod" /* j */
 export const exported = 1 /* k */
-export default foo /* l */
+export default (a) => foo /* l */
 1 as const /* m */
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3 /* n1 */ /* n2 */
 qux = 4 /* o1 */ /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2
-/* own line */ quux()
+/* own line */
+quux()
+blankAfter = 3
+/* c-blank-after */
+
+quux()
+blankBefore = 4
+
+/* c-blank-before */
+quux()
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5
+/* own before export */
+
+export default quux
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1) // prettier-ignore
 notSuppressed3()
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  )
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  )
-}
-function afterCloseParenReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-  ) /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue /* moves */
-parenthesizedChain = inner = someValue /* moves */
-parenthesizedNested = inner = someValue /* moves */
-parenthesizedTernary = cond ? someValue : other /* moves */
-parenthesizedLine = inner = someValue // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */)
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -899,14 +333,6 @@ assigned = someValue /* moves */
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return (
-    aLongLongLongLongLongCondition &&
-    anotherLongLongLongLongCondition /* stays */
-  )
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -925,60 +351,6 @@ do {} while (foo) // line between
 labeled: for (;;) {
   break labeled /* p */
   continue labeled /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1 /* r */
-  b = 2 // line r
-  declare c: number /* s */
-  d = 4 /* keeps */
-  /* own line */
-  e = 5
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number /* m1 */
-  z? /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void /* w */
-  m(): void {}
-  constructor(x: number) /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void /* y */
-}
-declare class Ambient {
-  dm(): void /* z */
-  dl(): void // line z
-  down(): void
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */
-  bar(): void /* u2 */
-}
-type ObjType = {
-  foo: string /* v */
-}
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[] // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */
 }
 
 --------------------------------
@@ -987,6 +359,8 @@ class WithIndexSignature {
 // https://github.com/oxc-project/oxc/issues/23110
 // A trailing comment between the statement content and its semicolon
 // is printed after the semicolon, like Prettier >= 3.9
+// (paren/chain shapes: trailing-comments-parens.ts,
+//  class and interface members: trailing-comments-class-members.ts)
 foo = 1 /* a */
 const myVar = "asdf" /* b */
 let noInit: string | number /* c */
@@ -1008,51 +382,36 @@ import x, { y } from "mod2" with { type: "json" } /* h */
 export { b } from "mod" /* i */
 export * from "mod" /* j */
 export const exported = 1 /* k */
-export default foo /* l */
+export default (a) => foo /* l */
 1 as const /* m */
 
 // Multiple comments move together, comments after the semicolon stay
 baz = 3 /* n1 */ /* n2 */
 qux = 4 /* o1 */ /* o2 */
 
-// An own-line comment becomes a leading comment of the next statement
+// An own-line comment becomes a leading comment of the next statement,
+// staying own-line with its blank lines
+// (see DIVERGENCES.md#deferred-own-line-comment-stays-own-line)
 bar = 2
-/* own line */ quux()
+/* own line */
+quux()
+blankAfter = 3
+/* c-blank-after */
+
+quux()
+blankBefore = 4
+
+/* c-blank-before */
+quux()
+// ... also when the next statement prints its own leading pass (export)
+beforeExport = 5
+/* own before export */
+
+export default quux
 
 // A trailing suppression comment keeps the statement's original text
 suppressed  =  ugly(   1) // prettier-ignore
 notSuppressed3()
-
-// A return/throw argument's parentheses survive in the output, so comments
-// inside them stay there (moving them behind the `;` would cross the `)` and,
-// when the group breaks, a line boundary too — breaking line directives);
-// only comments after the closing paren move behind the semicolon
-function multiLineReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition // eslint-disable-line some-rule
-  )
-}
-function ownLineCommentReturn() {
-  return (
-    aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
-    /* eslint-enable some-rule */
-  )
-}
-function afterCloseParenReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* moves */
-}
-// In an expression statement the parentheses are dropped, so the semicolon
-// directly follows the content: a comment inside them also moves behind it,
-// even from a nested assignment's dropped parentheses.
-// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
-// fixpoint directly, see prettier#19893)
-parenthesized = someValue /* moves */
-parenthesizedChain = inner = someValue /* moves */
-parenthesizedNested = inner = someValue /* moves */
-parenthesizedTernary = cond ? someValue : other /* moves */
-parenthesizedLine = inner = someValue // moves
-// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
-const parenthesizedInit = (inner = someValue /* stays */)
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -1061,11 +420,6 @@ assigned = someValue /* moves */
 export type Union =
   | AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLongMember
   | BbbbbbbbbbbbbbbbbbbbbbbbbbbbbbLongMember /* moves */
-
-// No source `;` at all (ASI): nothing to move the comment across
-function asiReturn() {
-  return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* stays */
-}
 
 // The declaration below is terminated by the `;` after the own-line comment;
 // the comment stays own-line and leads the next statement, not the declaration
@@ -1084,60 +438,6 @@ do {} while (foo) // line between
 labeled: for (;;) {
   break labeled /* p */
   continue labeled /* q */
-}
-
-// Class properties move the comment behind the semicolon,
-// an own-line comment before the semicolon keeps its own line
-class Cls {
-  a = 1 /* r */
-  b = 2 // line r
-  declare c: number /* s */
-  d = 4 /* keeps */
-  /* own line */
-  e = 5
-}
-
-// A definite/optional marker between the content end and the `;`
-class Markers {
-  x!: number /* m1 */
-  z? /* m2 */
-}
-
-// Bodyless method signatures (overloads, abstract, ambient) move the comment
-// behind the semicolon too; an own-line comment stays in place
-class Overloads {
-  m(): void /* w */
-  m(): void {}
-  constructor(x: number) /* x */
-  constructor() {}
-}
-abstract class Abstract {
-  abstract am(): void /* y */
-}
-declare class Ambient {
-  dm(): void /* z */
-  dl(): void // line z
-  down(): void
-  /* own line */
-}
-
-// Note: Prettier keeps interface / type literal member comments before the
-// semicolon (member separator, not a statement terminator); so do we,
-// also for index signatures — even in classes
-interface Iface {
-  foo: string /* u */
-  bar(): void /* u2 */
-}
-type ObjType = {
-  foo: string /* v */
-}
-// A LINE comment after a `;`-less member rides the line; the added separator
-// lands before it
-interface _KeywordDef {
-  type?: JSONType | JSONType[] // data types that keyword applies to
-}
-class WithIndexSignature {
-  [key: string]: unknown /* v2 */
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -1,13 +1,15 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
+assertion_line: 172
 expression: report
 ---
-js compatibility: 766/810 (94.57%), 23 files skipped
+js compatibility: 765/810 (94.44%), 23 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| js/arrows/arrow-chain-with-trailing-comments.js | 💥💥 | 93.75% |
 | js/arrows/issue-17421.js | 💥💥 | 88.70% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/assignment-comments/string.js | 💥 | 96.59% |
@@ -32,7 +34,7 @@ js compatibility: 766/810 (94.57%), 23 files skipped
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 88.24% |
 | js/for/9812-2.js | 💥 | 88.89% |
-| js/for/continue-and-break-comment-without-blocks.js | 💥 | 74.24% |
+| js/for/continue-and-break-comment-without-blocks.js | 💥 | 67.59% |
 | js/for-of/comments.js | 💥 | 44.83% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
@@ -83,7 +85,6 @@ js compatibility: 766/810 (94.57%), 23 files skipped
 
 - js/arrays/numbers-negative-comment-after-minus.js
 - js/arrays/numbers-with-holes.js
-- js/arrows/arrow-chain-with-trailing-comments.js
 - js/comments/return-statement.js
 - js/comments/first-argument/first-argument.js
 - js/for/continue-and-break-comment-without-blocks.js

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
@@ -1,16 +1,19 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
+assertion_line: 178
 expression: report
 ---
-ts compatibility: 624/659 (94.69%), 16 files skipped
+ts compatibility: 621/659 (94.23%), 16 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | typescript/as/as.ts | 💥 | 97.74% |
+| typescript/as/as-const/as-const.ts | 💥 | 66.67% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 93.33% |
 | typescript/as/comments/17407.ts | 💥 | 47.06% |
+| typescript/as/comments/18160.ts | 💥 | 54.21% |
 | typescript/call/callee-comments.ts | 💥 | 75.00% |
 | typescript/cast/18406.ts | 💥 | 84.21% |
 | typescript/class-comment/class-implements.ts | 💥 | 93.33% |
@@ -29,6 +32,7 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 | typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 88.24% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 80.00% |
+| typescript/satisfies-operators/comments-unstable.ts | 💥💥 | 61.54% |
 | typescript/template-literals/member-expression.ts | 💥 | 65.12% |
 | typescript/type-parameters-arguments/18041.ts | 💥 | 91.43% |
 | typescript/type-parameters-arguments/18604.ts | 💥 | 60.00% |
@@ -68,7 +72,5 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 - jsx/comments/in-attributes.js
 - jsx/spread/child.js
 - typescript/as/comments/17407.ts
-- typescript/as/comments/18160.ts
 - typescript/call/callee-comments.ts
 - typescript/method-chain/object/issue-17239.ts
-- typescript/satisfies-operators/comments-unstable.ts

--- a/crates/oxc_formatter_core/FORMATTER_POLICY.md
+++ b/crates/oxc_formatter_core/FORMATTER_POLICY.md
@@ -98,6 +98,10 @@ The invariants:
     - The replaceability test only separates these two
     - Comments may move behind a terminator (per-language compat tables decide when); they always stay before a separator
   - Grammar-fixed DELIMITER (braces, a head's parens) is neither: it bounds a region and stays user content, never crossed
+  - Redundant expression parentheses are NOT delimiters: the formatter drops them and re-derives parens by its own rules, so any paren in the output is formatter-owned
+    - Trailing comment inside the dropped pair moves behind the terminator, even across a re-printed pair
+    - The source pair stays user content only where a sub-printer claims it and prints the comment inside (per-language keeps tables)
+    - The line-boundary invariant still gates the move: never across a re-printed paren that ends up on its own line
 
 Per-language translations (which tokens are terminators, the compat tables, cursor bounds disciplines) live in each crate's AGENTS.md.
 
@@ -159,8 +163,6 @@ PRETTIER_FILTER=<path> cargo test -p <crate> --test conformance -- --nocapture
 ```
 
 The Prettier suite lives under `crates/oxc_formatter_tests/prettier/` and is self-provisioned on the first conformance run. It is gitignored, so use `rg --no-ignore` (or `-u`) when searching it.
-
-JSDoc formatting is covered by plain fixture-pair tests in `oxc_formatter` (`--test jsdoc`, committed input/expected pairs — a mismatch is a failing test, not a tracked report entry).
 
 Failures must be either fixed or classified under "Known divergences".
 


### PR DESCRIPTION
Refine comment position preserving rules, for statements and binary casts. Fixes idempotency issues for several sites.

---

Trailing is the same-line run only.
A newline-preceded comment is never trailing. It defers to the next node's leading pass, staying own-line with its blank lines.

Comments around `as`/`satisfies` keep their source side and line-start side, within the grammar-defined slots (line terminator is not allowed between `as` and before).