### PR TITLE
fix(formatter): re-add suppressed statement terminators per options.semi

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -179,8 +179,9 @@ deciding on the spot, we encode the same policy per site, so keep them in step:
 Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
 
 - Whether a suppressed statement re-adds `;` is a compat table, not a principle:
-  keyword statements (`debugger`/`break`/`continue`) always re-add,
-  content-terminated ones only when a source `;` was stripped — the asymmetry is observable only for a suppressed keyword statement relying on ASI
+  keyword statements (`debugger`/`break`/`continue`) and variable declarations (ignored range ends at the last declarator) always re-add;
+  content-terminated ones, including `export const` (measured, keep the asymmetry), only when a source `;` was stripped.
+  A `for` head declaration instead stays verbatim (DIVERGENCES.md#suppressed-for-head-declaration)
 - The `semi: false` ASI guard is decided from the guarded statement alone,
   never from the previous statement's output;
   sound because no statement leaves its own trailing `;`,

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -432,3 +432,80 @@ literal trailing space, so the exact fill overflows: it breaks the assignment an
 flat on the indented next line. One char over and the outputs converge; a naive port of the
 literal-space structure regresses `js/arrows/currying-4.js` (Prettier gates the hug on the chain's
 expand state), so matching costs more than this exact-width edge is worth.
+
+## suppressed-for-head-declaration
+
+- Why: semantics (Prettier's output no longer parses)
+- Pin: `tests/fixtures/js/semicolons/suppressed-for-head-declaration.js`
+- Drop when: Prettier stops re-adding `;` for a suppressed `for` head declaration
+
+```js
+// input
+for (/* prettier-ignore */ var i   =   1;;) [].sort();
+
+// ours
+for (/* prettier-ignore */ var i   =   1; ;) [].sort();
+
+// prettier
+for (/* prettier-ignore */ var i   =   1;; ;) [].sort();
+```
+
+Prettier's `shouldIgnoredNodePrintSemicolon` lists `VariableDeclaration` unconditionally,
+so a suppressed declaration in a `for` head gets an extra `;` and the head no longer parses
+(a `for (;;)` head admits exactly two semicolons).
+In the head the declaration has no terminator of its own; we keep it verbatim and let the `for` statement print its separators.
+
+## suppressed-source-paren-asi-guard
+
+- Why: semantics (Prettier's output re-parses as a call)
+- Pin: `tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js`
+- Drop when: Prettier guards a suppressed statement whose verbatim text starts with `(`
+
+```js
+// input (semi: false)
+let x = 1;
+
+// prettier-ignore
+(sourceParen).sort();
+
+// ours
+let x = 1
+
+// prettier-ignore
+;(sourceParen).sort()
+
+// prettier
+let x = 1
+
+// prettier-ignore
+(sourceParen).sort()
+```
+
+A suppressed expression statement prints its source text, which keeps parens the reprint would drop, so the line starts with `(` and needs the `semi: false` ASI guard.
+Prettier's `expressionNeedsAsiProtection` walks the AST's naked left side and never sees the source paren, so its output re-parses as `1(sourceParen)...`.
+We check the verbatim range's first byte instead and print the guard.
+
+## suppressed-cast-comment-asi-guard
+
+- Why: semantics (Prettier's guard placement detaches the type cast; verified with tsc)
+- Pin: `tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js`
+- Drop when: Prettier prints the ignored-slice ASI guard before a leading type cast comment
+
+```js
+// input (semi: false)
+// prettier-ignore
+/** @type {string[]} */ (cast).sort();
+
+// ours
+// prettier-ignore
+;/** @type {string[]} */ (cast).sort()
+
+// prettier
+// prettier-ignore
+/** @type {string[]} */ ;(cast).sort()
+```
+
+A cast comment types its parenthesized expression only when directly adjacent:
+with Prettier's placement tsc reports the target as its uncast type again.
+
+Prettier's `printIgnored` prepends the guard to the ignored slice, which starts after the leading comments; we reuse the reprint path's split (`ExpressionStatement::write`), so the guard, the cast comment, and the verbatim content print in that order.

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -838,7 +838,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -2250,7 +2250,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
         } else {
             self.write(f);
@@ -2520,7 +2520,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -2533,7 +2533,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -2705,7 +2705,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -2744,7 +2744,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FunctionBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -2894,7 +2894,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -3301,7 +3301,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> 
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -3314,7 +3314,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -3327,7 +3327,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -3340,7 +3340,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaratio
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
             self.format_trailing_comments(f);
         } else {
@@ -4803,7 +4803,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
         let needs_parentheses = self.needs_parentheses(f);
         format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            format_leading_comments(self.suppressed_span()).fmt(f);
+            self.write_suppressed_leading_comments(f);
             self.write_suppressed(f);
         } else {
             self.write(f);

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -136,14 +136,23 @@ pub trait FormatWrite<'ast> {
     /// Expression-shaped nodes don't route here: the generated `fmt` hands them to
     /// `write_suppressed_expression`, which keeps a cast target's source parentheses.
     ///
-    /// NOTE: `ExpressionStatement` and `VariableDeclaration` have the same issue in principle
-    /// but no confirmed divergence against Prettier 3.9 yet.
-    /// Extend the overrides one statement at a time, verifying each against Prettier first.
+    /// NOTE: Extend the overrides one statement at a time with verifying each.
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'ast>)
     where
         Self: GetSpan,
     {
         FormatSuppressedNode(self.suppressed_span()).fmt(f);
+    }
+
+    /// The leading-comments step of the suppressed path,
+    /// for nodes whose generated `fmt` leaves leading comments to the node;
+    /// it calls this, then [`Self::write_suppressed`].
+    /// Override to interleave with the comments (`ExpressionStatement`'s ASI guard).
+    fn write_suppressed_leading_comments(&self, f: &mut JsFormatter<'_, 'ast>)
+    where
+        Self: GetSpan,
+    {
+        format_leading_comments(self.suppressed_span()).fmt(f);
     }
 }
 
@@ -558,10 +567,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
     }
 }
 
-/// Returns `true` if the expression needs a leading semicolon to prevent ASI issues
+/// Returns `true` if the expression needs a leading semicolon to prevent ASI issues.
+///
+/// `verbatim` is set for a suppressed statement, whose printed form is the source text:
+/// that keeps source parens the reprint would drop, so a leading `(` is a hazard the AST checks below cannot see.
 fn expression_statement_needs_semicolon<'a>(
     stmt: &AstNode<'a, ExpressionStatement<'a>>,
     f: &JsFormatter<'_, 'a>,
+    verbatim: bool,
 ) -> bool {
     if matches!(
         stmt.parent(),
@@ -584,6 +597,11 @@ fn expression_statement_needs_semicolon<'a>(
     ) {
         return false;
     }
+
+    if verbatim && f.source_text().as_bytes()[stmt.span().start as usize] == b'(' {
+        return true;
+    }
+
     // Arrow functions need semicolon only if they will have parentheses
     // e.g., `(a) => {}` needs `;(a) => {}` but `a => {}` doesn't need semicolon
     if let Expression::ArrowFunctionExpression(arrow) = &stmt.expression {
@@ -649,30 +667,50 @@ fn expression_statement_needs_semicolon<'a>(
     })
 }
 
