### PR TITLE
fix(ast_visit): account for trimmed source offsets

### DIFF
--- a/apps/oxlint/test/fixtures/bom/files/bom_unicode.js
+++ b/apps/oxlint/test/fixtures/bom/files/bom_unicode.js
@@ -1,4 +1,4 @@
-﻿debugger;
+﻿/*x*/'é';debugger;
 // 😀🤪😆😎🤮
 debugger;
 debugger;

--- a/apps/oxlint/test/fixtures/bom/output.snap.md
+++ b/apps/oxlint/test/fixtures/bom/output.snap.md
@@ -35,25 +35,26 @@
    : ^^^^^^^^^
    `----
 
-  x bom-plugin(bom): Debugger statement at 0-9
-   ,-[files/bom_unicode.js:1:4]
- 1 | ﻿debugger;
-   : ^^^^^^^^^
- 2 | // 😀🤪😆😎🤮
-   `----
-
   x bom-plugin(bom):
   | hasBOM: true
-  | sourceText: "debugger;\n// 😀🤪😆😎🤮\ndebugger;\ndebugger;"
-  | Program span: 0-43
-   ,-[files/bom_unicode.js:1:4]
- 1 | ,-> ﻿debugger;
+  | sourceText: "/*x*/'é';debugger;\n// 😀🤪😆😎🤮\ndebugger;\ndebugger;"
+  | Program span: 5-52
+  | comments: [{"start":0,"end":5,"text":"/*x*/"},{"start":19,"end":32,"text":"// 😀🤪😆😎🤮"}]
+   ,-[files/bom_unicode.js:1:9]
+ 1 | ,-> ﻿/*x*/'é';debugger;
  2 | |   // 😀🤪😆😎🤮
  3 | |   debugger;
  4 | `-> debugger;
    `----
 
-  x bom-plugin(bom): Debugger statement at 24-33
+  x bom-plugin(bom): Debugger statement at 9-18
+   ,-[files/bom_unicode.js:1:14]
+ 1 | ﻿/*x*/'é';debugger;
+   :          ^^^^^^^^^
+ 2 | // 😀🤪😆😎🤮
+   `----
+
+  x bom-plugin(bom): Debugger statement at 33-42
    ,-[files/bom_unicode.js:3:1]
  2 | // 😀🤪😆😎🤮
  3 | debugger;
@@ -61,7 +62,7 @@
  4 | debugger;
    `----
 
-  x bom-plugin(bom): Debugger statement at 34-43
+  x bom-plugin(bom): Debugger statement at 43-52
    ,-[files/bom_unicode.js:4:1]
  3 | debugger;
  4 | debugger;
@@ -111,6 +112,7 @@
   | hasBOM: false
   | sourceText: "debugger;\n// 😀🤪😆😎🤮\ndebugger;\ndebugger;"
   | Program span: 0-43
+  | comments: [{"start":10,"end":23,"text":"// 😀🤪😆😎🤮"}]
    ,-[files/no_bom_unicode.js:1:1]
  1 | ,-> debugger;
  2 | |   // 😀🤪😆😎🤮

--- a/apps/oxlint/test/fixtures/bom/plugin.ts
+++ b/apps/oxlint/test/fixtures/bom/plugin.ts
@@ -16,12 +16,18 @@ const plugin: Plugin = {
 
         return {
           Program(node) {
+            const comments = context.sourceCode.getAllComments().map((comment) => ({
+              start: comment.start,
+              end: comment.end,
+              text: sourceText.slice(comment.start, comment.end),
+            }));
             context.report({
               message:
                 "\n"
                 + `hasBOM: ${context.sourceCode.hasBOM}\n`
                 + `sourceText: ${JSON.stringify(sourceText)}\n`
-                + `Program span: ${node.start}-${node.end}`,
+                + `Program span: ${node.start}-${node.end}`
+                + (comments.length === 0 ? "" : `\ncomments: ${JSON.stringify(comments)}`),
               node,
             });
           },

--- a/crates/oxc_ast_visit/src/utf8_to_utf16/translation.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/translation.rs
@@ -90,11 +90,13 @@ pub fn build_translations(source_text: &str, translations: &mut Vec<Translation>
 
                 // Record the index of the end of this Unicode character, because it's only offsets
                 // *after* this Unicode character that need to be shifted.
-                // Addition cannot overflow because length of source text is max `u32::MAX`.
+                // Offsets are relative to the start of the untrimmed source, so `offset` is added
+                // back on. Addition cannot overflow because the untrimmed source text is max
+                // `u32::MAX` bytes long.
                 let bytes_in_char =
                     difference_for_this_byte as usize + usize::from(byte >= 0xF0) + 1;
                 #[expect(clippy::cast_possible_truncation)]
-                let utf8_offset = (start_offset + index + bytes_in_char) as u32;
+                let utf8_offset = (start_offset + index + bytes_in_char) as u32 + offset;
                 translations.push(Translation { utf8_offset, utf16_difference });
             }
         }


### PR DESCRIPTION
## Summary

- keep UTF-8 translation offsets absolute when the converter is built from source with a trimmed BOM or partial-source prefix
- extend the Oxlint BOM fixture with the reported comment-before-Unicode case
- assert the JS plugin API returns the complete comment range and source slice

Without the fix, the integration snapshot reports an end offset of 4 and slices `"/*x*"`. With the fix, it reports an end offset of 5 and slices `"/*x*/"`.

Fixes #26162

*Update*: #26173 fixed the same bug in the same way, and has been merged. This PR adds more tests, so merging it on top.