### PR TITLE
fix(allocator): gate `Allocator::data_end_ptr` behind fixed_size feature

### DIFF
--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -103,6 +103,7 @@ impl Allocator {
     /// i.e to the start of the `ChunkFooter`.
     ///
     /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
+    #[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
     pub(crate) fn data_end_ptr(&self) -> NonNull<u8> {
         self.arena().data_end_ptr()
     }


### PR DESCRIPTION
## Summary

- compile Allocator::data_end_ptr only in supported fixed-size allocator builds
- remove the dead-code warning from coverage builds while preserving fixed-size pool usage