+/// Prints the statement's leading comments with the `semi: false` ASI guard spliced in
+/// before a trailing type cast comment: `;/** @type {string[]} */ ([]).forEach(...)`.
+/// `/** @type {string[]} */ ;([]).forEach(...)` form breaks type cast.
+/// For `verbatim`, see [`expression_statement_needs_semicolon`].
+fn write_leading_comments_with_asi_guard<'a>(
+    stmt: &AstNode<'a, ExpressionStatement<'a>>,
+    verbatim: bool,
+    f: &mut JsFormatter<'_, 'a>,
+) {
+    let start = stmt.span().start;
+    let needs_semicolon = f.options().semicolons == Semicolons::AsNeeded
+        && expression_statement_needs_semicolon(stmt, f, verbatim);
+    let leading_comments = f.context().comments().comments_before(start);
+    let split = if needs_semicolon
+        && leading_comments.last().is_some_and(|last| f.comments().is_type_cast_comment(last))
+    {
+        leading_comments.len() - 1
+    } else {
+        leading_comments.len()
+    };
+    write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[..split], start));
+    if needs_semicolon {
+        write!(f, ";");
+    }
+    write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[split..], start));
+}
+
 impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
+    fn write_suppressed_leading_comments(&self, f: &mut JsFormatter<'_, 'a>) {
+        // Prettier's `printIgnored` puts the guard after the cast comment and breaks the cast;
+        // ours goes before it (DIVERGENCES.md#suppressed-cast-comment-asi-guard)
+        write_leading_comments_with_asi_guard(self, true, f);
+    }
+
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        // The ignored range ends at the expression (plus source parens)
+        let (content_end, print_semicolon) =
+            semicolon_terminated_content_end(self.expression().span().end, self.span(), f);
+        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let span = self.span();
-        // Check if we need a leading semicolon to prevent ASI issues.
-        // Leading comments are printed here rather than in the generated `fmt`
-        // so the semicolon can go before a type cast comment;
-        // otherwise the cast is detached from its expression and the parentheses get dropped on the next format:
-        // `;/** @type {string[]} */ ([]).forEach(...)`
-        let needs_semicolon = f.options().semicolons == Semicolons::AsNeeded
-            && expression_statement_needs_semicolon(self, f);
-        let leading_comments = f.context().comments().comments_before(span.start);
-        // Split off a trailing type cast comment so the semicolon lands before it
-        let split = if needs_semicolon
-            && leading_comments.last().is_some_and(|last| f.comments().is_type_cast_comment(last))
-        {
-            leading_comments.len() - 1
-        } else {
-            leading_comments.len()
-        };
-        write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[..split], span.start));
-        if needs_semicolon {
-            write!(f, ";");
-        }
-        write!(f, FormatLeadingComments::CommentsOfNode(&leading_comments[split..], span.start));
+        write_leading_comments_with_asi_guard(self, false, f);
 
         if f.comments().has_trailing_suppression_comment(span.end) {
             // Preserve original text when the statement has an inline suppression comment:
@@ -763,10 +801,23 @@ fn break_or_continue_content_end(
     label.map_or(span.start + keyword_len, |label| label.span.end)
 }
 
+/// The ignored range end for a variable declaration: the last declarator,
+/// extended over a cast's source parens.
+/// The source `;` is always outside (Prettier's `locEnd` override lists `VariableDeclaration`).
+fn variable_declaration_content_end(
+    declaration: &VariableDeclaration<'_>,
+    f: &JsFormatter<'_, '_>,
+) -> u32 {
+    // `VariableDeclaration` always has at least one declarator
+    let declarations_end = declaration.declarations.last().unwrap().span.end;
+    // The stripped-`;` flag is discarded: a declaration re-adds its terminator unconditionally
+    semicolon_terminated_content_end(declarations_end, declaration.span, f).0
+}
+
 /// The ignored range end of a suppressed statement and whether the formatter prints its own terminator after it,
 /// mirroring Prettier's `locEnd` overrides (`language-js/location/overrides.js`) + `shouldIgnoredNodePrintSemicolon`:
 /// the trailing `;` (and anything between it and the content) is excluded from the verbatim range,
-/// keyword statements (`debugger`/`break`/`continue`) always re-add `;`,
+/// keyword statements (`debugger`/`break`/`continue`) and variable declarations always re-add `;`,
 /// content-terminated ones only when a source `;` was stripped, and statements ending in a body recurse into the rightmost body.
 fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
     match stmt {
@@ -787,6 +838,7 @@ fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_
         Statement::ContinueStatement(s) => {
             (break_or_continue_content_end(s.span, CONTINUE_KEYWORD_LEN, s.label.as_ref()), true)
         }
+        Statement::VariableDeclaration(s) => (variable_declaration_content_end(s, f), true),
         Statement::IfStatement(s) => {
             suppressed_statement_content_end(s.alternate.as_ref().unwrap_or(&s.consequent), f)
         }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -15,20 +15,45 @@ use crate::{
     write,
 };
 
-use super::FormatWrite;
+use crate::utils::suppressed::FormatSuppressedNode;
+
+use super::{
+    FormatWrite, variable_declaration_content_end, write_suppressed_statement_with_semicolon,
+};
+
+/// Whether the declaration is a `for`/`for-in`/`for-of` head,
+/// terminated by the head itself (the head-vs-body test is by span: a declaration can also be the body).
+/// Everywhere else the declaration terminates itself, including `export const ...`,
+/// whose `ExportDeclaration` prints no semicolon of its own (see its `FormatWrite` implementation).
+fn is_for_head_declaration(decl: &AstNode<'_, VariableDeclaration<'_>>) -> bool {
+    match decl.parent() {
+        AstNodes::ForStatement(stmt) => {
+            stmt.init.as_ref().is_some_and(|init| init.span() == decl.span())
+        }
+        AstNodes::ForInStatement(stmt) => stmt.left.span() == decl.span(),
+        AstNodes::ForOfStatement(stmt) => stmt.left.span() == decl.span(),
+        _ => false,
+    }
+}
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
+    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
+        if is_for_head_declaration(self) {
+            // No terminator of its own to re-add:
+            // Prettier appends one anyway and corrupts the head (DIVERGENCES.md#suppressed-for-head-declaration)
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            // The ignored range ends at the last declarator; the terminator is always the formatter's
+            write_suppressed_statement_with_semicolon(
+                self.span().start,
+                variable_declaration_content_end(self, f),
+                f,
+            );
+        }
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let semicolon = match self.parent() {
-            AstNodes::ForStatement(stmt) => {
-                stmt.init().is_some_and(|init| init.span() != self.span())
-            }
-            AstNodes::ForInStatement(stmt) => stmt.left().span() != self.span(),
-            AstNodes::ForOfStatement(stmt) => stmt.left().span() != self.span(),
-            // Everywhere else the declaration terminates itself, including `export const ...`,
-            // whose `ExportDeclaration` prints no semicolon of its own (see its `FormatWrite` implementation).
-            _ => true,
-        };
+        let semicolon = !is_for_head_declaration(self);
 
         if self.declare() {
             write!(f, ["declare", space()]);

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/for-body-declaration.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/for-body-declaration.js
@@ -1,0 +1,6 @@
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1
+
+for (init;;) var withInit = 2

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/for-body-declaration.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/for-body-declaration.js.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1
+
+for (init;;) var withInit = 2
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1;
+
+for (init; ;) var withInit = 2;
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1;
+
+for (init; ;) var withInit = 2;
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1
+
+for (init; ;) var withInit = 2
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A declaration as a `for` BODY terminates itself even when the head has no
+// init: the head-vs-body test is by span, not by parent kind.
+
+for (;;) var noInit = 1
+
+for (init; ;) var withInit = 2
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js
@@ -1,0 +1,7 @@
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+/** @type {string[]} */ (cast).sort();

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js.snap
@@ -1,0 +1,58 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+/** @type {string[]} */ (cast).sort();
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+/** @type {string[]} */ (cast).sort();
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+/** @type {string[]} */ (cast).sort();
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+;/** @type {string[]} */ (cast).sort()
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// The `semi: false` ASI guard prints BEFORE a leading type cast comment even
+// for a suppressed statement: a `;` between the cast comment and its parens
+// detaches the cast (tsc drops the type). Prettier prints it after the comment;
+// the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
+
+// prettier-ignore
+;/** @type {string[]} */ (cast).sort()
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-for-head-declaration.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-for-head-declaration.js
@@ -1,0 +1,5 @@
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1;;) [].sort()

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-for-head-declaration.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-for-head-declaration.js.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1;;) [].sort()
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1; ;) [].sort();
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1; ;) [].sort();
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1; ;) [].sort()
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A suppressed `for` head declaration stays verbatim: it has no terminator of
+// its own to re-add; Prettier appends one anyway and its output no longer parses.
+// The last line deviates from Prettier (DIVERGENCES.md#suppressed-for-head-declaration).
+
+for (/* prettier-ignore */ var i   =   1; ;) [].sort()
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js
@@ -1,0 +1,9 @@
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1;
+
+// prettier-ignore
+(sourceParen).sort();

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js.snap
@@ -1,0 +1,68 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1;
+
+// prettier-ignore
+(sourceParen).sort();
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1;
+
+// prettier-ignore
+(sourceParen).sort();
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1;
+
+// prettier-ignore
+(sourceParen).sort();
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1
+
+// prettier-ignore
+;(sourceParen).sort()
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A suppressed statement keeps its source parens, so the leading `(` needs
+// the `semi: false` ASI guard. Prettier misses it and its output re-parses
+// as a call; the guarded line deviates
+// (DIVERGENCES.md#suppressed-source-paren-asi-guard).
+
+let x = 1
+
+// prettier-ignore
+;(sourceParen).sort()
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
@@ -27,3 +27,43 @@ lbl3: for (;;) {
   // prettier-ignore
   break   lbl3
 }
