### PR TITLE
ci(coverage): error if `cargo coverage` passed unknown argument

### DIFF
--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -57,6 +57,7 @@ fn main() {
         "estree_tokens" => app_args.run_estree_tokens(&load()),
         "types" => app_args.run_types(&load()),
         "all" => app_args.run_all_with(&load()),
-        _ => app_args.run_all(),
+        "default" => app_args.run_all(),
+        task => panic!("Unknown coverage task: {task:?}"),
     }
 }


### PR DESCRIPTION
Small fix to `cargo coverage`.

Previously a typo e.g. `cargo coverage prser` would fall through to the catch-all arm and would run all coverage tasks.

Instead, this PR makes it panic with an error `Unknown coverage task: "prser"`. This ensures you are running what you think you are.