### PR TITLE
fix(formatter_css): preserve trailing comma in single-item scss lists

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -193,10 +193,10 @@ The harness snapshots both `--print-width 80` and `100`; verify fixtures at both
 
 ### Prettier conformance
 
-At the current version (v3.9.6), the divergences of eight files have been confirmed and are intentional (see DIVERGENCES.md):
+At the current version (v3.9.6), these divergences have been confirmed and are intentional (see DIVERGENCES.md):
 
 - CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`, `css/stylefmt-repo/media-queries-ranges/media-queries-ranges.css`, `css/postcss-plugins/postcss-nesting.css`
-- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`
+- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`, `scss/trailing-comma/comments.scss`, `scss/trailing-comma/list.scss`, `scss/trailing-comma/variable.scss`, `scss/function/arbitrary-arguments-comment.scss`, `scss/map/15193.scss`
 
 Two more files fail with MIXED hunks; they can't pass as files (the intentional hunks alone keep them failing), so the remaining diffs are itemized here:
 

--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -429,10 +429,74 @@ comma list and NOWHERE else. Prettier 3.9.6 changes `key: ($a + $b)` from a numb
 `key: 2 * ($a + $b)` inside `$var:` declarations (dart-sass: `Undefined operation "2 * (3px,)"`).
 Prettier's own #18530 / #19091 fixed subsets of this; we extend the same rule to every non-comma-list.
 
+## single-item-list-trailing-comma
+
+- Why: semantics (prettier/prettier#19928 fixed the paren form upstream)
+- Pin: `tests/fixtures/format/scss/single-item-list-trailing-comma.scss`
+- Drop when: upstream also keeps the paren-less form and `(fn(1),)` (dropped as a source-span artifact of its value parser)
+
+```scss
+/* input */
+$list: ("a",);
+$bare: "a",;
+$map: (k: ("a",));
+
+/* ours */
+$list: ("a",);
+$bare: "a",;
+$map: (
+  k: ("a",),
+);
+
+/* prettier */
+$list: ("a");
+$bare: "a";
+$map: (
+  k: ("a"),
+);
+```
+
+`("a",)` and `$x: "a",` are one-element lists in Sass while `"a"` is a string (dart-sass `type-of`):
+dropping the comma changes the value for `nth()` / `@each` / `list.append()`.
+Prettier 3.9.6 drops it everywhere but `var()`; we keep it whenever the list has exactly one element
+(multi-element lists and function arguments still drop theirs, the list is a list without it).
+
+## trailing-comma-none-before-tail-comment
+
+- Why: uniform-rule (a semantic no-op comma follows the option; Prettier's CSS printer keeps the source comma while its JS printer drops it)
+- Pin: `tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss`
+
+```scss
+/* input, trailingComma: none */
+$map: (a: 1, b: 2,
+  // own
+);
+
+/* ours */
+$map: (
+  a: 1,
+  b: 2
+  // own
+);
+
+/* prettier */
+$map: (
+  a: 1,
+  b: 2,
+  // own
+);
+```
+
+A trailing comma before an own-line comment is the same no-op as any other trailing comma, so `trailingComma: none` drops it.
+
+Prettier's postcss printer prints the comment as a list member, so a source comma before it becomes the separator and survives the option
+(`scss/map/15193.scss` pins that shape; the issue itself was about the comma landing INSIDE the comment).
+Its JS printer follows the option (`[1, 2\n // own]`), and so do all our formatter crates.
+
 ## own-line-trailing-comment-keeps-line
 
 - Why: prettier-bug
-- Pin: `tests/fixtures/format/scss/module-config-comments.scss`
+- Pin: `tests/fixtures/format/scss/module-config-comments.scss`, `tests/fixtures/format/scss/paren-tail-own-line-comment.scss`
 
 ```scss
 /* input */
@@ -453,11 +517,14 @@ Prettier's own #18530 / #19091 fixed subsets of this; we extend the same rule to
 );
 ```
 
-An own-line trailing comment before a list's closing `)` keeps its own line, in maps AND `@use`/`@forward
-with (...)` configs (for maps the trailing comma is also kept). Prettier pulls the comment up onto the last
-item's line, a `lineSuffix` artifact of its comma-group printing, and drops the map's trailing comma.
-Same-line trailing comments still glue (matching Prettier); moving an own-line comment up would destroy the
-author's visual grouping.
+An own-line trailing comment before a closing `)` keeps its own line:
+in maps and `@use`/`@forward with (...)` configs (any comment kind),
+in map-item lists (any kind, the body is already one item per line),
+and in paren lists, call/`@include` arguments and `@mixin` parameters
+(`//` only: an own-line block comment in a fill body is a fill item, see AGENTS.md).
+
+Prettier pulls the comment up onto the last item's line, a `lineSuffix` artifact of its comma-group printing.
+Same-line trailing comments still glue (matching Prettier); moving an own-line comment up would destroy the author's visual grouping.
 
 ## map-leading-comment-forced-break
 

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -85,6 +85,20 @@ pub(super) fn write_sass_variable_declaration<'a>(
     }
 }
 