+
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1
+
+;[].sort()
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  );
+
+;[].sort()
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2
+
+;[].sort()
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1
+
+;[].sort()
+
+// prettier-ignore
+export const exported   =   1
+
+foo()
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   );
+
+// prettier-ignore
+[breaking].sort();

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
@@ -32,6 +32,46 @@ lbl3: for (;;) {
   break   lbl3
 }
 
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1
+
+;[].sort()
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  );
+
+;[].sort()
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2
+
+;[].sort()
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1
+
+;[].sort()
+
+// prettier-ignore
+export const exported   =   1
+
+foo()
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   );
+
+// prettier-ignore
+[breaking].sort();
+
 ==================== Output ====================
 ------------------------------
 { printWidth: 80, semi: true }
@@ -66,6 +106,46 @@ lbl3: for (;;) {
   break   lbl3;
 }
 
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1;
+
+[].sort();
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  );
+
+[].sort();
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2;
+
+[].sort();
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1;
+
+[].sort();
+
+// prettier-ignore
+export const exported   =   1
+
+foo();
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   );
+
+// prettier-ignore
+[breaking].sort();
+
 -------------------------------
 { printWidth: 100, semi: true }
 -------------------------------
@@ -98,6 +178,46 @@ lbl3: for (;;) {
   // prettier-ignore
   break   lbl3;
 }
