### PR TITLE
fix(linter/typescript/no-extraneous-class): avoid deleting class expressions

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -145,7 +145,7 @@ impl Rule for NoExtraneousClass {
                     ctx.diagnostic_with_suggestion(
                         empty_class_diagnostic(span, has_decorators),
                         |fixer| {
-                            if has_decorators {
+                            if has_decorators || class.is_expression() {
                                 return fixer.noop();
                             }
                             if let AstKind::ExportDeclaration(decl) =
@@ -361,6 +361,12 @@ fn test() {
             "@foo class Foo {}",
             "@foo class Foo {}",
             Some(json!([{ "allowWithDecorator": false }])),
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            "const classes = { Foo: class Foo {} };",
+            "const classes = { Foo: class Foo {} };",
+            None,
             FixKind::DangerousSuggestion,
         ),
     ];


### PR DESCRIPTION
## Summary

- avoid suggesting deletion for empty class expressions
- keep deletion suggestions for removable class declarations
- add regression coverage for class expressions used as object property values

Fixes #26228
