### PR TITLE
docs(minifier): fix stale validation instructions

### DIFF
--- a/crates/oxc_minifier/docs/ASSUMPTIONS.md
+++ b/crates/oxc_minifier/docs/ASSUMPTIONS.md
@@ -2,7 +2,7 @@
 
 The Oxc minifier makes certain assumptions about JavaScript code to achieve optimal compression. These assumptions are standard for typical JavaScript but may not hold for unusual code patterns.
 
-These assumptions are validated using ECMAScript operations from [`oxc_ecmascript`](../oxc_ecmascript), which implements spec-compliant behavior for type conversions, side effect analysis, and constant evaluation.
+These assumptions are validated using ECMAScript operations from [`oxc_ecmascript`](../../oxc_ecmascript), which implements spec-compliant behavior for type conversions, side effect analysis, and constant evaluation.
 
 ## Core Assumptions
 

--- a/crates/oxc_minifier/docs/CLAUDE.md
+++ b/crates/oxc_minifier/docs/CLAUDE.md
@@ -41,7 +41,8 @@ src/
 just test           # Unit tests
 just minsize        # Size benchmarks (PRIMARY METRIC)
 cargo coverage      # Conformance tests
-just e2e           # End-to-end tests
+pnpm --filter "./napi/minify" --filter "./napi/transform" run build-test
+pnpm --dir tasks/e2e test # End-to-end tests
 just ready         # Run before committing
 ```
 
@@ -116,7 +117,7 @@ fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'
 
 ```bash
 # Debug conformance failures
-cargo coverage -- --debug
+cargo coverage --debug
 
 # Test single file
 cargo run -p oxc_minifier --example minifier test.js

--- a/crates/oxc_minifier/docs/CORRECTNESS.md
+++ b/crates/oxc_minifier/docs/CORRECTNESS.md
@@ -19,16 +19,14 @@ Run conformance tests:
 # Run all conformance tests
 cargo coverage
 
-# Run specific suite
-cargo coverage js    # test262
-cargo coverage babel # Babel tests
-cargo coverage ts    # TypeScript tests
+# Run minifier conformance tests (test262 and Babel)
+cargo coverage minifier
 
 # Debug mode
-cargo coverage -- --debug
+cargo coverage minifier --debug
 
-# Filter specific tests
-cargo coverage -- --filter "test-name"
+# Filter by test file path
+cargo coverage minifier --filter "path/to/test.js"
 ```
 
 ### Size Tracking

--- a/crates/oxc_minifier/docs/ROADMAP.md
+++ b/crates/oxc_minifier/docs/ROADMAP.md
@@ -54,4 +54,4 @@
 - Performance profiling and optimization
 - Documentation improvements
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines.

--- a/tasks/coverage/README.md
+++ b/tasks/coverage/README.md
@@ -13,18 +13,20 @@ just submodules
 ```bash
 # full run
 cargo coverage
-cargo coverage js # for test262
-cargo coverage babel # for babel
-cargo coverage ts # for typescript
+
+# run a single tool against its supported conformance suites
+cargo coverage parser
+cargo coverage transformer
+cargo coverage minifier
 
 # run in watch
-cargo watch -x 'coverage js'
+cargo watch -x 'coverage minifier'
 
 # filter for a file path
-cargo watch -x 'coverage js --filter filter-file-path'
+cargo watch -x 'coverage minifier --filter filter-file-path'
 
 # find crash scene by turning off rayon and print out the test cases in serial
-cargo coverage -- --debug
+cargo coverage --debug
 
 # Run after submodules are updated
 UPDATE_SNAPSHOT=1 just c


### PR DESCRIPTION
Updates the minifier documentation to use supported validation commands and fixes broken relative links. Also refreshes the coverage task README so it no longer advertises removed suite selectors.