### PR TITLE
fix(minifier): preserve annotations when removing parentheses

### DIFF
--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -6,7 +6,9 @@ use oxc_ecmascript::{
     side_effects::{is_typed_array_constructor, is_valid_regexp},
 };
 use oxc_semantic::IsGlobalReference;
+use oxc_span::GetSpan;
 use oxc_syntax::scope::ScopeFlags;
+use rustc_hash::FxHashMap;
 
 use super::PeepholeOptimizations;
 use crate::{
@@ -43,16 +45,63 @@ pub struct NormalizeOptions {
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/Normalize.java>
 pub struct Normalize {
     options: NormalizeOptions,
+    annotation_comment_anchors: AnnotationCommentAnchors,
+}
+
+#[derive(Default)]
+struct AnnotationCommentAnchors {
+    // Original comment anchor -> current surviving expression start.
+    anchors: FxHashMap<u32, u32>,
+}
+
+impl AnnotationCommentAnchors {
+    fn collect(program: &Program<'_>) -> Self {
+        let source_text = program.source_text.as_bytes();
+        let anchors = program
+            .comments
+            .iter()
+            .filter(|comment| {
+                comment.is_annotation()
+                    && source_text.get(comment.attached_to as usize) == Some(&b'(')
+            })
+            .map(|comment| (comment.attached_to, comment.attached_to))
+            .collect();
+        Self { anchors }
+    }
+
+    fn parentheses_removed(&mut self, paren_start: u32, expression_start: u32) {
+        if let Some(attached_to) = self.anchors.get_mut(&paren_start) {
+            *attached_to = expression_start;
+        }
+    }
+
+    fn expression_survives(&mut self, expression_start: u32) {
+        if let Some(attached_to) = self.anchors.get_mut(&expression_start) {
+            *attached_to = expression_start;
+        }
+    }
+
+    fn apply(&self, comments: &mut [Comment]) {
+        for comment in comments {
+            if comment.is_annotation()
+                && let Some(&attached_to) = self.anchors.get(&comment.attached_to)
+            {
+                comment.attached_to = attached_to;
+            }
+        }
+    }
 }
 
 impl<'a> Normalize {
     pub fn build(&mut self, program: &mut Program<'a>, ctx: &mut ReusableTraverseCtx<'a>) {
+        self.annotation_comment_anchors = AnnotationCommentAnchors::collect(program);
         traverse_mut_with_ctx(self, program, ctx);
     }
 }
 
 impl<'a> Traverse<'a> for Normalize {
     fn exit_program(&mut self, node: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        self.annotation_comment_anchors.apply(&mut node.comments);
         if self.options.remove_unnecessary_use_strict && node.source_type.is_module() {
             node.directives.drain_filter(|d| d.directive.as_str() == "use strict");
         }
@@ -135,7 +184,10 @@ impl<'a> Traverse<'a> for Normalize {
         if matches!(expr, Expression::ParenthesizedExpression(_)) {
             expr.replace_with(|expr| {
                 let Expression::ParenthesizedExpression(paren_expr) = expr else { unreachable!() };
-                paren_expr.unbox().expression
+                let paren_expr = paren_expr.unbox();
+                self.annotation_comment_anchors
+                    .parentheses_removed(paren_expr.span.start, paren_expr.expression.span().start);
+                paren_expr.expression
             });
         }
         // Handled outside the match below so the replacement can go through
@@ -147,6 +199,7 @@ impl<'a> Traverse<'a> for Normalize {
         {
             let new_expr = Expression::new_void_0(call_expr.span, ctx);
             ctx.replace_expression(expr, new_expr);
+            self.annotation_comment_anchors.expression_survives(expr.span().start);
             return;
         }
         if let Some(e) = match expr {
@@ -169,6 +222,7 @@ impl<'a> Traverse<'a> for Normalize {
         } {
             *expr = e;
         }
+        self.annotation_comment_anchors.expression_survives(expr.span().start);
     }
 
     fn exit_call_expression(&mut self, e: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -246,7 +300,7 @@ impl<'a> Traverse<'a> for Normalize {
 
 impl<'a> Normalize {
     pub fn new(options: NormalizeOptions) -> Self {
-        Self { options }
+        Self { options, annotation_comment_anchors: AnnotationCommentAnchors::default() }
     }
 
     fn is_console_call_expression(call_expr: &CallExpression<'_>) -> bool {

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -52,6 +52,22 @@ fn parens() {
 }
 
 #[test]
+fn preserve_annotation_anchor_when_removing_parentheses() {
+    test(
+        "function f(a,b){if(a){/* istanbul ignore else */if(b)foo();bar()}}",
+        "function f(a,b){a&&/* istanbul ignore else */(b&&foo(),bar())}",
+    );
+    test("a&&/* c8 ignore next */(((b(),c())))", "a&&/* c8 ignore next */(b(),c())");
+    test("a&&/* normal *//* c8 ignore next */(b(),c())", "a&&/* c8 ignore next */(b(),c())");
+    test("/* c8 ignore start */if(a||b)c()", "/* c8 ignore start */(a||b)&&c()");
+    test(
+        "for(i in x)/* istanbul ignore else */if({}.p())foo()",
+        "for(i in x)/* istanbul ignore else */({}).p()&&foo()",
+    );
+    test("import(/* @vite-ignore */((a?b:c)+d))", "import(/* @vite-ignore */(a?b:c)+d)");
+}
+
+#[test]
 fn drop_console() {
     let options = CompressOptions { drop_console: true, ..default_options() };
     test_options("console.log()", "", &options);

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 657404 # 657.40 kB
   arena allocs: 6809
   arena reallocs: 842
-  arena size: 1164432 # 1.16 MB
+  arena size: 1163376 # 1.16 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB


### PR DESCRIPTION
Annotations can disappear when compressed output is compressed again. Codegen
may insert parentheses around a transformed expression, so reparsing attaches
the annotation to `(`. Normalize removes that node without moving the comment
anchor, and the next codegen pass cannot emit it.

Normalize now moves recognized annotation anchors from removed parentheses to
the surviving expression. If an enclosing expression still begins at the
original offset, it keeps that anchor instead. Normal comments and files
without these annotations are unchanged.

## Example

After the first compression:

```js
a && /* istanbul ignore else */(b && foo(), bar());
```

Before this fix, the second compression produced:

```js
a && (b && foo(), bar());
```

After this fix, the second compression preserves the annotation:

```js
a && /* istanbul ignore else */(b && foo(), bar());
```

Verified with `just ready`, `just minsize`, and the annotation-enabled
monitor-oxc corpus. Corpus mismatches fell from 69 to one across 105,541 files;
the remaining `xlsx` case reproduces in parser + codegen without the minifier.

Found while validating oxc-project/monitor-oxc#218.

AI assistance: Codex was used to investigate, implement, and verify this
change. The contributor is responsible for the submitted change.