+/// `("a",)` / `$x: "a",`: a single element followed by a comma is a one-element LIST in Sass,
+/// and `"a"` alone is a string (dart-sass `type-of`), so the comma is the value and is kept regardless of `trailing_commas`.
+/// Multi-element lists drop theirs (the list is a list without it).
+/// `comma_spans` holds one span per source comma, so a lone element with a span means a trailing comma.
+/// Not a concern for CSS declarations (dart-sass serializes both as `"a"`) nor Less (no list/scalar split).
+pub(super) fn is_single_item_list(list: &SassList<'_>) -> bool {
+    list.elements.len() == 1 && list.comma_spans.as_ref().is_some_and(|s| !s.is_empty())
+}
+
+/// Start offset of the source comma after element `i` (for [`value::write_group_comma`]).
+pub(super) fn list_comma_start(list: &SassList<'_>, i: usize) -> Option<u32> {
+    list.comma_spans.as_ref().and_then(|s| s.get(i)).map(|sp| to_span(sp).start)
+}
+
 /// A single `ComponentValue` in declaration-value position:
 /// comma-separated `SassList`s get Prettier's top-level list layout
 /// (one entry per line when any entry has multiple parts).
@@ -93,9 +107,11 @@ pub(super) fn write_top_level_value<'a>(
     ctx: ValueContext<'a>,
     f: &mut CssFormatter<'_, 'a>,
 ) {
-    let (elements, comma_spans) = match value {
-        ComponentValue::SassList(list) => (&list.elements, list.comma_spans.as_ref()),
-        ComponentValue::LessList(list) => (&list.elements, list.comma_spans.as_ref()),
+    let (elements, comma_spans, keep_trailing_comma) = match value {
+        ComponentValue::SassList(list) => {
+            (&list.elements, list.comma_spans.as_ref(), is_single_item_list(list))
+        }
+        ComponentValue::LessList(list) => (&list.elements, list.comma_spans.as_ref(), false),
         _ => {
             value::write_component_value(value, ctx, f);
             return;
@@ -134,7 +150,7 @@ pub(super) fn write_top_level_value<'a>(
                 .enumerate()
                 .any(|(i, (g, _))| value::comma_group_is_multi(g, i == 0))
                 || has_comments);
-        value::write_value_groups(&groups, ctx, force_hard_line, true, f);
+        value::write_value_groups(&groups, ctx, force_hard_line, keep_trailing_comma, f);
     } else {
         value::write_comma_group(elements, ctx, f);
     }
@@ -354,20 +370,12 @@ pub(super) fn write_sass_map<'a>(
                 write!(f, group(&indent(&pair)));
             }
         }
-        // Own-line comments after the last item make it "non-last" in Prettier's sequence,
-        // so it always gets a comma.
-        let last_item_end = map.items.last().map_or(0, |it| to_span(it.span()).end);
-        let has_ownline_tail = f
-            .context()
-            .comments()
-            .iter_before(r_paren)
-            .any(|c| c.span.start >= last_item_end && value::comment_is_own_line(c, source));
         // A comment before the FIRST item drops the trailing comma:
         // the comment becomes `groups[0]` of the paren group,
         // so `isKeyValuePairInParenGroupNode` no longer sees a key-value pair and the group stops being an SCSS map item.
         // A comment before a LATER item never does
         // (Prettier keeps the comma there whether or not the source had one — required for idempotency).
-        let printed_comma = (trailing && !first_item_has_leading_comment) || has_ownline_tail;
+        let printed_comma = trailing && !first_item_has_leading_comment;
         if printed_comma {
             write!(f, ",");
         }
@@ -385,16 +393,20 @@ pub(super) fn write_sass_map<'a>(
                 value::flush_same_line_comments(to_span(last.span()).end, r_paren, f);
             }
         }
-        // Own-line comments before `)`: same-line runs stay glued
-        let tail: Vec<comments::CssComment> = f.context().comments().take_before(r_paren).to_vec();
-        for (i, &comment) in tail.iter().enumerate() {
-            if i == 0 || comment.inline || tail[i - 1].inline {
+        // The rest goes below the last item, one line per `//`;
+        // block comments after a block comment stay glued.
+        // Not `write_paren_tail_comments`:
+        // a next-slot comment (above) is same-line in source but still starts a line here,
+        // and consecutive own-line block comments glue.
+        let mut after_inline = true;
+        for &comment in f.context().comments().take_before(r_paren) {
+            if after_inline || comment.inline {
                 write!(f, hard_line_break());
             } else {
-                // Block comments are fill items: they join when they fit
                 write!(f, " ");
             }
             comments::write_single_comment(comment, f);
+            after_inline = comment.inline;
         }
     });
     write!(f, ["(", indent(&body), hard_line_break(), ")"]);
