### PR TITLE
fix(linter): qualify rules in rules output

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -760,6 +760,16 @@ mod test {
     use crate::{DEFAULT_OXLINTRC_NAME, tester::Tester};
     use oxc_linter::rules::RULES;
 
+    fn markdown_rule_row<'a>(output: &'a str, plugin: &str, name: &str) -> Vec<&'a str> {
+        output
+            .lines()
+            .find_map(|line| {
+                let cells = line.split('|').skip(1).take(5).map(str::trim).collect::<Vec<_>>();
+                (cells.len() == 5 && cells[0] == name && cells[1] == plugin).then_some(cells)
+            })
+            .unwrap_or_else(|| panic!("Missing rule row for {plugin}/{name}"))
+    }
+
     // lints the full directory of fixtures,
     // so do not snapshot it, test only
     #[test]
@@ -1656,6 +1666,39 @@ mod test {
             })
             .collect();
         assert!(rule_names.is_sorted(), "The rules list should be sorted by scope and value");
+
+        for (scope, value, expected) in [
+            ("eslint", "no-implied-eval", false),
+            ("typescript", "no-implied-eval", true),
+            ("typescript", "prefer-string-starts-ends-with", false),
+            ("unicorn", "prefer-string-starts-ends-with", true),
+            ("vue", "no-dupe-keys", false),
+            ("eslint", "no-dupe-keys", true),
+        ] {
+            let rule = rules
+                .iter()
+                .find(|rule| rule["scope"] == scope && rule["value"] == value)
+                .unwrap_or_else(|| panic!("Missing rule {scope}/{value}"));
+            assert_eq!(rule["default"], expected, "Incorrect default for {scope}/{value}");
+        }
+    }
+
+    #[test]
+    fn test_rules_markdown_output_uses_qualified_rule_names() {
+        let (stdout, _) = Tester::new().with_cwd("fixtures".into()).test_output(&["--rules"]);
+
+        for (plugin, name, expected) in [
+            ("eslint", "no-implied-eval", ""),
+            ("typescript", "no-implied-eval", "✅"),
+            ("typescript", "prefer-string-starts-ends-with", ""),
+            ("unicorn", "prefer-string-starts-ends-with", "✅"),
+            ("vue", "no-dupe-keys", ""),
+            ("eslint", "no-dupe-keys", "✅"),
+        ] {
+            let row = markdown_rule_row(&stdout, plugin, name);
+            assert_eq!(row[2], expected, "Incorrect default for {plugin}/{name}");
+            assert_eq!(row[3], expected, "Incorrect enabled state for {plugin}/{name}");
+        }
     }
 
     #[test]

