### PR TITLE
fix(formatter): do not skip cast comment lookup

### DIFF
--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -68,14 +68,17 @@ pub fn classify_type_cast<'a>(span: Span, f: &JsFormatter<'_, 'a>) -> TypeCast<'
         && last_printed_comment.span.end <= span.start
         && comments.is_type_cast_comment_followed_by_paren(last_printed_comment)
     {
-        return match classify_cast_comment_gap(last_printed_comment.span.end, span.start, f) {
+        match classify_cast_comment_gap(last_printed_comment.span.end, span.start, f) {
             CastCommentGap::ParensAndTrivia if is_followed_by_closing_paren(span, f) => {
-                TypeCast::Target(&[])
+                return TypeCast::Target(&[]);
             }
-            // `Trivia` here means the cast binds to an inner node; since the comment is already printed,
-            // there is nothing left to keep adjacent at this level.
-            _ => TypeCast::None,
-        };
+            // The printed comment is unrelated to this node;
+            // fall through to look for the node's own unprinted cast comment.
+            CastCommentGap::Code => {}
+            // `Trivia` here means the cast binds to an inner node;
+            // since the comment is already printed, there is nothing left to keep adjacent at this level.
+            _ => return TypeCast::None,
+        }
     }
 
     if let Some(type_cast_comment_index) = comments.get_type_cast_comment_index(span) {

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/type-cast-after-ignored-cast.js
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/type-cast-after-ignored-cast.js
@@ -1,0 +1,26 @@
+// A suppressed range marks its comments as printed without going through the
+// cast machinery, so the last printed comment can be a cast-shaped one that is
+// unrelated to the next node; classification must still find that node's own
+// cast comment, or every cast after the ignored line loses its parentheses
+// (issue #26202).
+
+// prettier-ignore
+const a = /** @type {string} */ (x);
+const b = /** @type {string} */ (y);
+const c = /** @type {number} */ (z);
+
+// The cascade also applied to later statements of any shape.
+function f() {
+  return /** @type {B} */ (y);
+}
+const obj = /** @type {Obj} */ ({ k: 1 });
+
+// Interleaved suppressions reset the state each time.
+// oxfmt-ignore
+const d = /** @type {D} */ (v);
+const e = /** @type {E} */ (w);
+
+// A cast-shaped comment without a following `(` still stays paren-less.
+// oxfmt-ignore
+const g = /** @type {G} */ (p);
+const h = /** @type {G} */ q;

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/type-cast-after-ignored-cast.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/type-cast-after-ignored-cast.js.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed range marks its comments as printed without going through the
+// cast machinery, so the last printed comment can be a cast-shaped one that is
+// unrelated to the next node; classification must still find that node's own
+// cast comment, or every cast after the ignored line loses its parentheses
+// (issue #26202).
+
+// prettier-ignore
+const a = /** @type {string} */ (x);
+const b = /** @type {string} */ (y);
+const c = /** @type {number} */ (z);
+
+// The cascade also applied to later statements of any shape.
+function f() {
+  return /** @type {B} */ (y);
+}
+const obj = /** @type {Obj} */ ({ k: 1 });
+
+// Interleaved suppressions reset the state each time.
+// oxfmt-ignore
+const d = /** @type {D} */ (v);
+const e = /** @type {E} */ (w);
+
+// A cast-shaped comment without a following `(` still stays paren-less.
+// oxfmt-ignore
+const g = /** @type {G} */ (p);
+const h = /** @type {G} */ q;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A suppressed range marks its comments as printed without going through the
+// cast machinery, so the last printed comment can be a cast-shaped one that is
+// unrelated to the next node; classification must still find that node's own
+// cast comment, or every cast after the ignored line loses its parentheses
+// (issue #26202).
+
+// prettier-ignore
+const a = /** @type {string} */ (x);
+const b = /** @type {string} */ (y);
+const c = /** @type {number} */ (z);
+
+// The cascade also applied to later statements of any shape.
+function f() {
+  return /** @type {B} */ (y);
+}
+const obj = /** @type {Obj} */ ({ k: 1 });
+
+// Interleaved suppressions reset the state each time.
+// oxfmt-ignore
+const d = /** @type {D} */ (v);
+const e = /** @type {E} */ (w);
+
+// A cast-shaped comment without a following `(` still stays paren-less.
+// oxfmt-ignore
+const g = /** @type {G} */ (p);
+const h = /** @type {G} */ q;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A suppressed range marks its comments as printed without going through the
+// cast machinery, so the last printed comment can be a cast-shaped one that is
+// unrelated to the next node; classification must still find that node's own
+// cast comment, or every cast after the ignored line loses its parentheses
+// (issue #26202).
+
+// prettier-ignore
+const a = /** @type {string} */ (x);
+const b = /** @type {string} */ (y);
+const c = /** @type {number} */ (z);
+
+// The cascade also applied to later statements of any shape.
+function f() {
+  return /** @type {B} */ (y);
+}
+const obj = /** @type {Obj} */ ({ k: 1 });
+
+// Interleaved suppressions reset the state each time.
+// oxfmt-ignore
+const d = /** @type {D} */ (v);
+const e = /** @type {E} */ (w);
+
+// A cast-shaped comment without a following `(` still stays paren-less.
+// oxfmt-ignore
+const g = /** @type {G} */ (p);
+const h = /** @type {G} */ q;
+
+===================== End =====================


### PR DESCRIPTION
Fixes #26202 

---

The trigger for this issue is the presence of a suppressed typecast.

```js
// oxfmt-ignore
const cast = /** c */ (x)
```

Because a comment had already been printed in a subsequent typecast check without going through the casting mechanism, it failed to find its own cast comment.