@@ -407,18 +419,15 @@ pub(super) fn write_sass_list<'a>(
     f: &mut CssFormatter<'_, 'a>,
 ) {
     if list.comma_spans.is_some() {
-        let comma_spans = list.comma_spans.as_ref();
+        let keep_trailing_comma = is_single_item_list(list);
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             let mut filler = f.fill();
             for (i, el) in list.elements.iter().enumerate() {
                 let is_last = i + 1 == list.elements.len();
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     value::write_component_value(el, ctx, f);
-                    if !is_last {
-                        value::write_group_comma(
-                            comma_spans.and_then(|s| s.get(i)).map(|sp| to_span(sp).start),
-                            f,
-                        );
+                    if !is_last || keep_trailing_comma {
+                        value::write_group_comma(list_comma_start(list, i), f);
                     }
                 });
                 filler.entry(&soft_line_break_or_space(), &content);
@@ -549,6 +558,7 @@ fn write_sass_parameters<'a>(parameters: &SassParameters<'a>, f: &mut CssFormatt
     let source = f.context().source_text();
     let comma_start =
         |i: usize| parameters.comma_spans.get(i).map(|sp: &oxc_css_parser::Span| to_span(sp).start);
+    let r_paren = to_span(&parameters.span).end.saturating_sub(1);
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         write!(f, soft_line_break());
         for (i, param) in parameters.params.iter().enumerate() {
@@ -571,6 +581,7 @@ fn write_sass_parameters<'a>(parameters: &SassParameters<'a>, f: &mut CssFormatt
             let span = to_span(arbitrary.name.span());
             write!(f, [text(source.text_for(&span)), "..."]);
         }
+        value::flush_paren_tail_comments(r_paren, /* body_hard_broken */ false, f);
     });
     write!(
         f,
@@ -591,6 +602,7 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
     if let Some(arguments) = &include.arguments {
         let args = &arguments.args;
         let comma_spans = &arguments.comma_spans;
+        let r_paren = to_span(&arguments.span).end.saturating_sub(1);
         // Same first-argument gate as `write_function` (which see), over typed args
         let first_arg_is_kw =
             args.first().is_some_and(|a| matches!(a, ComponentValue::SassKeywordArgument(_)));
@@ -627,6 +639,7 @@ pub(super) fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssForma
                 };
                 write_top_level_value(arg, arg_ctx, f);
             }
+            value::flush_paren_tail_comments(r_paren, /* body_hard_broken */ false, f);
         });
         write!(
             f,

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -570,7 +570,7 @@ pub(super) fn write_declaration_value<'a>(
         && (groups.iter().enumerate().any(|(i, (g, _))| comma_group_is_multi(g, i == 0))
             || has_comments);
 
-    write_value_groups(&groups, ctx, force_hard_line, true, f);
+    write_value_groups(&groups, ctx, force_hard_line, false, f);
 }
 
 /// Does this comma group count as a `value-comma_group` for Prettier's `shouldBreakList`?
