### PR TITLE
feat(linter): add unicorn/no-subtraction-comparison

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1587,6 +1587,7 @@ export interface DummyRuleMap {
   "unicorn/no-process-exit"?: RuleNoConfig;
   "unicorn/no-single-promise-in-promise-methods"?: RuleNoConfig;
   "unicorn/no-static-only-class"?: RuleNoConfig;
+  "unicorn/no-subtraction-comparison"?: RuleNoConfig;
   "unicorn/no-thenable"?: RuleNoConfig;
   "unicorn/no-this-assignment"?: RuleNoConfig;
   "unicorn/no-typeof-undefined"?: RuleNoConfig | [AllowWarnDeny, NoTypeofUndefined];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3434,6 +3434,12 @@ impl RuleRunner for crate::rules::unicorn::no_static_only_class::NoStaticOnlyCla
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_subtraction_comparison::NoSubtractionComparison {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_thenable::NoThenable {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::AssignmentExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -675,6 +675,7 @@ pub use crate::rules::unicorn::no_object_as_default_parameter::NoObjectAsDefault
 pub use crate::rules::unicorn::no_process_exit::NoProcessExit as UnicornNoProcessExit;
 pub use crate::rules::unicorn::no_single_promise_in_promise_methods::NoSinglePromiseInPromiseMethods as UnicornNoSinglePromiseInPromiseMethods;
 pub use crate::rules::unicorn::no_static_only_class::NoStaticOnlyClass as UnicornNoStaticOnlyClass;
+pub use crate::rules::unicorn::no_subtraction_comparison::NoSubtractionComparison as UnicornNoSubtractionComparison;
 pub use crate::rules::unicorn::no_thenable::NoThenable as UnicornNoThenable;
 pub use crate::rules::unicorn::no_this_assignment::NoThisAssignment as UnicornNoThisAssignment;
 pub use crate::rules::unicorn::no_typeof_undefined::NoTypeofUndefined as UnicornNoTypeofUndefined;
@@ -1423,6 +1424,7 @@ pub enum RuleEnum {
     UnicornNoProcessExit(UnicornNoProcessExit),
     UnicornNoSinglePromiseInPromiseMethods(UnicornNoSinglePromiseInPromiseMethods),
     UnicornNoStaticOnlyClass(UnicornNoStaticOnlyClass),
+    UnicornNoSubtractionComparison(UnicornNoSubtractionComparison),
     UnicornNoThenable(UnicornNoThenable),
     UnicornNoThisAssignment(UnicornNoThisAssignment),
     UnicornNoTypeofUndefined(UnicornNoTypeofUndefined),
@@ -2362,7 +2364,8 @@ const UNICORN_NO_PROCESS_EXIT_ID: usize = UNICORN_NO_OBJECT_AS_DEFAULT_PARAMETER
 const UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID: usize = UNICORN_NO_PROCESS_EXIT_ID + 1usize;
 const UNICORN_NO_STATIC_ONLY_CLASS_ID: usize =
     UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID + 1usize;
-const UNICORN_NO_THENABLE_ID: usize = UNICORN_NO_STATIC_ONLY_CLASS_ID + 1usize;
+const UNICORN_NO_SUBTRACTION_COMPARISON_ID: usize = UNICORN_NO_STATIC_ONLY_CLASS_ID + 1usize;
+const UNICORN_NO_THENABLE_ID: usize = UNICORN_NO_SUBTRACTION_COMPARISON_ID + 1usize;
 const UNICORN_NO_THIS_ASSIGNMENT_ID: usize = UNICORN_NO_THENABLE_ID + 1usize;
 const UNICORN_NO_TYPEOF_UNDEFINED_ID: usize = UNICORN_NO_THIS_ASSIGNMENT_ID + 1usize;
 const UNICORN_NO_UNNECESSARY_ARRAY_FLAT_DEPTH_ID: usize = UNICORN_NO_TYPEOF_UNDEFINED_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3280,6 +3283,7 @@ static RULE_NAMES: [&str; 870usize] = [
     UnicornNoProcessExit::NAME,
     UnicornNoSinglePromiseInPromiseMethods::NAME,
     UnicornNoStaticOnlyClass::NAME,
+    UnicornNoSubtractionComparison::NAME,
     UnicornNoThenable::NAME,
     UnicornNoThisAssignment::NAME,
     UnicornNoTypeofUndefined::NAME,
@@ -4240,6 +4244,7 @@ impl RuleEnum {
                 UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID
             }
             Self::UnicornNoStaticOnlyClass(_) => UNICORN_NO_STATIC_ONLY_CLASS_ID,
+            Self::UnicornNoSubtractionComparison(_) => UNICORN_NO_SUBTRACTION_COMPARISON_ID,
             Self::UnicornNoThenable(_) => UNICORN_NO_THENABLE_ID,
             Self::UnicornNoThisAssignment(_) => UNICORN_NO_THIS_ASSIGNMENT_ID,
             Self::UnicornNoTypeofUndefined(_) => UNICORN_NO_TYPEOF_UNDEFINED_ID,
@@ -5273,6 +5278,7 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::CATEGORY
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::CATEGORY,
+            Self::UnicornNoSubtractionComparison(_) => UnicornNoSubtractionComparison::CATEGORY,
             Self::UnicornNoThenable(_) => UnicornNoThenable::CATEGORY,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::CATEGORY,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::CATEGORY,
@@ -6290,6 +6296,7 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::FIX
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::FIX,
+            Self::UnicornNoSubtractionComparison(_) => UnicornNoSubtractionComparison::FIX,
             Self::UnicornNoThenable(_) => UnicornNoThenable::FIX,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::FIX,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::FIX,
@@ -7425,6 +7432,9 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::documentation()
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::documentation(),
+            Self::UnicornNoSubtractionComparison(_) => {
+                UnicornNoSubtractionComparison::documentation()
+            }
             Self::UnicornNoThenable(_) => UnicornNoThenable::documentation(),
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::documentation(),
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::documentation(),
@@ -9441,6 +9451,10 @@ impl RuleEnum {
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::config_schema(generator)
                 .or_else(|| UnicornNoStaticOnlyClass::schema(generator)),
+            Self::UnicornNoSubtractionComparison(_) => {
+                UnicornNoSubtractionComparison::config_schema(generator)
+                    .or_else(|| UnicornNoSubtractionComparison::schema(generator))
+            }
             Self::UnicornNoThenable(_) => UnicornNoThenable::config_schema(generator)
                 .or_else(|| UnicornNoThenable::schema(generator)),
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::config_schema(generator)
@@ -10960,6 +10974,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(_) => "unicorn",
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => "unicorn",
             Self::UnicornNoStaticOnlyClass(_) => "unicorn",
+            Self::UnicornNoSubtractionComparison(_) => "unicorn",
             Self::UnicornNoThenable(_) => "unicorn",
             Self::UnicornNoThisAssignment(_) => "unicorn",
             Self::UnicornNoTypeofUndefined(_) => "unicorn",
@@ -12965,6 +12980,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(rule) => rule.run(node, ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run(node, ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run(node, ctx),
+            Self::UnicornNoSubtractionComparison(rule) => rule.run(node, ctx),
             Self::UnicornNoThenable(rule) => rule.run(node, ctx),
             Self::UnicornNoThisAssignment(rule) => rule.run(node, ctx),
             Self::UnicornNoTypeofUndefined(rule) => rule.run(node, ctx),
@@ -13852,6 +13868,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(rule) => rule.run_once(ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run_once(ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run_once(ctx),
+            Self::UnicornNoSubtractionComparison(rule) => rule.run_once(ctx),
             Self::UnicornNoThenable(rule) => rule.run_once(ctx),
             Self::UnicornNoThisAssignment(rule) => rule.run_once(ctx),
             Self::UnicornNoTypeofUndefined(rule) => rule.run_once(ctx),
@@ -14822,6 +14839,7 @@ impl RuleEnum {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::UnicornNoStaticOnlyClass(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoSubtractionComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoThenable(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoThisAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoTypeofUndefined(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15744,6 +15762,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(rule) => rule.should_run(ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.should_run(ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.should_run(ctx),
+            Self::UnicornNoSubtractionComparison(rule) => rule.should_run(ctx),
             Self::UnicornNoThenable(rule) => rule.should_run(ctx),
             Self::UnicornNoThisAssignment(rule) => rule.should_run(ctx),
             Self::UnicornNoTypeofUndefined(rule) => rule.should_run(ctx),
@@ -16844,6 +16863,9 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::IS_TSGOLINT_RULE
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::IS_TSGOLINT_RULE,
+            Self::UnicornNoSubtractionComparison(_) => {
+                UnicornNoSubtractionComparison::IS_TSGOLINT_RULE
+            }
             Self::UnicornNoThenable(_) => UnicornNoThenable::IS_TSGOLINT_RULE,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::IS_TSGOLINT_RULE,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::IS_TSGOLINT_RULE,
@@ -17994,6 +18016,7 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::VERSION
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::VERSION,
+            Self::UnicornNoSubtractionComparison(_) => UnicornNoSubtractionComparison::VERSION,
             Self::UnicornNoThenable(_) => UnicornNoThenable::VERSION,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::VERSION,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::VERSION,
@@ -19067,6 +19090,7 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::HAS_CONFIG
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::HAS_CONFIG,
+            Self::UnicornNoSubtractionComparison(_) => UnicornNoSubtractionComparison::HAS_CONFIG,
             Self::UnicornNoThenable(_) => UnicornNoThenable::HAS_CONFIG,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::HAS_CONFIG,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::HAS_CONFIG,
@@ -20101,6 +20125,7 @@ impl RuleEnum {
                 UnicornNoSinglePromiseInPromiseMethods::INFO
             }
             Self::UnicornNoStaticOnlyClass(_) => UnicornNoStaticOnlyClass::INFO,
+            Self::UnicornNoSubtractionComparison(_) => UnicornNoSubtractionComparison::INFO,
             Self::UnicornNoThenable(_) => UnicornNoThenable::INFO,
             Self::UnicornNoThisAssignment(_) => UnicornNoThisAssignment::INFO,
             Self::UnicornNoTypeofUndefined(_) => UnicornNoTypeofUndefined::INFO,
@@ -21014,6 +21039,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(rule) => rule.types_info(),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.types_info(),
             Self::UnicornNoStaticOnlyClass(rule) => rule.types_info(),
+            Self::UnicornNoSubtractionComparison(rule) => rule.types_info(),
             Self::UnicornNoThenable(rule) => rule.types_info(),
             Self::UnicornNoThisAssignment(rule) => rule.types_info(),
             Self::UnicornNoTypeofUndefined(rule) => rule.types_info(),
@@ -21888,6 +21914,7 @@ impl RuleEnum {
             Self::UnicornNoProcessExit(rule) => rule.run_info(),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run_info(),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run_info(),
+            Self::UnicornNoSubtractionComparison(rule) => rule.run_info(),
             Self::UnicornNoThenable(rule) => rule.run_info(),
             Self::UnicornNoThisAssignment(rule) => rule.run_info(),
             Self::UnicornNoTypeofUndefined(rule) => rule.run_info(),
@@ -22864,6 +22891,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
             UnicornNoSinglePromiseInPromiseMethods::default(),
         ),
         RuleEnum::UnicornNoStaticOnlyClass(UnicornNoStaticOnlyClass::default()),
+        RuleEnum::UnicornNoSubtractionComparison(UnicornNoSubtractionComparison::default()),
         RuleEnum::UnicornNoThenable(UnicornNoThenable::default()),
         RuleEnum::UnicornNoThisAssignment(UnicornNoThisAssignment::default()),
         RuleEnum::UnicornNoTypeofUndefined(UnicornNoTypeofUndefined::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -611,6 +611,7 @@ pub(crate) mod unicorn {
     pub mod no_process_exit;
     pub mod no_single_promise_in_promise_methods;
     pub mod no_static_only_class;
+    pub mod no_subtraction_comparison;
     pub mod no_thenable;
     pub mod no_this_assignment;
     pub mod no_typeof_undefined;

--- a/crates/oxc_linter/src/rules/unicorn/no_subtraction_comparison.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_subtraction_comparison.rs
@@ -1,0 +1,444 @@
+use oxc_ast::{
+    AstKind,
+    ast::{BinaryExpression, Expression, TSLiteral, TSType},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_subtraction_comparison_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Prefer comparing the values directly over comparing the difference with `0`.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoSubtractionComparison;
+
+// Ported from:
+// <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/no-subtraction-comparison.js>
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prefers comparing two values directly instead of subtracting them and
+    /// comparing the result with zero.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Subtracting first obscures the comparison's intent and is often left over
+    /// from code that previously served as a comparator function.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// if (a - b > 0) {}
+    /// if (0 <= a - b) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// if (a > b) {}
+    /// if (a >= b) {}
+    /// ```
+    ///
+    /// The rule only applies an automatic fix when it can establish that the
+    /// rewrite preserves numeric comparison semantics. Otherwise, it offers an
+    /// editor suggestion. Comparisons that contain comments are only reported.
+    NoSubtractionComparison,
+    unicorn,
+    nursery,
+    conditional_fix_suggestion,
+    version = "next",
+    short_description = "Prefer comparing values directly over subtracting and comparing to `0`.",
+);
+
+impl Rule for NoSubtractionComparison {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(comparison) = node.kind() else {
+            return;
+        };
+
+        if !(comparison.operator.is_compare() || comparison.operator.is_equality()) {
+            return;
+        }
+
+        let Some((subtraction, operator)) = get_subtraction_and_operator(comparison) else {
+            return;
+        };
+
+        let diagnostic = no_subtraction_comparison_diagnostic(comparison.span);
+        if ctx.has_comments_between(comparison.span) {
+            ctx.diagnostic(diagnostic);
+            return;
+        }
+
+        let replacement = format!(
+            "{} {} {}",
+            ctx.source_range(subtraction.left.span()),
+            operator.as_str(),
+            ctx.source_range(subtraction.right.span())
+        );
+
+        let can_fix = if matches!(operator, BinaryOperator::LessThan | BinaryOperator::GreaterThan)
+        {
+            is_number(&subtraction.left, ctx) && is_number(&subtraction.right, ctx)
+        } else {
+            is_static_finite_number(&subtraction.left, ctx)
+                && is_static_finite_number(&subtraction.right, ctx)
+        };
+
+        if can_fix {
+            ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                fixer.replace(comparison.span, replacement)
+            });
+        } else {
+            ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
+                fixer.replace(comparison.span, replacement)
+            });
+        }
+    }
+}
+
+fn get_subtraction_and_operator<'a>(
+    comparison: &'a BinaryExpression<'a>,
+) -> Option<(&'a BinaryExpression<'a>, BinaryOperator)> {
+    if is_zero(&comparison.right) {
+        let subtraction = get_subtraction(&comparison.left)?;
+        return Some((subtraction, comparison.operator));
+    }
+
+    if is_zero(&comparison.left) {
+        let subtraction = get_subtraction(&comparison.right)?;
+        return Some((subtraction, invert_operator(comparison.operator)?));
+    }
+
+    None
+}
+
+fn get_subtraction<'a>(expression: &'a Expression<'a>) -> Option<&'a BinaryExpression<'a>> {
+    let Expression::BinaryExpression(binary) = expression.without_parentheses() else {
+        return None;
+    };
+    (binary.operator == BinaryOperator::Subtraction).then_some(binary)
+}
+
+fn is_zero(expression: &Expression) -> bool {
+    matches!(
+        expression.without_parentheses(),
+        Expression::NumericLiteral(number) if number.value == 0.0
+    )
+}
+
+fn invert_operator(operator: BinaryOperator) -> Option<BinaryOperator> {
+    Some(match operator {
+        BinaryOperator::LessThan => BinaryOperator::GreaterThan,
+        BinaryOperator::LessEqualThan => BinaryOperator::GreaterEqualThan,
+        BinaryOperator::GreaterThan => BinaryOperator::LessThan,
+        BinaryOperator::GreaterEqualThan => BinaryOperator::LessEqualThan,
+        BinaryOperator::Equality
+        | BinaryOperator::Inequality
+        | BinaryOperator::StrictEquality
+        | BinaryOperator::StrictInequality => operator,
+        _ => return None,
+    })
+}
+
+// Mirrors the syntax-based checks used by eslint-plugin-unicorn's `is-number`
+// helper. This deliberately avoids assuming that arbitrary identifiers or
+// optional-chain results are numbers.
+fn is_number<'a>(expression: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    let expression = expression.without_parentheses();
+    match expression {
+        Expression::NumericLiteral(_) => true,
+        Expression::TSAsExpression(as_expression) => {
+            is_number_type(&as_expression.type_annotation)
+                || is_number(&as_expression.expression, ctx)
+        }
+        Expression::TSSatisfiesExpression(satisfies) => {
+            is_number_type(&satisfies.type_annotation) || is_number(&satisfies.expression, ctx)
+        }
+        Expression::TSTypeAssertion(assertion) => {
+            is_number_type(&assertion.type_annotation) || is_number(&assertion.expression, ctx)
+        }
+        Expression::TSNonNullExpression(non_null) => is_number(&non_null.expression, ctx),
+        Expression::UnaryExpression(unary) => match unary.operator {
+            UnaryOperator::UnaryPlus => true,
+            UnaryOperator::UnaryNegation | UnaryOperator::BitwiseNot => {
+                is_number(&unary.argument, ctx)
+            }
+            _ => false,
+        },
+        Expression::BinaryExpression(binary) => match binary.operator {
+            BinaryOperator::Addition => {
+                is_number(&binary.left, ctx) && is_number(&binary.right, ctx)
+            }
+            BinaryOperator::ShiftRightZeroFill => true,
+            BinaryOperator::Subtraction
+            | BinaryOperator::Multiplication
+            | BinaryOperator::Division
+            | BinaryOperator::Remainder
+            | BinaryOperator::Exponential
+            | BinaryOperator::ShiftLeft
+            | BinaryOperator::ShiftRight
+            | BinaryOperator::BitwiseOR
+            | BinaryOperator::BitwiseXOR
+            | BinaryOperator::BitwiseAnd => {
+                is_number(&binary.left, ctx) || is_number(&binary.right, ctx)
+            }
+            _ => false,
+        },
+        Expression::ConditionalExpression(conditional) => {
+            is_number(&conditional.consequent, ctx) && is_number(&conditional.alternate, ctx)
+        }
+        Expression::SequenceExpression(sequence) => {
+            sequence.expressions.last().is_some_and(|last| is_number(last, ctx))
+        }
+        Expression::CallExpression(call) => is_number_call(call, ctx),
+        expression if expression.is_member_expression() => is_number_member(expression, ctx),
+        _ => false,
+    }
+}
+
+fn is_number_call<'a>(call: &oxc_ast::ast::CallExpression<'a>, ctx: &LintContext<'a>) -> bool {
+    if call.optional {
+        return false;
+    }
+
+    if let Expression::Identifier(identifier) = call.callee.without_parentheses()
+        && matches!(identifier.name.as_str(), "Number" | "parseInt" | "parseFloat")
+        && ctx.is_reference_to_global_variable(identifier)
+    {
+        return true;
+    }
+
+    let Some(member) = call.callee.get_member_expr() else {
+        return false;
+    };
+    if member.optional() {
+        return false;
+    }
+
+    let Some(property) = member.static_property_name() else {
+        return false;
+    };
+    if is_global_member_object(member.object(), "Math", ctx) {
+        return matches!(
+            property,
+            "abs"
+                | "acos"
+                | "acosh"
+                | "asin"
+                | "asinh"
+                | "atan"
+                | "atanh"
+                | "atan2"
+                | "cbrt"
+                | "ceil"
+                | "clz32"
+                | "cos"
+                | "cosh"
+                | "exp"
+                | "expm1"
+                | "floor"
+                | "fround"
+                | "hypot"
+                | "imul"
+                | "log"
+                | "log1p"
+                | "log10"
+                | "log2"
+                | "max"
+                | "min"
+                | "pow"
+                | "random"
+                | "round"
+                | "sign"
+                | "sin"
+                | "sinh"
+                | "sqrt"
+                | "tan"
+                | "tanh"
+                | "trunc"
+        );
+    }
+
+    is_global_member_object(member.object(), "Number", ctx)
+        && matches!(property, "parseFloat" | "parseInt")
+}
+
+fn is_number_member<'a>(expression: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    let member = expression.to_member_expression();
+    if member.optional() {
+        return false;
+    }
+
+    let Some(property) = member.static_property_name() else {
+        return false;
+    };
+    if property == "length" && !member.is_computed() {
+        return true;
+    }
+
+    if is_global_member_object(member.object(), "Math", ctx) {
+        return matches!(
+            property,
+            "E" | "LN2" | "LN10" | "LOG2E" | "LOG10E" | "PI" | "SQRT1_2" | "SQRT2"
+        );
+    }
+
+    is_global_member_object(member.object(), "Number", ctx)
+        && matches!(
+            property,
+            "EPSILON"
+                | "MAX_SAFE_INTEGER"
+                | "MAX_VALUE"
+                | "MIN_SAFE_INTEGER"
+                | "MIN_VALUE"
+                | "NaN"
+                | "NEGATIVE_INFINITY"
+                | "POSITIVE_INFINITY"
+        )
+}
+
+fn is_global_member_object<'a>(object: &Expression<'a>, name: &str, ctx: &LintContext<'a>) -> bool {
+    let Expression::Identifier(identifier) = object.without_parentheses() else {
+        return false;
+    };
+    identifier.name == name && ctx.is_reference_to_global_variable(identifier)
+}
+
+fn is_number_type(type_annotation: &TSType) -> bool {
+    match type_annotation {
+        TSType::TSNumberKeyword(_) => true,
+        TSType::TSLiteralType(literal) => {
+            matches!(literal.literal, TSLiteral::NumericLiteral(_))
+        }
+        _ => false,
+    }
+}
+
+fn is_static_finite_number<'a>(expression: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    let expression = expression.without_parentheses();
+    match expression {
+        Expression::NumericLiteral(number) => number.value.is_finite(),
+        Expression::UnaryExpression(unary)
+            if matches!(
+                unary.operator,
+                UnaryOperator::UnaryPlus | UnaryOperator::UnaryNegation
+            ) =>
+        {
+            is_static_finite_number(&unary.argument, ctx)
+        }
+        expression if expression.is_member_expression() => {
+            let member = expression.to_member_expression();
+            let Some(property) = member.static_property_name() else {
+                return false;
+            };
+            (is_global_member_object(member.object(), "Math", ctx)
+                && matches!(
+                    property,
+                    "E" | "LN2" | "LN10" | "LOG2E" | "LOG10E" | "PI" | "SQRT1_2" | "SQRT2"
+                ))
+                || (is_global_member_object(member.object(), "Number", ctx)
+                    && matches!(
+                        property,
+                        "EPSILON"
+                            | "MAX_SAFE_INTEGER"
+                            | "MAX_VALUE"
+                            | "MIN_SAFE_INTEGER"
+                            | "MIN_VALUE"
+                    ))
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "a > b",
+        "a < b",
+        "a === b",
+        "a - b",
+        "a - b > 1",
+        "a - b > c",
+        "a - b === c",
+        "a + b > 0",
+        "a * b > 0",
+        "a % b > 0",
+        "a > 0",
+        "0 > a",
+        "0 > 0",
+        "a - b > 0n",
+        "a - b > -0",
+        "a - b instanceof c",
+    ];
+
+    let fail = vec![
+        "if (a - b > 0) {}",
+        "if (a - b >= 0) {}",
+        "if (a - b < 0) {}",
+        "if (a - b <= 0) {}",
+        "a - b === 0",
+        "a - b !== 0",
+        "a - b == 0",
+        "a - b != 0",
+        "0 < a - b",
+        "0 <= a - b",
+        "0 > a - b",
+        "0 >= a - b",
+        "0 === a - b",
+        "0 !== a - b",
+        "1 - 2 > 0",
+        "foo.length - bar.length > 0",
+        "Number(a) - Number(b) < 0",
+        "Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY > 0",
+        "1 - 2 >= 0",
+        "1 - 1 === 0",
+        "0 < foo.length - bar.length",
+        "Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY >= 0",
+        "Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY === 0",
+        "foo.length - bar.length >= 0",
+        "foo.length - bar > 0",
+        "Math.round(a) - Math.round(b) > 0",
+        "a.length - b.length - c > 0",
+        "(foo.length) - (bar.length) > 0",
+        "const modes = new Set(['foo']); modes.clear(); (modes.size ? 1 : 'x') - (modes.size ? 1 : 'x') === 0",
+        "const modes = new Set(['foo']); modes.clear(); ((modes.size && 1) || value) - 1 === 0",
+        "const object = {value: true}; Object.defineProperty(object, 'value', {get() { return false; }}); (object.value ? 1 : value) - 1 === 0",
+        "const modes = new Set(['foo']); modes.clear(); ((modes.size ? 1 : value) as number) - 1 === 0", // {"parser": parsers.typescript},
+        "(a - b) > 0",
+        "a?.b - c?.d > 0",
+        "a - /* comment */ b > 0",
+        "(a as number) - (b as number) > 0", // {"parser": parsers.typescript},
+        "const alias = condition; var condition = true; (alias ? 1 : value) - 1 === 0",
+    ];
+
+    let fix = vec![
+        ("1 - 2 > 0", "1 > 2", None),
+        ("foo.length - bar.length > 0", "foo.length > bar.length", None),
+        ("Number(a) - Number(b) < 0", "Number(a) < Number(b)", None),
+        (
+            "Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY > 0",
+            "Number.POSITIVE_INFINITY > Number.POSITIVE_INFINITY",
+            None,
+        ),
+        ("1 - 2 >= 0", "1 >= 2", None),
+        ("1 - 1 === 0", "1 === 1", None),
+        ("0 < foo.length - bar.length", "foo.length > bar.length", None),
+        ("Math.round(a) - Math.round(b) > 0", "Math.round(a) > Math.round(b)", None),
+        ("(foo.length) - (bar.length) > 0", "(foo.length) > (bar.length)", None),
+        ("(a as number) - (b as number) > 0", "(a as number) > (b as number)", None),
+    ];
+
+    Tester::new(NoSubtractionComparison::NAME, NoSubtractionComparison::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_subtraction_comparison.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_subtraction_comparison.snap
@@ -1,0 +1,261 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:5]
+ 1 │ if (a - b > 0) {}
+   ·     ─────────
+   ╰────
+  help: Replace `a - b > 0` with `a > b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:5]
+ 1 │ if (a - b >= 0) {}
+   ·     ──────────
+   ╰────
+  help: Replace `a - b >= 0` with `a >= b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:5]
+ 1 │ if (a - b < 0) {}
+   ·     ─────────
+   ╰────
+  help: Replace `a - b < 0` with `a < b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:5]
+ 1 │ if (a - b <= 0) {}
+   ·     ──────────
+   ╰────
+  help: Replace `a - b <= 0` with `a <= b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a - b === 0
+   · ───────────
+   ╰────
+  help: Replace `a - b === 0` with `a === b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a - b !== 0
+   · ───────────
+   ╰────
+  help: Replace `a - b !== 0` with `a !== b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a - b == 0
+   · ──────────
+   ╰────
+  help: Replace `a - b == 0` with `a == b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a - b != 0
+   · ──────────
+   ╰────
+  help: Replace `a - b != 0` with `a != b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 < a - b
+   · ─────────
+   ╰────
+  help: Replace `0 < a - b` with `a > b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 <= a - b
+   · ──────────
+   ╰────
+  help: Replace `0 <= a - b` with `a >= b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 > a - b
+   · ─────────
+   ╰────
+  help: Replace `0 > a - b` with `a < b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 >= a - b
+   · ──────────
+   ╰────
+  help: Replace `0 >= a - b` with `a <= b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 === a - b
+   · ───────────
+   ╰────
+  help: Replace `0 === a - b` with `a === b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 !== a - b
+   · ───────────
+   ╰────
+  help: Replace `0 !== a - b` with `a !== b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 1 - 2 > 0
+   · ─────────
+   ╰────
+  help: Replace `1 - 2 > 0` with `1 > 2`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ foo.length - bar.length > 0
+   · ───────────────────────────
+   ╰────
+  help: Replace `foo.length - bar.length > 0` with `foo.length > bar.length`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ Number(a) - Number(b) < 0
+   · ─────────────────────────
+   ╰────
+  help: Replace `Number(a) - Number(b) < 0` with `Number(a) < Number(b)`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY > 0
+   · ───────────────────────────────────────────────────────
+   ╰────
+  help: Replace `Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY > 0` with `Number.POSITIVE_INFINITY > Number.POSITIVE_INFINITY`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 1 - 2 >= 0
+   · ──────────
+   ╰────
+  help: Replace `1 - 2 >= 0` with `1 >= 2`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 1 - 1 === 0
+   · ───────────
+   ╰────
+  help: Replace `1 - 1 === 0` with `1 === 1`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ 0 < foo.length - bar.length
+   · ───────────────────────────
+   ╰────
+  help: Replace `0 < foo.length - bar.length` with `foo.length > bar.length`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY >= 0
+   · ────────────────────────────────────────────────────────
+   ╰────
+  help: Replace `Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY >= 0` with `Number.POSITIVE_INFINITY >= Number.POSITIVE_INFINITY`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY === 0
+   · ─────────────────────────────────────────────────────────
+   ╰────
+  help: Replace `Number.POSITIVE_INFINITY - Number.POSITIVE_INFINITY === 0` with `Number.POSITIVE_INFINITY === Number.POSITIVE_INFINITY`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ foo.length - bar.length >= 0
+   · ────────────────────────────
+   ╰────
+  help: Replace `foo.length - bar.length >= 0` with `foo.length >= bar.length`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ foo.length - bar > 0
+   · ────────────────────
+   ╰────
+  help: Replace `foo.length - bar > 0` with `foo.length > bar`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ Math.round(a) - Math.round(b) > 0
+   · ─────────────────────────────────
+   ╰────
+  help: Replace `Math.round(a) - Math.round(b) > 0` with `Math.round(a) > Math.round(b)`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a.length - b.length - c > 0
+   · ───────────────────────────
+   ╰────
+  help: Replace `a.length - b.length - c > 0` with `a.length - b.length > c`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ (foo.length) - (bar.length) > 0
+   · ───────────────────────────────
+   ╰────
+  help: Replace `(foo.length) - (bar.length) > 0` with `(foo.length) > (bar.length)`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:48]
+ 1 │ const modes = new Set(['foo']); modes.clear(); (modes.size ? 1 : 'x') - (modes.size ? 1 : 'x') === 0
+   ·                                                ─────────────────────────────────────────────────────
+   ╰────
+  help: Replace `(modes.size ? 1 : 'x') - (modes.size ? 1 : 'x') === 0` with `(modes.size ? 1 : 'x') === (modes.size ? 1 : 'x')`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:48]
+ 1 │ const modes = new Set(['foo']); modes.clear(); ((modes.size && 1) || value) - 1 === 0
+   ·                                                ──────────────────────────────────────
+   ╰────
+  help: Replace `((modes.size && 1) || value) - 1 === 0` with `((modes.size && 1) || value) === 1`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:98]
+ 1 │ const object = {value: true}; Object.defineProperty(object, 'value', {get() { return false; }}); (object.value ? 1 : value) - 1 === 0
+   ·                                                                                                  ────────────────────────────────────
+   ╰────
+  help: Replace `(object.value ? 1 : value) - 1 === 0` with `(object.value ? 1 : value) === 1`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:48]
+ 1 │ const modes = new Set(['foo']); modes.clear(); ((modes.size ? 1 : value) as number) - 1 === 0
+   ·                                                ──────────────────────────────────────────────
+   ╰────
+  help: Replace `((modes.size ? 1 : value) as number) - 1 === 0` with `((modes.size ? 1 : value) as number) === 1`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ (a - b) > 0
+   · ───────────
+   ╰────
+  help: Replace `(a - b) > 0` with `a > b`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a?.b - c?.d > 0
+   · ───────────────
+   ╰────
+  help: Replace `a?.b - c?.d > 0` with `a?.b > c?.d`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ a - /* comment */ b > 0
+   · ───────────────────────
+   ╰────
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:1]
+ 1 │ (a as number) - (b as number) > 0
+   · ─────────────────────────────────
+   ╰────
+  help: Replace `(a as number) - (b as number) > 0` with `(a as number) > (b as number)`.
+
+  ⚠ unicorn(no-subtraction-comparison): Prefer comparing the values directly over comparing the difference with `0`.
+   ╭─[no_subtraction_comparison.tsx:1:48]
+ 1 │ const alias = condition; var condition = true; (alias ? 1 : value) - 1 === 0
+   ·                                                ─────────────────────────────
+   ╰────
+  help: Replace `(alias ? 1 : value) - 1 === 0` with `(alias ? 1 : value) === 1`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9177,6 +9177,9 @@
         "unicorn/no-static-only-class": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-subtraction-comparison": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-thenable": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
Adds the `unicorn/no-subtraction-comparison` rule, based on eslint-plugin-unicorn v73.

The rule handles zero on either side of the comparison, preserves operand parentheses, and avoids rewriting expressions that contain comments. It applies a fix only when numeric semantics are known; otherwise it reports an editor suggestion.

Verification:
- `typos`
- `cargo lintgen` and `pnpm run fmt` (idempotent)
- `cargo fmt --all -- --check`
- `just check`
- `cargo test -p oxc_linter --all-features` (1257 passed, 1 ignored; integration and doc tests passed)
- `cargo clippy -p oxc_linter --all-targets --all-features -- -D warnings -A linker-messages`
- generated schema parses as JSON and `pnpm --filter oxlint-app generate-config-types` is clean

Full-workspace `cargo test --all-features` reaches the `oxlint` CLI suite but cannot finish on this Windows checkout because its symlink fixture is materialized as a regular file. The Node-version snapshot passes under the repository's Node 26.5.0, and the terminal-color snapshots pass when color output is forced.

AI-assisted: I used an AI coding assistant while porting and reviewing the rule. I checked the upstream implementation and tests, reviewed the final diff, and ran the checks above.

Part of #684.