### PR TITLE
ci(release): cross-compile FreeBSD builds with Zig

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -221,43 +221,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - name: Build
-        id: build
-        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
-        env:
-          DEBUG: napi:*
-          RUSTUP_IO_THREADS: 1
+
+      - uses: oxc-project/setup-node@d59b270414aa7d0eed947eed4eb5b0b8a675f01d # v1.4.0
+
+      - run: rustup target add x86_64-unknown-freebsd
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          operating_system: freebsd
-          version: "14.2"
-          memory: 8G
-          cpu_count: 3
-          environment_variables: "DEBUG RUSTUP_IO_THREADS"
-          shell: bash
-          run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
-            curl https://sh.rustup.rs -sSf --output rustup.sh
-            sh rustup.sh -y --profile minimal --default-toolchain stable
-            source "$HOME/.cargo/env"
-            echo "~~~~ rustc --version ~~~~"
-            rustc --version
-            echo "~~~~ node -v ~~~~"
-            node -v
-            pwd
-            ls -lah
-            whoami
-            env
-            export COREPACK_INTEGRITY_KEYS=0
-            sudo corepack enable
-            pnpm install --ignore-scripts # postinstall: The current platform (freebsd) and architecture (x64) is not supported.
-            cd apps/oxlint
-            pnpm run build-napi-release --target x86_64-unknown-freebsd
-            cd ../..
-            cargo build --release -p oxlint --features allocator --target=x86_64-unknown-freebsd
-            rm -rf node_modules
-            rm -rf target/x86_64-unknown-freebsd/release/build
-            rm -rf target/x86_64-unknown-freebsd/release/deps
-            rm -rf target/x86_64-unknown-freebsd/release/incremental
+          version: "0.15.2"
+
+      - name: Install cargo-zigbuild
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+        with:
+          repo: rust-cross/cargo-zigbuild
+
+      - name: Build oxlint for node.js
+        working-directory: apps/oxlint
+        run: pnpm run build-napi-release --target x86_64-unknown-freebsd -x
+
+      - name: Build Rust binary
+        run: cargo zigbuild --release -p oxlint --features allocator --target=x86_64-unknown-freebsd
 
       - name: Upload NAPI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -527,43 +511,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - name: Build
-        id: build
-        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
-        env:
-          DEBUG: napi:*
-          RUSTUP_IO_THREADS: 1
+
+      - uses: oxc-project/setup-node@d59b270414aa7d0eed947eed4eb5b0b8a675f01d # v1.4.0
+
+      - run: rustup target add x86_64-unknown-freebsd
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          operating_system: freebsd
-          version: "14.2"
-          memory: 8G
-          cpu_count: 3
-          environment_variables: "DEBUG RUSTUP_IO_THREADS"
-          shell: bash
-          run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
-            curl https://sh.rustup.rs -sSf --output rustup.sh
-            sh rustup.sh -y --profile minimal --default-toolchain stable
-            source "$HOME/.cargo/env"
-            echo "~~~~ rustc --version ~~~~"
-            rustc --version
-            echo "~~~~ node -v ~~~~"
-            node -v
-            pwd
-            ls -lah
-            whoami
-            env
-            export COREPACK_INTEGRITY_KEYS=0
-            sudo corepack enable
-            pnpm install --ignore-scripts # postinstall: The current platform (freebsd) and architecture (x64) is not supported.
-            cd apps/oxfmt
-            pnpm run build-napi-release --target x86_64-unknown-freebsd
-            cd ../..
-            cargo build --release -p oxfmt --no-default-features --features allocator --target=x86_64-unknown-freebsd
-            rm -rf node_modules
-            rm -rf target/x86_64-unknown-freebsd/release/build
-            rm -rf target/x86_64-unknown-freebsd/release/deps
-            rm -rf target/x86_64-unknown-freebsd/release/incremental
+          version: "0.15.2"
+
+      - name: Install cargo-zigbuild
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+        with:
+          repo: rust-cross/cargo-zigbuild
+
+      - name: Build oxfmt for node.js
+        working-directory: apps/oxfmt
+        run: pnpm run build-napi-release --target x86_64-unknown-freebsd -x
+
+      - name: Build Rust binary
+        run: cargo zigbuild --release -p oxfmt --no-default-features --features allocator --target=x86_64-unknown-freebsd
 
       - name: Upload NAPI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -173,39 +173,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - name: Build
-        id: build
-        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
-        env:
-          DEBUG: napi:*
-          RUSTUP_IO_THREADS: 1
+
+      - uses: oxc-project/setup-node@d59b270414aa7d0eed947eed4eb5b0b8a675f01d # v1.4.0
+
+      - run: rustup target add x86_64-unknown-freebsd
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          operating_system: freebsd
-          version: "14.2"
-          memory: 8G
-          cpu_count: 3
-          environment_variables: "DEBUG RUSTUP_IO_THREADS"
-          shell: bash
-          run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
-            curl https://sh.rustup.rs -sSf --output rustup.sh
-            sh rustup.sh -y --profile minimal --default-toolchain stable
-            source "$HOME/.cargo/env"
-            echo "~~~~ rustc --version ~~~~"
-            rustc --version
-            echo "~~~~ node -v ~~~~"
-            node -v
-            pwd
-            ls -lah
-            whoami
-            env
-            cd napi/${{ inputs.name }}
-            export COREPACK_INTEGRITY_KEYS=0
-            sudo corepack enable
-            pnpm install --ignore-scripts # postinstall: The current platform (freebsd) and architecture (x64) is not supported.
-            pnpm build --target x86_64-unknown-freebsd
-            rm -rf node_modules
-            rm -rf target
+          version: "0.15.2"
+
+      - name: Install cargo-zigbuild
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+        with:
+          repo: rust-cross/cargo-zigbuild
+
+      - name: Build
+        working-directory: napi/${{ inputs.name }}
+        run: pnpm build --target x86_64-unknown-freebsd -x
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- cross-compile FreeBSD N-API modules and standalone binaries on Ubuntu with Zig
- apply the same build path to the reusable N-API release workflow and the Oxlint and Oxfmt release jobs
- preserve the existing x86_64-unknown-freebsd artifact names and publishing dependencies
