### PR TITLE
fix(formatter): print suppressed typecast parens

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -173,6 +173,8 @@ deciding on the spot, we encode the same policy per site, so keep them in step:
   (a single-statement body, `if (1) foo\n// c\n;`); a block's last statement keeps them inside instead
 - suppressed side: `suppressed_statement_content_end` (`print/mod.rs`) ends the ignored range at the content,
   so even a `prettier-ignore`d statement gets the formatter's terminator (per `semi`) instead of its source one
+- suppressed expression side: `write_suppressed_expression` (`utils/suppressed.rs`) owns the whole sequence
+  for expression-shaped nodes (the generated `fmt` and the arrow sequence-body site call it before anything of the node is printed), so a cast target keeps its source cast parens (excluded from its span, `utils/typecast.rs`'s `write_suppressed_cast_target`) and in-paren comments print in place via the verbatim range
 
 Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -15,7 +15,7 @@ use crate::{
     parentheses::NeedsParentheses,
     print::FormatWrite,
     utils::{
-        suppressed::FormatSuppressedNode,
+        suppressed::{FormatSuppressedNode, write_suppressed_expression},
         typecast::{
             format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren,
             format_type_cast_comment_node,
@@ -487,7 +487,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -497,11 +507,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -538,7 +544,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -548,11 +564,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -563,7 +575,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, true, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, true, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -573,11 +595,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -642,7 +660,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, true, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, true, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -652,11 +680,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -751,7 +775,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyKey<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -761,11 +795,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -776,7 +806,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -786,11 +826,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -854,7 +890,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MemberExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -864,11 +910,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -879,7 +921,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -889,11 +941,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -904,7 +952,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -914,11 +972,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -929,7 +983,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -939,11 +1003,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -954,7 +1014,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -964,11 +1034,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -979,7 +1045,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -989,11 +1065,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1004,7 +1076,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1014,11 +1096,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1073,7 +1151,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Argument<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1083,11 +1171,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1098,7 +1182,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1108,11 +1202,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1123,7 +1213,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1133,11 +1233,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1148,7 +1244,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1158,11 +1264,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1173,7 +1275,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1183,11 +1295,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1198,7 +1306,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1208,11 +1326,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1223,7 +1337,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1233,11 +1357,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1520,7 +1640,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1530,11 +1660,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1545,7 +1671,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1555,11 +1691,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1570,7 +1702,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1580,11 +1722,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1595,7 +1733,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1605,11 +1753,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -1661,7 +1805,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainElement<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -1671,11 +1825,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -2523,7 +2673,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>>
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -2533,11 +2693,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -2631,7 +2787,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionBody<'a>> 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -2641,11 +2807,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -2656,7 +2818,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -2666,11 +2838,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -2681,7 +2849,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -2691,11 +2869,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -2947,7 +3121,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -2957,11 +3141,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3289,7 +3469,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleExportName<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3299,11 +3489,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3314,7 +3500,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3324,11 +3520,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3339,7 +3531,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3349,11 +3551,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3364,7 +3562,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3374,11 +3582,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3389,7 +3593,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3399,11 +3613,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3414,7 +3624,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3424,11 +3644,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -3439,7 +3655,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -3449,11 +3675,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -4544,7 +4766,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSType<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -4554,11 +4786,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> 
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -4590,7 +4818,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -4600,11 +4838,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -4628,7 +4862,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -4638,11 +4882,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5400,7 +5640,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5410,11 +5660,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5425,7 +5671,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5435,11 +5691,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5537,7 +5789,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedNa
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5547,11 +5809,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5562,7 +5820,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5572,11 +5840,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5613,7 +5877,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5623,11 +5897,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5638,7 +5908,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5648,11 +5928,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5663,7 +5939,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5673,11 +5959,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5754,7 +6036,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReferen
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5764,11 +6056,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }
@@ -5818,7 +6106,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclar
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+        if is_suppressed {
+            write_suppressed_expression(
+                self.span(),
+                self.leading_comments_start(),
+                self.needs_parentheses(f),
+                f,
+            );
+            self.format_trailing_comments(f);
+            return;
+        }
+        if format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
@@ -5828,11 +6126,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
             needs_parentheses,
             f,
         );
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
         if needs_parentheses {
             ")".fmt(f);
         }

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::{
         assignment_like::AssignmentLikeLayout, expression::ExpressionLeftSide,
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
-        suppressed::FormatSuppressedNode, typecast::format_leading_comments_and_open_paren,
+        suppressed::write_suppressed_expression, typecast::format_leading_comments_and_open_paren,
     },
     write,
 };
@@ -866,13 +866,15 @@ fn format_sequence_with_leading_comment<'a, 'b>(
     let is_suppressed = f.comments().is_suppressed(sequence_span.start);
 
     let format_sequence = format_with(move |f| {
-        format_leading_comments_and_open_paren(sequence_span, leading_comments_start, true, f);
         if is_suppressed {
-            write!(f, FormatSuppressedNode(sequence_span));
+            // The single owner keeps a cast target's source parens (`() => /** @type {A} */ (a, b)`),
+            // which double as the sequence-body parens this site otherwise forces.
+            write_suppressed_expression(sequence_span, leading_comments_start, true, f);
         } else {
+            format_leading_comments_and_open_paren(sequence_span, leading_comments_start, true, f);
             write!(f, format_body);
+            write!(f, [")"]);
         }
-        write!(f, [")"]);
     });
 
     Some(format_with(move |f| {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -133,6 +133,8 @@ pub trait FormatWrite<'ast> {
     }
     /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`):
     /// prints `suppressed_span` verbatim.
+    /// Expression-shaped nodes don't route here: the generated `fmt` hands them to
+    /// `write_suppressed_expression`, which keeps a cast target's source parentheses.
     ///
     /// NOTE: `ExpressionStatement` and `VariableDeclaration` have the same issue in principle
     /// but no confirmed divergence against Prettier 3.9 yet.

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -1,7 +1,40 @@
 use oxc_formatter_core::{LINE_TERMINATORS, arena_cow_str, normalize_newlines};
 use oxc_span::Span;
 
-use crate::{Buffer, Format, formatter::prelude::*, write};
+use crate::{
+    Buffer, Format,
+    formatter::prelude::*,
+    utils::typecast::{format_leading_comments_and_open_paren, write_suppressed_cast_target},
+    write,
+};
+
+/// Prints a suppressed expression (`oxfmt-ignore` / `prettier-ignore`):
+/// the single owner of the whole suppressed sequence for expression-shaped nodes
+/// (leading comments, formatter-added parens, the verbatim range),
+/// called by the generated `fmt` before anything of the node is printed,
+/// so the cast decision is made once, with every comment still unprinted.
+///
+/// A cast target keeps its source cast parentheses (see `write_suppressed_cast_target`).
+///
+/// `needs_parentheses` promises a PARENTHESIZED output, not a formatter pair:
+/// on the cast path the kept source parens satisfy it (a formatter pair on top would print `((x))`),
+/// so callers must not add parens of their own around this call.
+pub fn write_suppressed_expression(
+    span: Span,
+    leading_comments_start: u32,
+    needs_parentheses: bool,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    if write_suppressed_cast_target(span, f) {
+        return;
+    }
+
+    format_leading_comments_and_open_paren(span, leading_comments_start, needs_parentheses, f);
+    FormatSuppressedNode(span).fmt(f);
+    if needs_parentheses {
+        write!(f, ")");
+    }
+}
 
 pub struct FormatSuppressedNode(pub Span);
 

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -8,6 +8,7 @@ use crate::{
         prelude::*,
         trivia::{FormatLeadingComments, format_leading_comments},
     },
+    utils::suppressed::FormatSuppressedNode,
     write,
 };
 
@@ -139,6 +140,94 @@ pub fn format_type_cast_comment_node<'a>(
     }
 
     true
+}
+
+/// Prints a suppressed node that is a cast target keeping its source cast parentheses;
+/// returns `false` when it is not one
+/// (the caller, `write_suppressed_expression`, prints its plain verbatim range instead).
+/// Must run before anything of the node is printed, with every comment still unprinted.
+///
+/// A cast target's span excludes its own wrapping parentheses (`preserve_parens: false`),
+/// so a plain verbatim range would print `/** @type {A} */ x`, silently breaking the cast.
+/// Leading comments print only up to the cast comment (`pending` ends with it, see [`TypeCast::Target`]);
+/// the in-paren comments (`(/* c */ x)`) print in place via the verbatim text, which also marks them.
+/// An empty `pending` (the cast comment printed by an ancestor) cannot reach here suppressed,
+/// and falls through regardless.
+pub fn write_suppressed_cast_target(span: Span, f: &mut JsFormatter<'_, '_>) -> bool {
+    if let TypeCast::Target(pending) = classify_type_cast(span, f)
+        && let Some(cast_comment) = pending.last()
+        && let Some(verbatim_span) = cast_parens_span(cast_comment.span.end, span, f)
+    {
+        write!(f, [FormatLeadingComments::Comments(pending)]);
+        FormatSuppressedNode(verbatim_span).fmt(f);
+        true
+    } else {
+        false
+    }
+}
+
+/// The verbatim range for a suppressed cast target:
+/// from the first `(` after the cast comment to after the matching `)`.
+///
+/// The gap is already classified as parens and trivia ([`CastCommentGap::ParensAndTrivia`]);
+/// comments are skipped by span ([`gap_segments`]), so `(` `)` bytes inside them don't count.
+/// The parser guarantees each counted `(` wraps the node and closes after it (see [`CastCommentGap`]).
+#[expect(clippy::cast_possible_truncation)] // Offsets fit in `u32`, source length does
+fn cast_parens_span(cast_comment_end: u32, span: Span, f: &JsFormatter<'_, '_>) -> Option<Span> {
+    let comments = f.context().comments();
+    let source = f.source_text();
+    let source_end = source.as_str().len() as u32;
+
+    // Find the first `(` between the cast comment and the node and count them
+    let mut open_parens = 0usize;
+    let mut first_open_paren = None;
+    let backward_comments = comments.comments_in_range(cast_comment_end, span.start);
+    for (from, to) in gap_segments(backward_comments, cast_comment_end, span.start) {
+        for (offset, &byte) in source.bytes_range(from, to).iter().enumerate() {
+            if byte == b'(' {
+                open_parens += 1;
+                first_open_paren.get_or_insert(from + offset as u32);
+            }
+        }
+    }
+    let start = first_open_paren?;
+
+    // Consume the matching `)`s after the node (only trivia sits between them);
+    // `)` bytes inside comments don't count.
+    for (from, to) in gap_segments(comments.comments_after(span.end), span.end, source_end) {
+        for (offset, &byte) in source.bytes_range(from, to).iter().enumerate() {
+            if byte == b')' {
+                open_parens -= 1;
+                if open_parens == 0 {
+                    return Some(Span::new(start, from + offset as u32 + 1));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Byte segments between `start` and `bound` lying outside the given comment spans:
+/// one `(gap_start, gap_end)` pair per gap, ending with the tail segment up to `bound`.
+fn gap_segments(
+    comment_spans: &[Comment],
+    start: u32,
+    bound: u32,
+) -> impl Iterator<Item = (u32, u32)> + '_ {
+    let mut pos = start;
+    comment_spans
+        .iter()
+        .map(|comment| comment.span)
+        .chain(std::iter::once(Span::empty(bound)))
+        .filter_map(move |span| {
+            // A comment ending exactly at `pos` lies before the range
+            if span.start < pos {
+                return None;
+            }
+            let segment = (pos, span.start);
+            pos = span.end;
+            Some(segment)
+        })
 }
 
 /// Prints a node's leading comments and the formatter-added `(` in the correct order.

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/suppressed-argument-cast-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/suppressed-argument-cast-parens.js
@@ -1,0 +1,50 @@
+// A suppressed expression's verbatim range is its span, which excludes the
+// node's own wrapping source parens (`preserve_parens: false`). A cast target
+// must keep them, or `/** @type {A} */ x` silently stops being a cast for tsc.
+
+foo(
+  // prettier-ignore
+  /** @type {A} */ (x),
+  /** @type {B} */ (y),
+);
+
+// Nested parens are kept as written.
+foo(
+  // prettier-ignore
+  /** @type {A} */ ((x)),
+);
+
+// In-paren comments stay in place via the verbatim text (no duplication).
+foo(
+  // prettier-ignore
+  /** @type {B} */ (/* in */ z),
+  // prettier-ignore
+  /** @type {C} */ (v /* :) */),
+);
+
+// A cast-shaped comment not immediately followed by `(` is not a cast:
+// the parens drop, like Prettier.
+foo(
+  // prettier-ignore
+  /** @type {D} */ /* mid */ (u),
+);
+
+// Bare parens (no cast comment) also drop, like Prettier.
+foo(
+  // prettier-ignore
+  (x + 1),
+);
+
+// Trailing comment after the closing paren stays trailing.
+foo(
+  // prettier-ignore
+  /** @type {C} */ (z) /* t */,
+  w,
+);
+
+// An arrow's sequence body routes through the same owner:
+// the source cast parens double as the body parens it forces (no `((...))`),
+// and the in-paren comment survives in place.
+const g = () =>
+  // prettier-ignore
+  /** @type {A} */ (/* c */ a, b);

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/suppressed-argument-cast-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/suppressed-argument-cast-parens.js.snap
@@ -1,0 +1,165 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed expression's verbatim range is its span, which excludes the
+// node's own wrapping source parens (`preserve_parens: false`). A cast target
+// must keep them, or `/** @type {A} */ x` silently stops being a cast for tsc.
+
+foo(
+  // prettier-ignore
+  /** @type {A} */ (x),
+  /** @type {B} */ (y),
+);
+
+// Nested parens are kept as written.
+foo(
+  // prettier-ignore
+  /** @type {A} */ ((x)),
+);
+
+// In-paren comments stay in place via the verbatim text (no duplication).
+foo(
+  // prettier-ignore
+  /** @type {B} */ (/* in */ z),
+  // prettier-ignore
+  /** @type {C} */ (v /* :) */),
+);
+
+// A cast-shaped comment not immediately followed by `(` is not a cast:
+// the parens drop, like Prettier.
+foo(
+  // prettier-ignore
+  /** @type {D} */ /* mid */ (u),
+);
+
+// Bare parens (no cast comment) also drop, like Prettier.
+foo(
+  // prettier-ignore
+  (x + 1),
+);
+
+// Trailing comment after the closing paren stays trailing.
+foo(
+  // prettier-ignore
+  /** @type {C} */ (z) /* t */,
+  w,
+);
+
+// An arrow's sequence body routes through the same owner:
+// the source cast parens double as the body parens it forces (no `((...))`),
+// and the in-paren comment survives in place.
+const g = () =>
+  // prettier-ignore
+  /** @type {A} */ (/* c */ a, b);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A suppressed expression's verbatim range is its span, which excludes the
+// node's own wrapping source parens (`preserve_parens: false`). A cast target
+// must keep them, or `/** @type {A} */ x` silently stops being a cast for tsc.
+
+foo(
+  // prettier-ignore
+  /** @type {A} */ (x),
+  /** @type {B} */ (y),
+);
+
+// Nested parens are kept as written.
+foo(
+  // prettier-ignore
+  /** @type {A} */ ((x)),
+);
+
+// In-paren comments stay in place via the verbatim text (no duplication).
+foo(
+  // prettier-ignore
+  /** @type {B} */ (/* in */ z),
+  // prettier-ignore
+  /** @type {C} */ (v /* :) */),
+);
+
+// A cast-shaped comment not immediately followed by `(` is not a cast:
+// the parens drop, like Prettier.
+foo(
+  // prettier-ignore
+  /** @type {D} */ /* mid */ u,
+);
+
+// Bare parens (no cast comment) also drop, like Prettier.
+foo(
+  // prettier-ignore
+  x + 1,
+);
+
+// Trailing comment after the closing paren stays trailing.
+foo(
+  // prettier-ignore
+  /** @type {C} */ (z) /* t */,
+  w,
+);
+
+// An arrow's sequence body routes through the same owner:
+// the source cast parens double as the body parens it forces (no `((...))`),
+// and the in-paren comment survives in place.
+const g = () =>
+  // prettier-ignore
+  /** @type {A} */ (/* c */ a, b);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A suppressed expression's verbatim range is its span, which excludes the
+// node's own wrapping source parens (`preserve_parens: false`). A cast target
+// must keep them, or `/** @type {A} */ x` silently stops being a cast for tsc.
+
+foo(
+  // prettier-ignore
+  /** @type {A} */ (x),
+  /** @type {B} */ (y),
+);
+
+// Nested parens are kept as written.
+foo(
+  // prettier-ignore
+  /** @type {A} */ ((x)),
+);
+
+// In-paren comments stay in place via the verbatim text (no duplication).
+foo(
+  // prettier-ignore
+  /** @type {B} */ (/* in */ z),
+  // prettier-ignore
+  /** @type {C} */ (v /* :) */),
+);
+
+// A cast-shaped comment not immediately followed by `(` is not a cast:
+// the parens drop, like Prettier.
+foo(
+  // prettier-ignore
+  /** @type {D} */ /* mid */ u,
+);
+
+// Bare parens (no cast comment) also drop, like Prettier.
+foo(
+  // prettier-ignore
+  x + 1,
+);
+
+// Trailing comment after the closing paren stays trailing.
+foo(
+  // prettier-ignore
+  /** @type {C} */ (z) /* t */,
+  w,
+);
+
+// An arrow's sequence body routes through the same owner:
+// the source cast parens double as the body parens it forces (no `((...))`),
+// and the in-paren comment survives in place.
+const g = () =>
+  // prettier-ignore
+  /** @type {A} */ (/* c */ a, b);
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -6,6 +6,9 @@
 //!   - they change the shape of the generated code, nothing else
 //! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `suppressed_span`, `write_suppressed`)
 //!   - defaults cover the common case, overrides sit next to the node's `write` and need no regeneration
+//!   - EXCEPT: expression-shaped nodes bypass `write_suppressed` entirely
+//!     (their suppressed path goes to `write_suppressed_expression`, see below),
+//!     so an override on such a node would silently never be called
 //!
 //! Add a new list only for a variation the emitted shape must express;
 //! for anything a node merely answers, add a trait method with a total default.
@@ -93,7 +96,7 @@ impl Generator for FormatterFormatGenerator {
                 formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
-                utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
+                utils::{suppressed::{FormatSuppressedNode, write_suppressed_expression}, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
                 print::FormatWrite,
             };
 
@@ -196,31 +199,53 @@ fn generate_struct_implementation(
                 }
             });
 
-        let write_implementation = if suppressed_check.is_none() {
-            write_call
-        } else {
-            // When `fmt` doesn't print leading/trailing comments itself,
-            // the suppressed path still has to print them, or the suppression comment would be lost.
-            let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
+        // Expression-shaped nodes (formatter parens + own comment printing) hand the whole
+        // suppressed sequence to one owner, so the cast-target decision is made once
+        // while every comment is still unprinted (see `write_suppressed_expression`).
+        // These nodes have no `suppressed_span`/`write_suppressed` overrides (those are statements).
+        let suppressed_expression_return =
+            (suppressed_check.is_some() && needs_parentheses && !do_not_print_leading_comment)
+                .then(|| {
+                    quote! {
+                        if is_suppressed {
+                            write_suppressed_expression(
+                                self.span(),
+                                self.leading_comments_start(),
+                                self.needs_parentheses(f),
+                                f,
+                            );
+                            self.format_trailing_comments(f);
+                            return;
+                        }
+                    }
+                });
+
+        let write_implementation =
+            if suppressed_check.is_none() || suppressed_expression_return.is_some() {
+                write_call
+            } else {
+                // When `fmt` doesn't print leading/trailing comments itself,
+                // the suppressed path still has to print them, or the suppression comment would be lost.
+                let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
+                    quote! {
+                        format_leading_comments(self.suppressed_span()).fmt(f);
+                    }
+                });
+                let suppressed_trailing_comments = do_not_print_comment.then(|| {
+                    quote! {
+                        self.format_trailing_comments(f);
+                    }
+                });
                 quote! {
-                    format_leading_comments(self.suppressed_span()).fmt(f);
+                    if is_suppressed {
+                        #suppressed_leading_comments
+                        self.write_suppressed(f);
+                        #suppressed_trailing_comments
+                    } else {
+                        #write_call
+                    }
                 }
-            });
-            let suppressed_trailing_comments = do_not_print_comment.then(|| {
-                quote! {
-                    self.format_trailing_comments(f);
-                }
-            });
-            quote! {
-                if is_suppressed {
-                    #suppressed_leading_comments
-                    self.write_suppressed(f);
-                    #suppressed_trailing_comments
-                } else {
-                    #write_call
-                }
-            }
-        };
+            };
 
         let type_cast_comment_formatting = needs_parentheses.then(|| {
             let is_object_or_array_argument =
@@ -232,7 +257,10 @@ fn generate_struct_implementation(
                     quote! { false }
                 };
 
-            let suppressed_check_for_typecast = suppressed_check.is_some().then(|| {
+            // With the suppressed early return above, the flag is trivially false here
+            let suppressed_check_for_typecast = (suppressed_check.is_some()
+                && suppressed_expression_return.is_none())
+            .then(|| {
                 quote! {
                     !is_suppressed &&
                 }
@@ -254,6 +282,7 @@ fn generate_struct_implementation(
         } else {
             quote! {
                 #suppressed_check
+                #suppressed_expression_return
                 #type_cast_comment_formatting
                 #leading_comments
                 #needs_parentheses_before


### PR DESCRIPTION
```js
// input
foo(
  // oxfmt-ignore
  /** @type {A} */ (x),
  /** @type {B} */ (y),
);

// before
foo(
  // oxfmt-ignore
  /** @type {A} */ x, // <-
  /** @type {B} */ (y),
);

// after
foo(
  // oxfmt-ignore
  /** @type {A} */ (x), // <-
  /** @type {B} */ (y),
);
```