@@ -604,11 +604,13 @@ pub(super) fn write_group_comma(comma_start: Option<u32>, f: &mut CssFormatter<'
 
 /// Top-level comma-group list layout, shared between flat component streams and SCSS comma lists.
 /// Each group comes paired with the start of its trailing comma (see [`split_comma_groups`] / [`write_group_comma`]).
+/// `keep_trailing_comma`: the last group's comma is written too (see [`scss::is_single_item_list`]);
+/// only a one-group list sets it, so it matters to the fill branch alone.
 pub(super) fn write_value_groups<'a>(
     groups: &[(&[ComponentValue<'a>], Option<u32>)],
     ctx: ValueContext<'a>,
     force_hard_line: bool,
-    _top_level: bool,
+    keep_trailing_comma: bool,
     f: &mut CssFormatter<'_, 'a>,
 ) {
     // A single comma group never forces (it isn't a list)
@@ -688,7 +690,7 @@ pub(super) fn write_value_groups<'a>(
                 let gctx = if is_last { ctx } else { ValueContext { tail_bound: None, ..ctx } };
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write_comma_group(group_values, gctx, f);
-                    if !is_last {
+                    if !is_last || keep_trailing_comma {
                         write_group_comma(comma, f);
                     }
                 });
@@ -713,6 +715,48 @@ pub(super) fn comment_is_own_line(comment: comments::CssComment, source: SourceT
         }
     }
     true
+}
+
+/// Comments between the last element and its closing `)`.
+///
+/// - Same-line: glued to the element, `a /* c */)`
+///   - A `//` also forces the group open, so `)` lands on the next line
+/// - Own-line `//`: keeps its own line (DIVERGENCES.md#own-line-trailing-comment-keeps-line)
+/// - Own-line block comment: glued too, like any value-level block comment
+///   - it carries no line semantics, and keeping it own-line would pin a wrapped layout
+///   - With `body_hard_broken` it keeps its own line instead:
+///     the body already prints one element per line, so there is no wrapped layout to pin.
+/// - After a `//`: always a new line, or the `//` would swallow the next comment.
+fn write_paren_tail_comments(
+    tail: &[comments::CssComment],
+    body_hard_broken: bool,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    let source = f.context().source_text();
+    let mut after_inline = false;
+    for &comment in tail {
+        let keeps_line = comment.inline || body_hard_broken;
+        if after_inline || (keeps_line && comment_is_own_line(comment, source)) {
+            write!(f, hard_line_break());
+        } else {
+            write!(f, space());
+        }
+        comments::write_single_comment(comment, f);
+        if comment.inline {
+            write!(f, expand_parent());
+        }
+        after_inline = comment.inline;
+    }
+}
+
+/// Drains the comments before `r_paren` and writes them per [`write_paren_tail_comments`].
+pub(super) fn flush_paren_tail_comments(
+    r_paren: u32,
+    body_hard_broken: bool,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    let tail = f.context().comments().take_before(r_paren);
+    write_paren_tail_comments(tail, body_hard_broken, f);
 }
 
 /// Emits pending comments that precede `upper_bound` inline
@@ -1365,76 +1409,80 @@ pub(super) fn write_component_value<'a>(
             // `$var: ((a, b), (c, d))` / map item values: one item per line.
             // ONLY a comma-separated list takes this break:
             // the trailing comma is a semantic no-op there and NOWHERE else.
+            //
             // NOTE: `(x,)` is a single-element list in Sass,
             // so adding it to `($a + $b)` / `(a b)` / `(-$a)` changes the value
             // and `2 * ($a + $b,)` fails to compile.
             // (Prettier 3.9.1 does all of these; #19091 exempted single-node scalars only)
+            //
+            // The reverse also holds: `("a",)` keeps its comma regardless of `trailing_commas`
+            // (see `is_single_item_list`; prettier#19928 preserves it too).
+            let comma_list = match &*paren.expr {
+                ComponentValue::SassList(list) if list.comma_spans.is_some() => Some(list),
+                _ => None,
+            };
+            let keep_trailing_comma = comma_list.is_some_and(scss::is_single_item_list);
+            // A single-item list of ONE component value (`k: ("a",)`, `k: ((1 2),)`, `k: (fn(1),)`)
+            // is not a map item and stays flat (`isSCSSMapItemNode`'s "parenthesized scalar" exit):
+            // only a multi-token item (`k: (1 2,)`, `k: ($a + $b,)`) is a `value-comma_group` there.
+            let single_scalar_item = keep_trailing_comma
+                && comma_list.is_some_and(|list| {
+                    !matches!(
+                        list.elements[0],
+                        ComponentValue::SassList(_) | ComponentValue::SassBinaryExpression(_)
+                    )
+                });
+            let inner_ctx = ValueContext { paren_break: false, ..ctx };
+            let trailing = f.options().allow_trailing_comma();
+            let r_paren = to_span(paren.span()).end.saturating_sub(1);
             if ctx.paren_break
-                && let ComponentValue::SassList(list) = &*paren.expr
-                && list.comma_spans.is_some()
+                && !single_scalar_item
+                && let Some(list) = comma_list
             {
                 // Comma-list map-item values always break (`isSCSSMapItemNode`),
                 // with a trailing comma per option.
-                let inner_ctx = ValueContext { paren_break: false, ..ctx };
-                let trailing = f.options().allow_trailing_comma();
-                let elements = &list.elements;
-                let comma_spans = list.comma_spans.as_ref();
                 let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write!(f, hard_line_break());
-                    for (i, el) in elements.iter().enumerate() {
+                    for (i, el) in list.elements.iter().enumerate() {
                         if i > 0 {
-                            write_group_comma(
-                                comma_spans.and_then(|s| s.get(i - 1)).map(|sp| to_span(sp).start),
-                                f,
-                            );
                             write!(f, hard_line_break());
                         }
                         write_component_value(el, inner_ctx, f);
+                        let is_last = i + 1 == list.elements.len();
+                        if !is_last || keep_trailing_comma {
+                            write_group_comma(scss::list_comma_start(list, i), f);
+                        } else if trailing {
+                            write!(f, ",");
+                        }
                     }
-                    if trailing {
-                        write!(f, ",");
-                    }
+                    flush_paren_tail_comments(r_paren, /* body_hard_broken */ true, f);
                 });
                 write!(f, ["(", indent(&body), hard_line_break(), ")"]);
                 return;
             }
-            let inner_ctx = ValueContext { paren_break: false, ..ctx };
-            let trailing = f.options().allow_trailing_comma();
-            let r_paren = to_span(paren.span()).end.saturating_sub(1);
             let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 write!(f, soft_line_break());
                 // A comma list directly inside parens shares the paren's
                 // indent (no nested group level).
-                if let ComponentValue::SassList(list) = &*paren.expr
-                    && list.comma_spans.is_some()
-                {
-                    let comma_spans = list.comma_spans.as_ref();
+                if let Some(list) = comma_list {
                     for (i, el) in list.elements.iter().enumerate() {
                         if i > 0 {
-                            write_group_comma(
-                                comma_spans.and_then(|s| s.get(i - 1)).map(|sp| to_span(sp).start),
-                                f,
-                            );
                             write!(f, soft_line_break_or_space());
                         }
                         write_component_value(el, inner_ctx, f);
-                    }
-                    // `ctx.paren_break` cannot be set here,
-                    // a comma list with it takes the hard-break branch above.
-                    if trailing && ctx.map_key {
-                        write!(f, if_group_breaks(&text(",")));
+                        let is_last = i + 1 == list.elements.len();
+                        if !is_last || keep_trailing_comma {
+                            write_group_comma(scss::list_comma_start(list, i), f);
+                        } else if trailing && ctx.map_key {
+                            // `ctx.paren_break` cannot be set here,
+                            // a comma list with it takes the hard-break branch above.
+                            write!(f, if_group_breaks(&text(",")));
+                        }
                     }
                 } else {
                     write_component_value(&paren.expr, inner_ctx, f);
                 }
-                // Inline comments before `)` stay inside, forcing the break
-                for &comment in f.context().comments().take_before(r_paren) {
-                    write!(f, " ");
-                    comments::write_single_comment(comment, f);
-                    if comment.inline {
-                        write!(f, expand_parent());
-                    }
-                }
+                flush_paren_tail_comments(r_paren, /* body_hard_broken */ false, f);
             });
             write!(
                 f,
@@ -2185,17 +2233,11 @@ pub(super) fn write_function<'a>(
                 write_group_comma(comma, f);
             }
         }
