### PR TITLE
fix(linter/eslint/no-unused-vars): handle stored arrow references

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -224,11 +224,20 @@ fn test_vars_self_use_js() {
     let pass = vec![
         // https://github.com/oxc-project/oxc/issues/11215
         "export function promisify() { var fn; function fn() {} return fn; }",
+        // https://github.com/VSC-NeuroPilot/neuropilot/blob/5fb53e68ad41fa74c0114e1639473909173279d3/src/rce.ts#L128-L202
+        "const sink = {}; const promise = new Promise(resolve => { sink.callback = async () => { return promise; }; void resolve; }); console.log(sink);",
+        "const value = factory(() => { return value; });",
+        "const value = new Factory(() => { return value; });",
+        "let value; consume(value = () => { return value; });",
+        "let value; consume(value = () => { return value(); });",
     ];
 
     let fail = vec![
         // https://github.com/oxc-project/oxc/issues/11215
         "export function promisify() { var fn; function fn() { fn() } }",
+        "const value = (() => () => { return value; })();",
+        "let value; consume((value = () => value, 0));",
+        "let value; consume((value = () => value(), 0));",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -829,39 +829,61 @@ impl<'a> Symbol<'_, 'a> {
     }
 
     fn is_self_function_expr_assignment(&self, ref_node: &AstNode<'a>) -> bool {
+        let mut is_self_assignment = false;
+
         for (parent, grandparent) in self.iter_relevant_parent_and_grandparent_kinds(ref_node.id())
         {
+            if is_self_assignment {
+                match grandparent {
+                    AstKind::CallExpression(call)
+                        if !call.callee.span().contains_inclusive(parent.span()) =>
+                    {
+                        return false;
+                    }
+                    AstKind::NewExpression(new)
+                        if !new.callee.span().contains_inclusive(parent.span()) =>
+                    {
+                        return false;
+                    }
+                    AstKind::VariableDeclarator(decl) if self != &decl.id => return false,
+                    AstKind::AssignmentExpression(assignment) if self != &assignment.left => {
+                        return false;
+                    }
+                    _ => {}
+                }
+            }
+
             match (parent, grandparent) {
                 // const a = function() {}
                 (AstKind::Function(f), AstKind::VariableDeclarator(decl))
                     if f.is_expression() && self == &decl.id =>
                 {
-                    return true;
+                    is_self_assignment = true;
                 }
                 // const a = () => {}
                 (AstKind::ArrowFunctionExpression(_), AstKind::VariableDeclarator(decl))
                     if self == &decl.id =>
                 {
-                    return true;
+                    is_self_assignment = true;
                 }
                 // let a; a = function() {}
                 (AstKind::Function(f), AstKind::AssignmentExpression(assignment))
                     if f.is_expression() && self == &assignment.left =>
                 {
-                    return true;
+                    is_self_assignment = true;
                 }
                 // let a; a = () => {}
                 (
                     AstKind::ArrowFunctionExpression(_),
                     AstKind::AssignmentExpression(assignment),
                 ) if self == &assignment.left => {
-                    return true;
+                    is_self_assignment = true;
                 }
                 _ => {}
             }
         }
 
-        false
+        is_self_assignment
     }
 
     /// Checks if a reference is within a function or class declaration
@@ -928,6 +950,8 @@ impl<'a> Symbol<'_, 'a> {
         // set to `true` when we find an arrow function and we want to get its
         // name from the variable its assigned to.
         let mut needs_variable_identifier = false;
+        let mut child_span = self.nodes().get_node(node_id).span();
+        let mut assigned_symbol_id = None;
 
         for parent in self.iter_relevant_parents_of(node_id) {
             match parent.kind() {
@@ -940,17 +964,51 @@ impl<'a> Symbol<'_, 'a> {
                 AstKind::VariableDeclarator(decl) if needs_variable_identifier => {
                     return decl.id.get_binding_identifier().map(BindingIdentifier::symbol_id);
                 }
+                // An arrow assigned to a property belongs to that property, not to an enclosing
+                // variable declarator. Keep scanning after a direct self-assignment because the
+                // assignment expression itself may escape.
+                AstKind::AssignmentExpression(assignment) if needs_variable_identifier => {
+                    let symbol_id = match &assignment.left {
+                        AssignmentTarget::AssignmentTargetIdentifier(id) => {
+                            self.scoping().get_reference(id.reference_id()).symbol_id()
+                        }
+                        _ => None,
+                    };
+                    if symbol_id != Some(self.id()) {
+                        return symbol_id;
+                    }
+                    assigned_symbol_id = symbol_id;
+                }
+                // An arrow passed to a function or constructor can be called later. An arrow used
+                // as the callee is an IIFE, so continue looking for the variable storing its result.
+                AstKind::CallExpression(call)
+                    if needs_variable_identifier
+                        && !call.callee.span().contains_inclusive(child_span) =>
+                {
+                    return None;
+                }
+                AstKind::NewExpression(new)
+                    if needs_variable_identifier
+                        && !new.callee.span().contains_inclusive(child_span) =>
+                {
+                    return None;
+                }
                 AstKind::IdentifierReference(id) if needs_variable_identifier => {
-                    return self.scoping().get_reference(id.reference_id()).symbol_id();
+                    let symbol_id = self.scoping().get_reference(id.reference_id()).symbol_id();
+                    if symbol_id != Some(self.id()) {
+                        return symbol_id;
+                    }
+                    assigned_symbol_id = symbol_id;
                 }
                 AstKind::Program(_) => {
-                    return None;
+                    return assigned_symbol_id;
                 }
                 _ => {}
             }
+            child_span = parent.span();
         }
 
-        None
+        assigned_symbol_id
     }
 
     pub fn has_reference_used_as_type_query(&self) -> bool {


### PR DESCRIPTION
## Summary

- recognize references returned from arrow functions stored on properties
- treat arrow functions passed to calls and constructors as independently callable
- preserve self-use detection for immediately invoked arrow functions
- add regression coverage based on VSC-NeuroPilot/neuropilot