### PR TITLE
build(vscode): VS Code settings use `--all-features`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,13 @@
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
+  // Analyze and check with all features enabled, matching the `ck` and `lint` aliases
+  // in `.cargo/config.toml` which `just check` / `just lint` / CI use.
+  // Without this, rust-analyzer only sees default features, so feature-gated code gets
+  // no completions, no jump-to-definition, and no diagnostics.
+  // `rust-analyzer.check.features` defaults to this setting, so it covers `cargo check`
+  // and `cargo clippy` on save too.
+  "rust-analyzer.cargo.features": "all",
   // Exclude huge gitignored submodules and `node_modules` from rust-analyzer's file scan -
   // it does not respect `.gitignore`.
   // Skipping these directories (500k+ files) speeds up server startup and reduces memory use.


### PR DESCRIPTION
Some code in Oxc repo is Cargo feature-gated - most notably all the code in `oxc_data_structures`, but also bits and pieces all over the place.

Currently, when using VS Code, Rust Analyzer only gives you jump-to-definition etc on code which is part of default features set. Code that's gated behind a Cargo feature is "dark" to RA. Ditto `cargo check` and Clippy which are run on save in VS Code. This makes working on feature-gated code slow and annoying.

This PR alters the default VS Code settings for the repo to run Rust Analyzer, check, and Clippy within VS Code with the equivalent of `--all-features`. This matches what `just check` / `cargo ck` and `just lint` do.

This also has a beneficial side effect:

RA shares `target` directory with the terminal. In a workflow where you're using RA and also running `just check` / `just lint` regularly (which agents do), previously each would compile separately with different settings. Now they all use the same settings, so share the same build artifacts. This reduces both compile/check/lint time, and reduces the speed at which `target` directory grows.