-        // Comments between the last argument and `)` wrap as fill items;
-        // `//` comments stay glued to the argument (their hardline follows).
+        // Block comments between the last argument and `)` wrap as fill items;
+        // with a `//` among them they take the paren-tail layout instead.
         let tail: &'a [comments::CssComment] = f.context().comments().take_before(r_paren);
         if tail.iter().any(|c| c.inline) {
-            for &comment in tail {
-                write!(f, " ");
-                comments::write_single_comment(comment, f);
-                if comment.inline {
-                    write!(f, [expand_parent(), hard_line_break()]);
-                }
-            }
+            write_paren_tail_comments(tail, /* body_hard_broken */ false, f);
         } else if !tail.is_empty() {
             let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 let mut filler = f.fill();
@@ -2205,9 +2247,6 @@ pub(super) fn write_function<'a>(
                 for &comment in tail {
                     let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                         comments::write_single_comment(comment, f);
-                        if comment.inline {
-                            write!(f, [expand_parent(), hard_line_break()]);
-                        }
                     });
                     filler.entry(&soft_line_break_or_space(), &entry);
                 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/paren-tail-own-line-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/paren-tail-own-line-comment.scss
@@ -1,0 +1,51 @@
+// An own-line `//` before a closing `)` keeps its own line, in lists and argument parens
+// as in maps (DIVERGENCES.md "own-line-trailing-comment-keeps-line": Prettier pulls it
+// up onto the last item's line, unless the body is hard-broken like `$map-item`).
+// Same-line comments still glue to the last item.
+$list: ("a", "b",
+  // own
+);
+$map-item: (k: (1, 2,
+  // own
+));
+$args: fn(1,
+  // own
+);
+@include mix(1,
+  // own
+);
+@mixin m($a,
+  // own
+) {
+  a: b;
+}
+
+// Same-line before `)`: glued, `//` still forces the parens open.
+$same-block: ("a", "b" /* c */);
+$same-inline: ("a", "b" // c
+);
+$args-same: fn(1 /* c */);
+@include mix-same(1 // c
+);
+
+// An own-line BLOCK comment is a value-level fill item: it joins the line,
+// except in a body that already breaks one item per line (nothing to pin).
+$block: ("a", "b",
+  /* own */
+);
+$args-block: fn(1
+  /* own */
+);
+$map-item-block: (k: (1, 2,
+  /* own */
+));
+
+// Anything after a `//` starts a new line: the `//` would swallow it.
+$after-inline: fn(1,
+  // one
+  /* two */
+);
+$list-after-inline: ("a", "b",
+  // one
+  /* two */
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/paren-tail-own-line-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/paren-tail-own-line-comment.scss.snap
@@ -1,0 +1,198 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// An own-line `//` before a closing `)` keeps its own line, in lists and argument parens
+// as in maps (DIVERGENCES.md "own-line-trailing-comment-keeps-line": Prettier pulls it
+// up onto the last item's line, unless the body is hard-broken like `$map-item`).
+// Same-line comments still glue to the last item.
+$list: ("a", "b",
+  // own
+);
+$map-item: (k: (1, 2,
+  // own
+));
+$args: fn(1,
+  // own
+);
+@include mix(1,
+  // own
+);
+@mixin m($a,
+  // own
+) {
+  a: b;
+}
+
+// Same-line before `)`: glued, `//` still forces the parens open.
+$same-block: ("a", "b" /* c */);
+$same-inline: ("a", "b" // c
+);
+$args-same: fn(1 /* c */);
+@include mix-same(1 // c
+);
+
+// An own-line BLOCK comment is a value-level fill item: it joins the line,
+// except in a body that already breaks one item per line (nothing to pin).
+$block: ("a", "b",
+  /* own */
+);
+$args-block: fn(1
+  /* own */
+);
+$map-item-block: (k: (1, 2,
+  /* own */
+));
+
+// Anything after a `//` starts a new line: the `//` would swallow it.
+$after-inline: fn(1,
+  // one
+  /* two */
+);
+$list-after-inline: ("a", "b",
+  // one
+  /* two */
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// An own-line `//` before a closing `)` keeps its own line, in lists and argument parens
+// as in maps (DIVERGENCES.md "own-line-trailing-comment-keeps-line": Prettier pulls it
+// up onto the last item's line, unless the body is hard-broken like `$map-item`).
+// Same-line comments still glue to the last item.
+$list: (
+  "a",
+  "b"
+  // own
+);
+$map-item: (
+  k: (
+    1,
+    2,
+    // own
+  ),
+);
+$args: fn(
+  1
+  // own
+);
+@include mix(
+  1
+  // own
+);
+@mixin m(
+  $a
+  // own
+) {
+  a: b;
+}
+
+// Same-line before `)`: glued, `//` still forces the parens open.
+$same-block: ("a", "b" /* c */);
+$same-inline: (
+  "a",
+  "b" // c
+);
+$args-same: fn(1 /* c */);
+@include mix-same(
+  1 // c
+);
+
+// An own-line BLOCK comment is a value-level fill item: it joins the line,
+// except in a body that already breaks one item per line (nothing to pin).
+$block: ("a", "b" /* own */);
+$args-block: fn(1 /* own */);
+$map-item-block: (
+  k: (
+    1,
+    2,
+    /* own */
+  ),
+);
+
+// Anything after a `//` starts a new line: the `//` would swallow it.
+$after-inline: fn(
+  1
+  // one
+  /* two */
+);
+$list-after-inline: (
+  "a",
+  "b"
+  // one
+  /* two */
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// An own-line `//` before a closing `)` keeps its own line, in lists and argument parens
+// as in maps (DIVERGENCES.md "own-line-trailing-comment-keeps-line": Prettier pulls it
+// up onto the last item's line, unless the body is hard-broken like `$map-item`).
+// Same-line comments still glue to the last item.
+$list: (
+  "a",
+  "b"
+  // own
+);
+$map-item: (
+  k: (
+    1,
+    2,
+    // own
+  ),
+);
+$args: fn(
+  1
+  // own
+);
+@include mix(
+  1
+  // own
+);
+@mixin m(
+  $a
+  // own
+) {
+  a: b;
+}
+
+// Same-line before `)`: glued, `//` still forces the parens open.
+$same-block: ("a", "b" /* c */);
+$same-inline: (
+  "a",
+  "b" // c
+);
+$args-same: fn(1 /* c */);
+@include mix-same(
+  1 // c
+);
+
+// An own-line BLOCK comment is a value-level fill item: it joins the line,
+// except in a body that already breaks one item per line (nothing to pin).
+$block: ("a", "b" /* own */);
+$args-block: fn(1 /* own */);
+$map-item-block: (
+  k: (
+    1,
+    2,
+    /* own */
+  ),
+);
+
+// Anything after a `//` starts a new line: the `//` would swallow it.
+$after-inline: fn(
+  1
+  // one
+  /* two */
+);
+$list-after-inline: (
+  "a",
+  "b"
+  // one
+  /* two */
+);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/single-item-list-trailing-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/single-item-list-trailing-comma.scss
@@ -1,0 +1,51 @@
+// `(x,)` is a single-element list in Sass: the trailing comma IS the list,
+// so it is preserved regardless of the `trailingComma` option (prettier#19928).
+$single-string: ("a",);
+$single-space-list: (1 2 3,);
+$single-nested-list: ((1, 2),);
+$single-call: (fn(1),);
+@include assert-equal(daff-string-split(".a", "."), ("a",));
+
+// Same without parens (`$x: "a",` is a list, `$x: "a"` a string).
+$bare-string: "a",;
+$bare-space-list: 1 2,;
+$bare-comment: "a" /* c */,;
+@function g() {
+  @return "a",;
+}
+
+// Multi-element lists and function arguments still drop it.
+$bare-multiple: "a", "b",;
+$multiple-items: (1, 2,);
+$single-argument: foo(1,);
+
+// A map is not a list: its trailing comma follows `trailingComma`, not the source.
+$single-entry-map: (a: 1,);
+
+// Nested in arguments / operations / control directives.
+$nested-in-args: foo(("a",));
+$nested-list: (("a",), ("b",));
+$operation: ("a",) + ("b",);
+@each $x in ("a",) {
+  a: $x;
+}
+@function f() {
+  @return ("a",);
+}
+
+// Map item values: a single-item list of ONE component value stays flat (not a map item),
+// a multi-token item (space list, binary expression) takes the map-item break.
+$map: (k: ("a",), j: (1, 2,), i: ((1 2),), f: (fn(1),), h: (1 2,), g: ($a + $b,));
+
+// Comments around the comma.
+$comment-before-comma: ("a" /* c */,);
+$comment-after-comma: ("a", // ,
+);
+$comment-without-comma: ("a" // ,
+);
+// Declaration value position (the Prettier test case updated by prettier#19928).
+.simplification {
+  foo: (
+    calc(), // It is a comment
+  );
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/single-item-list-trailing-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/single-item-list-trailing-comma.scss.snap
@@ -1,0 +1,204 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `(x,)` is a single-element list in Sass: the trailing comma IS the list,
+// so it is preserved regardless of the `trailingComma` option (prettier#19928).
+$single-string: ("a",);
+$single-space-list: (1 2 3,);
+$single-nested-list: ((1, 2),);
+$single-call: (fn(1),);
+@include assert-equal(daff-string-split(".a", "."), ("a",));
+
+// Same without parens (`$x: "a",` is a list, `$x: "a"` a string).
+$bare-string: "a",;
+$bare-space-list: 1 2,;
+$bare-comment: "a" /* c */,;
+@function g() {
+  @return "a",;
+}
+
+// Multi-element lists and function arguments still drop it.
+$bare-multiple: "a", "b",;
+$multiple-items: (1, 2,);
+$single-argument: foo(1,);
+
+// A map is not a list: its trailing comma follows `trailingComma`, not the source.
+$single-entry-map: (a: 1,);
+
+// Nested in arguments / operations / control directives.
+$nested-in-args: foo(("a",));
+$nested-list: (("a",), ("b",));
+$operation: ("a",) + ("b",);
+@each $x in ("a",) {
+  a: $x;
+}
+@function f() {
+  @return ("a",);
+}
+
+// Map item values: a single-item list of ONE component value stays flat (not a map item),
+// a multi-token item (space list, binary expression) takes the map-item break.
+$map: (k: ("a",), j: (1, 2,), i: ((1 2),), f: (fn(1),), h: (1 2,), g: ($a + $b,));
+
+// Comments around the comma.
+$comment-before-comma: ("a" /* c */,);
+$comment-after-comma: ("a", // ,
+);
+$comment-without-comma: ("a" // ,
+);
+// Declaration value position (the Prettier test case updated by prettier#19928).
+.simplification {
+  foo: (
+    calc(), // It is a comment
+  );
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `(x,)` is a single-element list in Sass: the trailing comma IS the list,
+// so it is preserved regardless of the `trailingComma` option (prettier#19928).
+$single-string: ("a",);
+$single-space-list: (1 2 3,);
+$single-nested-list: ((1, 2),);
+$single-call: (fn(1),);
+@include assert-equal(daff-string-split(".a", "."), ("a",));
+
+// Same without parens (`$x: "a",` is a list, `$x: "a"` a string).
+$bare-string: "a",;
+$bare-space-list: 1 2,;
+$bare-comment: "a" /* c */,;
+@function g() {
+  @return "a",;
+}
+
+// Multi-element lists and function arguments still drop it.
+$bare-multiple: "a", "b";
+$multiple-items: (1, 2);
+$single-argument: foo(1);
+
+// A map is not a list: its trailing comma follows `trailingComma`, not the source.
+$single-entry-map: (
+  a: 1,
+);
+
+// Nested in arguments / operations / control directives.
+$nested-in-args: foo(("a",));
+$nested-list: (("a",), ("b",));
+$operation: ("a",) + ("b",);
+@each $x in ("a",) {
+  a: $x;
+}
+@function f() {
+  @return ("a",);
+}
+
+// Map item values: a single-item list of ONE component value stays flat (not a map item),
+// a multi-token item (space list, binary expression) takes the map-item break.
+$map: (
+  k: ("a",),
+  j: (
+    1,
+    2,
+  ),
+  i: ((1 2),),
+  f: (fn(1),),
+  h: (
+    1 2,
+  ),
+  g: (
+    $a + $b,
+  ),
+);
+
+// Comments around the comma.
+$comment-before-comma: ("a" /* c */,);
+$comment-after-comma: (
+  "a", // ,
+);
+$comment-without-comma: (
+  "a" // ,
+);
+// Declaration value position (the Prettier test case updated by prettier#19928).
+.simplification {
+  foo: (
+    calc(), // It is a comment
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `(x,)` is a single-element list in Sass: the trailing comma IS the list,
+// so it is preserved regardless of the `trailingComma` option (prettier#19928).
+$single-string: ("a",);
+$single-space-list: (1 2 3,);
+$single-nested-list: ((1, 2),);
+$single-call: (fn(1),);
+@include assert-equal(daff-string-split(".a", "."), ("a",));
+
+// Same without parens (`$x: "a",` is a list, `$x: "a"` a string).
+$bare-string: "a",;
+$bare-space-list: 1 2,;
+$bare-comment: "a" /* c */,;
+@function g() {
+  @return "a",;
+}
+
+// Multi-element lists and function arguments still drop it.
+$bare-multiple: "a", "b";
+$multiple-items: (1, 2);
+$single-argument: foo(1);
+
+// A map is not a list: its trailing comma follows `trailingComma`, not the source.
+$single-entry-map: (
+  a: 1,
+);
+
+// Nested in arguments / operations / control directives.
+$nested-in-args: foo(("a",));
+$nested-list: (("a",), ("b",));
+$operation: ("a",) + ("b",);
+@each $x in ("a",) {
+  a: $x;
+}
+@function f() {
+  @return ("a",);
+}
+
+// Map item values: a single-item list of ONE component value stays flat (not a map item),
+// a multi-token item (space list, binary expression) takes the map-item break.
+$map: (
+  k: ("a",),
+  j: (
+    1,
+    2,
+  ),
+  i: ((1 2),),
+  f: (fn(1),),
+  h: (
+    1 2,
+  ),
+  g: (
+    $a + $b,
+  ),
+);
+
+// Comments around the comma.
+$comment-before-comma: ("a" /* c */,);
+$comment-after-comma: (
+  "a", // ,
+);
+$comment-without-comma: (
+  "a" // ,
+);
+// Declaration value position (the Prettier test case updated by prettier#19928).
+.simplification {
+  foo: (
+    calc(), // It is a comment
+  );
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/options.json
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/options.json
@@ -1,0 +1,1 @@
+[{ "printWidth": 80, "trailingComma": "none" }]

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss
@@ -1,0 +1,23 @@
+// `trailingComma: none` drops the commas the formatter would ADD.
+// A single-item list's source comma is the value and stays.
+$single-string: ("a",);
+$bare-string: "a",;
+$map-scalar-item: (k: ("a",));
+$map-multi-token-item: (k: (1 2,));
+
+// Maps and multi-element lists lose theirs.
+$single-entry-map: (a: 1,);
+$map: (a: 1, b: 2,);
+$map-list-item: (k: (1, 2,));
+
+// An own-line comment before `)` changes nothing: the comma is a no-op there, so it goes too
+// (DIVERGENCES.md "trailing-comma-none-before-tail-comment": Prettier keeps a source comma).
+$map-own-line-comment: (a: 1, b: 2,
+  // own
+);
+$map-item-own-line-comment: (k: (1, 2,
+  // own
+));
+$map-item-own-line-block: (k: (1, 2,
+  /* own */
+));

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss.snap
@@ -1,0 +1,136 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `trailingComma: none` drops the commas the formatter would ADD.
+// A single-item list's source comma is the value and stays.
+$single-string: ("a",);
+$bare-string: "a",;
+$map-scalar-item: (k: ("a",));
+$map-multi-token-item: (k: (1 2,));
+
+// Maps and multi-element lists lose theirs.
+$single-entry-map: (a: 1,);
+$map: (a: 1, b: 2,);
+$map-list-item: (k: (1, 2,));
+
+// An own-line comment before `)` changes nothing: the comma is a no-op there, so it goes too
+// (DIVERGENCES.md "trailing-comma-none-before-tail-comment": Prettier keeps a source comma).
+$map-own-line-comment: (a: 1, b: 2,
+  // own
+);
+$map-item-own-line-comment: (k: (1, 2,
+  // own
+));
+$map-item-own-line-block: (k: (1, 2,
+  /* own */
+));
+
+==================== Output ====================
+-----------------------------------------
+{ printWidth: 80, trailingComma: "none" }
+-----------------------------------------
+// `trailingComma: none` drops the commas the formatter would ADD.
+// A single-item list's source comma is the value and stays.
+$single-string: ("a",);
+$bare-string: "a",;
+$map-scalar-item: (
+  k: ("a",)
+);
+$map-multi-token-item: (
+  k: (
+    1 2,
+  )
+);
+
+// Maps and multi-element lists lose theirs.
+$single-entry-map: (
+  a: 1
+);
+$map: (
+  a: 1,
+  b: 2
+);
+$map-list-item: (
+  k: (
+    1,
+    2
+  )
+);
+
+// An own-line comment before `)` changes nothing: the comma is a no-op there, so it goes too
+// (DIVERGENCES.md "trailing-comma-none-before-tail-comment": Prettier keeps a source comma).
+$map-own-line-comment: (
+  a: 1,
+  b: 2
+  // own
+);
+$map-item-own-line-comment: (
+  k: (
+    1,
+    2
+    // own
+  )
+);
+$map-item-own-line-block: (
+  k: (
+    1,
+    2
+    /* own */
+  )
+);
+
+------------------------------------------
+{ printWidth: 100, trailingComma: "none" }
+------------------------------------------
+// `trailingComma: none` drops the commas the formatter would ADD.
+// A single-item list's source comma is the value and stays.
+$single-string: ("a",);
+$bare-string: "a",;
+$map-scalar-item: (
+  k: ("a",)
+);
+$map-multi-token-item: (
+  k: (
+    1 2,
+  )
+);
+
+// Maps and multi-element lists lose theirs.
+$single-entry-map: (
+  a: 1
+);
+$map: (
+  a: 1,
+  b: 2
+);
+$map-list-item: (
+  k: (
+    1,
+    2
+  )
+);
+
+// An own-line comment before `)` changes nothing: the comma is a no-op there, so it goes too
+// (DIVERGENCES.md "trailing-comma-none-before-tail-comment": Prettier keeps a source comma).
+$map-own-line-comment: (
+  a: 1,
+  b: 2
+  // own
+);
+$map-item-own-line-comment: (
+  k: (
+    1,
+    2
+    // own
+  )
+);
+$map-item-own-line-block: (
+  k: (
+    1,
+    2
+    /* own */
+  )
+);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
@@ -2,17 +2,22 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-scss compatibility: 84/90 (93.33%), 6 files skipped
+scss compatibility: 79/90 (87.78%), 6 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | scss/comments/4878.scss | 💥 | 89.39% |
+| scss/function/arbitrary-arguments-comment.scss | 💥💥 | 72.73% |
+| scss/map/15193.scss | 💥✨ | 42.86% |
 | scss/map/comment.scss | 💥💥 | 73.91% |
 | scss/map/function-argument/functional-argument.scss | 💥 | 96.00% |
 | scss/parens/2.scss | 💥 | 75.00% |
 | scss/parens/issue-16594.scss | 💥 | 71.43% |
+| scss/trailing-comma/comments.scss | 💥💥 | 95.00% |
+| scss/trailing-comma/list.scss | 💥💥 | 95.56% |
+| scss/trailing-comma/variable.scss | 💥💥 | 50.00% |
 | scss/variables/apply-rule.scss | 💥 | 87.88% |
 
 # Skipped (parse error, TODO: should be ignored or supported)


### PR DESCRIPTION
Keep these as-is.

```scss
foo: ("a",);

$x: "a",;
```

Even if they consist of a single element, these are still lists, and if the commas are removed, their type changes.

And also fixed inconsistent comment printing.