+
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1;
+
+[].sort();
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  );
+
+[].sort();
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2;
+
+[].sort();
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1;
+
+[].sort();
+
+// prettier-ignore
+export const exported   =   1
+
+foo();
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   );
+
+// prettier-ignore
+[breaking].sort();
 
 -------------------------------
 { printWidth: 80, semi: false }
@@ -132,6 +252,46 @@ lbl3: for (;;) {
   break   lbl3
 }
 
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1
+
+;[].sort()
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  )
+
+;[].sort()
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2
+
+;[].sort()
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1
+
+;[].sort()
+
+// prettier-ignore
+export const exported   =   1
+
+foo()
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   )
+
+// prettier-ignore
+;[breaking].sort()
+
 --------------------------------
 { printWidth: 100, semi: false }
 --------------------------------
@@ -164,5 +324,45 @@ lbl3: for (;;) {
   // prettier-ignore
   break   lbl3
 }
+
+// A suppressed variable declaration always gets the formatter's terminator:
+// the ignored range ends at the last declarator, source `;` or not
+// (unlike content-terminated statements, and unlike `export const`).
+
+// prettier-ignore
+const noSemi   =   1
+
+;[].sort()
+
+// prettier-ignore
+let cast = /** @type {string} */ (   value  )
+
+;[].sort()
+
+// prettier-ignore
+var multi   =   1,   multi2   =   2
+
+;[].sort()
+
+// The rightmost-body recursion reaches the declaration
+// prettier-ignore
+if (cond) var inBody   =   1
+
+;[].sort()
+
+// prettier-ignore
+export const exported   =   1
+
+foo()
+
+// A suppressed expression statement also ends its ignored range at the content
+// (`;` re-added only when a source `;` was stripped),
+// and still gets its `semi: false` ASI guard.
+
+// prettier-ignore
+stmt(   )
+
+// prettier-ignore
+;[breaking].sort()
 
 ===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -224,13 +224,19 @@ fn generate_struct_implementation(
             if suppressed_check.is_none() || suppressed_expression_return.is_some() {
                 write_call
             } else {
-                // When `fmt` doesn't print leading/trailing comments itself,
-                // the suppressed path still has to print them, or the suppression comment would be lost.
-                let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
+                // When `fmt` doesn't print leading comments itself,
+                // the suppressed path delegates them to the node;
+                // see `FormatWrite::write_suppressed_leading_comments`.
+                let suppressed_write_call = if do_not_print_leading_comment {
                     quote! {
-                        format_leading_comments(self.suppressed_span()).fmt(f);
+                        self.write_suppressed_leading_comments(f);
+                        self.write_suppressed(f);
                     }
-                });
+                } else {
+                    quote! {
+                        self.write_suppressed(f);
+                    }
+                };
                 let suppressed_trailing_comments = do_not_print_comment.then(|| {
                     quote! {
                         self.format_trailing_comments(f);
@@ -238,8 +244,7 @@ fn generate_struct_implementation(
                 });
                 quote! {
                     if is_suppressed {
-                        #suppressed_leading_comments
-                        self.write_suppressed(f);
+                        #suppressed_write_call
                         #suppressed_trailing_comments
                     } else {
                         #write_call

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1062221
+  arena allocs: 1061813
   arena reallocs: 927
-  arena size: 89942128 # 89.94 MB
+  arena size: 89925376 # 89.93 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,7 +16,7 @@ App.tsx:
   sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
-  arena allocs: 208764
+  arena allocs: 208750
   arena reallocs: 364
   arena size: 16832304 # 16.83 MB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
-  arena allocs: 427080
+  arena allocs: 426837
   arena reallocs: 428
-  arena size: 29354040 # 29.35 MB
+  arena size: 29344176 # 29.34 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2502783
+  arena allocs: 2502477
   arena reallocs: 1889
-  arena size: 244438216 # 244.44 MB
+  arena size: 244425688 # 244.43 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
-  arena allocs: 63089
+  arena allocs: 63077
   arena reallocs: 38
-  arena size: 5665552 # 5.67 MB
+  arena size: 5664512 # 5.66 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 554778
+  arena allocs: 554419
   arena reallocs: 1041
-  arena size: 38290408 # 38.29 MB
+  arena size: 38275832 # 38.28 MB


### PR DESCRIPTION
```js
// input (semi: true)
// oxfmt-ignore
const a = x

// before
// oxfmt-ignore
const a = x

// after
// oxfmt-ignore
const a = x;
```

```js
// input (semi: false)
let a = 1;
// oxfmt-ignore
[b].sort();

// before
let a = 1
// oxfmt-ignore
[b].sort(); // <- ASI failure

// after
let a = 1
// oxfmt-ignore
;[b].sort() // <- OK
```