### PR TITLE
feat(linter): add exemption list for reportUnusedDisableDirectives

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -815,6 +815,17 @@ export interface OxlintOptions {
    */
   reportUnusedDisableDirectives?: AllowWarnDeny;
   /**
+   * Rule ids that are exempt from unused-disable-directive reporting.
+   *
+   * A disable directive that suppresses no violation is normally reported when
+   * `reportUnusedDisableDirectives` is enabled. Rules listed here are skipped, so contributors
+   * can add disable directives for an in-flight rule (e.g. during a large-scale migration)
+   * without them turning into "unused directive" errors.
+   *
+   * Only supported in the root configuration file.
+   */
+  reportUnusedDisableDirectivesExempt?: string[];
+  /**
    * Whether oxlint should respect `eslint-disable*` and `eslint-enable*`
    * directives in addition to its native `oxlint-*` directives.
    *

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -453,6 +453,9 @@ impl CliRunner {
                 },
             }
         };
+        let report_unused_directives_exempt: Vec<String> =
+            config_store.report_unused_disable_directives_exempt().to_vec();
+
         let (mut diagnostic_service, tx_error) = Self::get_diagnostic_service(
             &output_formatter,
             &warning_options,
@@ -549,7 +552,11 @@ impl CliRunner {
 
         match lint_result {
             Ok(lint_runner) => {
-                lint_runner.report_unused_directives(report_unused_directives, &tx_error);
+                lint_runner.report_unused_directives(
+                    report_unused_directives,
+                    &report_unused_directives_exempt,
+                    &tx_error,
+                );
             }
             Err(err) => {
                 print_and_flush_stdout(stdout, &format!("{err}\n"));

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -388,6 +388,17 @@ impl ConfigStore {
         self.base.base.config.options.report_unused_disable_directives
     }
 
+    /// Rule ids exempt from unused-disable-directive reporting, from the root config.
+    pub fn report_unused_disable_directives_exempt(&self) -> &[String] {
+        self.base
+            .base
+            .config
+            .options
+            .report_unused_disable_directives_exempt
+            .as_deref()
+            .unwrap_or(&[])
+    }
+
     /// Whether eslint-style disable directives are respected.
     pub fn respect_eslint_disable_directives(&self) -> bool {
         self.base.base.config.options.respect_eslint_disable_directives.unwrap_or(true)

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -57,6 +57,16 @@ pub struct OxlintOptions {
     /// Only supported in the root configuration file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub report_unused_disable_directives: Option<AllowWarnDeny>,
+    /// Rule ids that are exempt from unused-disable-directive reporting.
+    ///
+    /// A disable directive that suppresses no violation is normally reported when
+    /// `reportUnusedDisableDirectives` is enabled. Rules listed here are skipped, so contributors
+    /// can add disable directives for an in-flight rule (e.g. during a large-scale migration)
+    /// without them turning into "unused directive" errors. 
+    ///
+    /// Only supported in the root configuration file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report_unused_disable_directives_exempt: Option<Vec<String>>,
     /// Whether oxlint should respect `eslint-disable*` and `eslint-enable*`
     /// directives in addition to its native `oxlint-*` directives.
     ///
@@ -74,6 +84,7 @@ impl OxlintOptions {
             && self.deny_warnings.is_none()
             && self.max_warnings.is_none()
             && self.report_unused_disable_directives.is_none()
+            && self.report_unused_disable_directives_exempt.is_none()
             && self.respect_eslint_disable_directives.is_none()
     }
 
@@ -87,6 +98,10 @@ impl OxlintOptions {
             report_unused_disable_directives: self
                 .report_unused_disable_directives
                 .or(other.report_unused_disable_directives),
+            report_unused_disable_directives_exempt: self
+                .report_unused_disable_directives_exempt
+                .clone()
+                .or_else(|| other.report_unused_disable_directives_exempt.clone()),
             respect_eslint_disable_directives: self
                 .respect_eslint_disable_directives
                 .or(other.respect_eslint_disable_directives),
@@ -641,6 +656,15 @@ mod test {
         )
         .unwrap();
         assert_eq!(config.options.respect_eslint_disable_directives, Some(true));
+
+        let config: Oxlintrc = serde_json::from_value(json!({
+            "options": { "reportUnusedDisableDirectivesExempt": ["no-console", "@scope/plugin/rule"] }
+        }))
+        .unwrap();
+        assert_eq!(
+            config.options.report_unused_disable_directives_exempt.as_deref(),
+            Some(["no-console".to_string(), "@scope/plugin/rule".to_string()].as_slice())
+        );
     }
 
     #[test]

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -378,10 +378,11 @@ impl<'a> ContextHost<'a> {
     }
 
     /// report unused enable/disable directives, add these as Messages to diagnostics
-    pub fn report_unused_directives(&self, rule_severity: Severity) {
+    pub fn report_unused_directives(&self, rule_severity: Severity, exempt: &[String]) {
         // report unused disable
         // relate to lint result, check after linter run finish
-        let unused_disable_comments = self.disable_directives().collect_unused_disable_comments();
+        let unused_disable_comments =
+            self.disable_directives().collect_unused_disable_comments_filtered(exempt);
         let fix_message = "remove unused disable directive";
         let source_text = self.source_text();
 

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -373,6 +373,13 @@ impl DisableDirectives {
     }
 
     pub fn collect_unused_disable_comments(&self) -> Vec<DisableRuleComment> {
+        self.collect_unused_disable_comments_filtered(&[])
+    }
+
+    pub fn collect_unused_disable_comments_filtered(
+        &self,
+        exempt: &[String],
+    ) -> Vec<DisableRuleComment> {
         let used = self.used_disable_comments.borrow();
 
         self.intervals
@@ -401,6 +408,10 @@ impl DisableDirectives {
                         }
                         match &interval.val {
                             DisabledRule::Single { rule_name, name_span, .. } => {
+                                // Skip rules exempt from unused-directive reporting.
+                                if exempt.contains(rule_name) {
+                                    return None;
+                                }
                                 Some(RuleCommentRule {
                                     directive_prefix: interval.val.directive_prefix(),
                                     rule_name: rule_name.clone(),
@@ -1350,12 +1361,14 @@ semi*/
 /// # Arguments
 /// * `directives` - The disable directives to check for unused comments
 /// * `severity` - The severity level (Warn or Deny) for the diagnostics
+/// * `exempt` - Rule ids that must not be reported as unused directives
 ///
 /// # Returns
 /// A vector of diagnostics for all unused directives
 pub fn create_unused_directives_diagnostics(
     directives: &DisableDirectives,
     severity: crate::AllowWarnDeny,
+    exempt: &[String],
 ) -> Vec<oxc_diagnostics::OxcDiagnostic> {
     use oxc_diagnostics::OxcDiagnostic;
 
@@ -1368,7 +1381,7 @@ pub fn create_unused_directives_diagnostics(
     };
 
     // Report unused disable comments
-    let unused_disable = directives.collect_unused_disable_comments();
+    let unused_disable = directives.collect_unused_disable_comments_filtered(exempt);
     for unused_comment in unused_disable {
         let span = unused_comment.span;
         match unused_comment.r#type {
@@ -2123,5 +2136,36 @@ function test() {
             directives.contains("export", export_span),
             "`import/export` directive must suppress the `export` rule"
         );
+    }
+
+    #[test]
+    fn exempt_rules_are_not_reported_as_unused() {
+        let allocator = Allocator::default();
+        let exempt = ["no-console".to_string()];
+
+        let build = |source_text: &str| {
+            let semantic = process_source(&allocator, source_text);
+            DisableDirectivesBuilder::new().build(semantic.source_text(), semantic.comments())
+        };
+
+        // A single-rule directive whose only rule is exempt is dropped entirely,
+        // but is still reported when the rule is not exempt.
+        let directives = build("// oxlint-disable-next-line no-console\nconst a = 1;\n");
+        assert!(directives.collect_unused_disable_comments_filtered(&exempt).is_empty());
+        assert_eq!(directives.collect_unused_disable_comments().len(), 1);
+
+        // A directive mixing an exempt and a non-exempt rule still reports the non-exempt rule.
+        let directives = build("// oxlint-disable-next-line no-console, no-debugger\nconst a = 1;\n");
+        let unused = directives.collect_unused_disable_comments_filtered(&exempt);
+        assert_eq!(unused.len(), 1);
+        let RuleCommentType::Single(rules) = &unused[0].r#type else {
+            panic!("expected the surviving non-exempt rule to be reported individually");
+        };
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_name, "no-debugger");
+
+        // A directive naming only non-exempt rules is unaffected.
+        let directives = build("// oxlint-disable-next-line no-debugger\nconst a = 1;\n");
+        assert_eq!(directives.collect_unused_disable_comments_filtered(&exempt).len(), 1);
     }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -499,7 +499,10 @@ impl Linter {
         {
             ctx_host.rewind_sub_hosts();
             loop {
-                ctx_host.report_unused_directives(severity.into());
+                ctx_host.report_unused_directives(
+                    severity.into(),
+                    self.config.report_unused_disable_directives_exempt(),
+                );
 
                 if !ctx_host.next_sub_host() {
                     break;

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -88,12 +88,18 @@ impl DirectivesStore {
     ///
     /// # Panics
     /// Panics if the mutex is poisoned or if sending to the error channel fails.
-    pub fn report_unused(&self, severity: AllowWarnDeny, cwd: &Path, tx_error: &DiagnosticSender) {
+    pub fn report_unused(
+        &self,
+        severity: AllowWarnDeny,
+        exempt: &[String],
+        cwd: &Path,
+        tx_error: &DiagnosticSender,
+    ) {
         use crate::create_unused_directives_diagnostics;
 
         let map = self.map.lock().expect("DirectivesStore mutex poisoned in report_unused");
         for (path, directives) in map.iter() {
-            let diagnostics = create_unused_directives_diagnostics(directives, severity);
+            let diagnostics = create_unused_directives_diagnostics(directives, severity, exempt);
 
             if !diagnostics.is_empty() {
                 let source_text = std::fs::read_to_string(path.as_path()).unwrap_or_default();
@@ -320,10 +326,11 @@ impl LintRunner {
     pub fn report_unused_directives(
         &self,
         severity: Option<AllowWarnDeny>,
+        exempt: &[String],
         tx_error: &DiagnosticSender,
     ) {
         if let Some(severity) = severity {
-            self.directives_store.report_unused(severity, &self.cwd, tx_error);
+            self.directives_store.report_unused(severity, exempt, &self.cwd, tx_error);
         }
     }
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -17074,6 +17074,14 @@
           ],
           "markdownDescription": "Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).\n\nEquivalent to passing `--report-unused-disable-directives-severity` on the CLI.\nCLI flags take precedence over this value when both are set.\nOnly supported in the root configuration file."
         },
+        "reportUnusedDisableDirectivesExempt": {
+          "description": "Rule ids that are exempt from unused-disable-directive reporting.\n\nA disable directive that suppresses no violation is normally reported when\n`reportUnusedDisableDirectives` is enabled. Rules listed here are skipped, so contributors\ncan add disable directives for an in-flight rule (e.g. during a large-scale migration)\nwithout them turning into \"unused directive\" errors.\n\nOnly supported in the root configuration file.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Rule ids that are exempt from unused-disable-directive reporting.\n\nA disable directive that suppresses no violation is normally reported when\n`reportUnusedDisableDirectives` is enabled. Rules listed here are skipped, so contributors\ncan add disable directives for an in-flight rule (e.g. during a large-scale migration)\nwithout them turning into \"unused directive\" errors.\n\nOnly supported in the root configuration file."
+        },
         "respectEslintDisableDirectives": {
           "description": "Whether oxlint should respect `eslint-disable*` and `eslint-enable*`\ndirectives in addition to its native `oxlint-*` directives.\n\nDefaults to `true`.\nOnly supported in the root configuration file.",
           "type": "boolean",


### PR DESCRIPTION
adds a new optional root-config option `reportUnusedDisableDirectivesExempt`, which allows a specific set of rules to never be reported as unused `oxlint-disable` directives, even if `reportUnusedDisableDirectives` is enabled

justification: This makes it easier to enable new rules in a large codebase with high commit volume. Temporarily exempting a rule from `reportUnusedDisableDirectives` can prevent a race that breaks lint.

In eslint this feature was possible to implement via a thin wrapper on the node cli, but oxlint doesn't have this and would require some janky json post-processing

please note that AI was used to assist the writing of this change. all changes were manually audited and tested

### testing
new tests 
* `disable_directives::exempt_rules_are_not_reported_as_unused`
* test for new config option

```
cargo clippy -p oxc_linter --all-targets
cargo test -p oxc_linter config::oxlintrc
cargo test -p oxc_linter disable_directives
```
all pass cleanly

### intentionally left out
this option is config-only, no CLI flag (`--report-unused-disable-directives-exempt`), but I can add this if desired