### PR TITLE
fix(runtime): remove stale regenerator exports

### DIFF
--- a/npm/runtime/package.json
+++ b/npm/runtime/package.json
@@ -1055,10 +1055,7 @@
       "./src/helpers/writeOnlyError.js"
     ],
     "./package": "./package.json",
-    "./package.json": "./package.json",
-    "./regenerator": "./regenerator/index.js",
-    "./regenerator/": "./regenerator/",
-    "./regenerator/*.js": "./regenerator/*.js"
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"


### PR DESCRIPTION
## Summary

- remove the `@oxc-project/runtime/regenerator` export entries, which point to files that are not present in the package

## Details

The runtime package was copied manually from `@babel/runtime`, while its legacy `regenerator/index.js` shim and dependency were intentionally omitted. Keeping the copied export entries advertised an API that has never resolved in a published Oxc runtime package.
