### PR TITLE
test(all): run conformance with `panic = "unwind"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,17 +337,14 @@ debug = true # Include maximum amount of debug information
 # Profile for `cargo coverage`
 [profile.coverage]
 inherits = "release"
+# The conformance harnesses catch panics.
+# Inheriting the release profile's `panic = "abort"` would prevent `catch_unwind` working.
+panic = "unwind"
 opt-level = 2 # Compile faster
 codegen-units = 256 # Compile faster
 lto = "thin" # Faster compile time with thin LTO
 debug-assertions = true # Make sure `debug_assert!`s pass
 overflow-checks = true # Catch arithmetic overflow errors
-
-# Profile for the codegen conformance addon. It catches panics and converts them to JS errors, so
-# it must unwind rather than inherit the release profile's `panic = "abort"` setting.
-[profile.codegen-conformance]
-inherits = "coverage"
-panic = "unwind"
 
 # Profile for linting with release mode-like settings.
 # Catches lint errors which only appear in release mode.

--- a/tasks/codegen_conformance/package.json
+++ b/tasks/codegen_conformance/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "scripts": {
     "build-dev": "napi build --esm --platform",
-    "build-test": "pnpm run build-dev --profile codegen-conformance",
+    "build-test": "pnpm run build-dev --profile coverage",
     "build": "pnpm run build-test"
   },
   "devDependencies": {


### PR DESCRIPTION
Conformance tests for `oxc_lexer` crate rely on using `catch_unwind` to catch panics and report them, rather than crashing the whole process. Currently this doesn't work because conformance is compiled with `panic = "abort"` (inherited from `release` profile).

This PR fixes that by adding `panic = "unwind"` to `coverage` profile.

I've measured the time it takes to run conformance locally before/after this change, and the difference is within noise (+/- 2%), so this seems to have no adverse effects.

`codegen-conformance` profile only existed to add `panic = "unwind"` too, so after this change it becomes identical to `coverage` profile. That makes it redundant, so this PR removes it in favour of just using `coverage` everywhere.