--- a/apps/oxlint/src/mode/rules.rs
+++ b/apps/oxlint/src/mode/rules.rs
@@ -10,9 +10,9 @@ pub fn run_rules(
     output_formatter: &OutputFormatter,
     stdout: &mut dyn std::io::Write,
 ) -> CliRunResult {
-    // Build the set of enabled builtin rule names from the resolved config.
-    let enabled: FxHashSet<&str> =
-        lint_config.rules().iter().map(|(rule, _)| rule.name()).collect();
+    // Build the set of enabled builtin rules from the resolved config.
+    let enabled: FxHashSet<(&str, &str)> =
+        lint_config.rules().iter().map(|(rule, _)| (rule.plugin_name(), rule.name())).collect();
 
     if let Some(output) = output_formatter.all_rules(enabled) {
         print_and_flush_stdout(stdout, &output);

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashSet;
 pub struct DefaultOutputFormatter;
 
 impl InternalFormatter for DefaultOutputFormatter {
-    fn all_rules(&self, enabled_rules: FxHashSet<&str>) -> Option<String> {
+    fn all_rules(&self, enabled_rules: FxHashSet<(&str, &str)>) -> Option<String> {
         let mut output = String::new();
         let table = RuleTable::default();
         for section in &table.sections {

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -19,7 +19,7 @@ pub struct JsonOutputFormatter {
 }
 
 impl InternalFormatter for JsonOutputFormatter {
-    fn all_rules(&self, _enabled_rules: FxHashSet<&str>) -> Option<String> {
+    fn all_rules(&self, _enabled_rules: FxHashSet<(&str, &str)>) -> Option<String> {
         #[derive(Debug, Serialize)]
         struct RuleInfoJson<'a> {
             scope: &'a str,
@@ -35,13 +35,13 @@ impl InternalFormatter for JsonOutputFormatter {
 
         // Determine which rules are turned on by default (same logic as RuleTable)
         let default_plugin_names = ["eslint", "unicorn", "typescript", "oxc"];
-        let default_rules: FxHashSet<&'static str> = RULES
+        let default_rules: FxHashSet<(&'static str, &'static str)> = RULES
             .iter()
             .filter(|rule| {
                 rule.category() == RuleCategory::Correctness
                     && default_plugin_names.contains(&rule.plugin_name())
             })
-            .map(oxc_linter::rules::RuleEnum::name)
+            .map(|rule| (rule.plugin_name(), rule.name()))
             .collect();
 
         let mut rules_info: Vec<_> = RULES
@@ -54,7 +54,7 @@ impl InternalFormatter for JsonOutputFormatter {
                 version: rule.version(),
                 type_aware: rule.is_tsgolint_rule(),
                 fix: rule.fix().to_string(),
-                default: default_rules.contains(rule.name()),
+                default: default_rules.contains(&(rule.plugin_name(), rule.name())),
                 docs_url: format!(
                     "https://oxc.rs/docs/guide/usage/linter/rules/{}/{}.html",
                     rule.plugin_name(),

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -130,7 +130,7 @@ impl LintCommandInfo {
 /// The Formatter is then managed by [`OutputFormatter`].
 trait InternalFormatter {
     /// Print all available rules by oxlint
-    fn all_rules(&self, _enabled_rules: FxHashSet<&str>) -> Option<String> {
+    fn all_rules(&self, _enabled_rules: FxHashSet<(&str, &str)>) -> Option<String> {
         None
     }
 
@@ -170,7 +170,7 @@ impl OutputFormatter {
 
     /// Print all available rules by oxlint
     /// See [`InternalFormatter::all_rules`] for more details.
-    pub fn all_rules(&self, enabled_rules: FxHashSet<&str>) -> Option<String> {
+    pub fn all_rules(&self, enabled_rules: FxHashSet<(&str, &str)>) -> Option<String> {
         self.internal.all_rules(enabled_rules)
     }
 

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -52,13 +52,14 @@ impl RuleTable {
                 rule.category() == RuleCategory::Correctness
                     && default_plugin_names.contains(&rule.plugin_name())
             })
-            .map(super::rules::RuleEnum::name)
-            .collect::<FxHashSet<&str>>();
+            .map(|rule| (rule.plugin_name(), rule.name()))
+            .collect::<FxHashSet<(&str, &str)>>();
 
         let mut rows = RULES
             .iter()
             .map(|rule| {
                 let name = rule.name();
+                let plugin = rule.plugin_name();
                 RuleTableRow {
                     name,
                     #[cfg(feature = "ruledocs")]
@@ -67,9 +68,9 @@ impl RuleTable {
                     documentation: rule.documentation(),
                     #[cfg(feature = "ruledocs")]
                     schema: generator.as_mut().and_then(|g| rule.schema(g)),
-                    plugin: rule.plugin_name().to_string(),
+                    plugin: plugin.to_string(),
                     category: rule.category(),
-                    turned_on_by_default: default_rules.contains(name),
+                    turned_on_by_default: default_rules.contains(&(plugin, name)),
                     autofix: rule.fix(),
                     is_tsgolint_rule: rule.is_tsgolint_rule(),
                 }
@@ -123,7 +124,7 @@ impl RuleTableSection {
     /// When `enabled` is [`Some`], an "Enabled?" column is added and the set
     /// is used to determine which rules are enabled. When `enabled` is
     /// [`None`], the column is omitted (used by docs rendering).
-    fn render_markdown_table_inner(&self, enabled: Option<&FxHashSet<&str>>) -> String {
+    fn render_markdown_table_inner(&self, enabled: Option<&FxHashSet<(&str, &str)>>) -> String {
         const FIX_EMOJI_COL_WIDTH: usize = 10;
         const DEFAULT_EMOJI_COL_WIDTH: usize = 9;
         const ENABLED_EMOJI_COL_WIDTH: usize = 10;
@@ -171,7 +172,7 @@ impl RuleTableSection {
             let plugin_name = &row.plugin;
 
             let (enabled_mark, enabled_width) = if include_enabled {
-                if enabled.unwrap().contains(rule_name) {
+                if enabled.unwrap().contains(&(plugin_name.as_str(), rule_name)) {
                     ("✅", ENABLED - 1)
                 } else {
                     ("", ENABLED)
@@ -230,7 +231,7 @@ impl RuleTableSection {
         self.render_markdown_table_inner(None)
     }
 
-    pub fn render_markdown_table_cli(&self, enabled: &FxHashSet<&str>) -> String {
+    pub fn render_markdown_table_cli(&self, enabled: &FxHashSet<(&str, &str)>) -> String {
         self.render_markdown_table_inner(Some(enabled))
     }
 }
@@ -269,7 +270,7 @@ mod test {
             // enable the first rule in the section for the CLI view
             let mut enabled = FxHashSet::default();
             if let Some(first) = section.rows.first() {
-                enabled.insert(first.name);
+                enabled.insert((first.plugin.as_str(), first.name));
             }
 
             let rendered_table = section.render_markdown_table_cli(&enabled);


### PR DESCRIPTION
## Summary

- preserve plugin names when tracking default and enabled rules
- prevent same-named rules from inheriting another plugin’s state in Markdown and JSON output
- add regression coverage for all known rule-name collisions

Fixes #26209.
