### PR TITLE
refactor(coverage/lexer): clarify code and fix clippy warnings

### DIFF
--- a/tasks/coverage/src/lexer_diff.rs
+++ b/tasks/coverage/src/lexer_diff.rs
@@ -1,172 +1,40 @@
+//! Differential test of the incubating `oxc_lexer` crate against the parser's own lexer.
+//!
+//! Each fixture is lexed twice. The parser is the oracle: its token stream is what `oxc_lexer`
+//! must reproduce. Trivia and `Eof` are dropped from `oxc_lexer`'s output first, because the
+//! parser never surfaces them as tokens.
+//!
+//! Sources that both sides reject identically still count as a pass - see [`lex_diff`].
+
 use std::{
     fmt::Write,
+    iter,
     panic::{AssertUnwindSafe, catch_unwind},
 };
 
 use oxc::{
     allocator::Allocator,
-    diagnostics::OxcDiagnostic,
-    parser::{Parser, config::TokensParserConfig},
-    span::SourceType,
+    diagnostics::{LabeledSpan, OxcDiagnostic},
+    parser::{Parser, Token, config::TokensParserConfig},
+    span::{SourceType, Span},
 };
+use oxc_lexer::{LexOptions, PAD, TokenKind, diagnostics::to_oxc_diagnostic};
 use rayon::prelude::*;
 
 use crate::{
     BabelFile, CoverageResult, MiscFile, Test262File, TestResult, TypeScriptFile, test262::TestFlag,
 };
 
-fn lexer_stream(
-    code: &str,
-    source_type: SourceType,
-) -> (Vec<(u32, u32)>, Vec<oxc_lexer::Diagnostic>) {
-    let n = code.len();
-    // `lex_utf8` requires >= n + 64 bytes of trailing padding.
-    let mut buf = Vec::with_capacity(n + 64);
-    buf.extend_from_slice(code.as_bytes());
-    buf.resize(n + 64, 0);
-
-    let mut options = oxc_lexer::default_options();
-    options.source_type_module = source_type.is_module();
-    options.jsx = source_type.is_jsx();
-    options.ts = source_type.is_typescript();
-
-    let (result, arena) = oxc_lexer::lex_utf8(&buf, n as u32, options);
-    let kinds = result.tok_kinds(&arena);
-    let token_spans = result.tok_spans(&arena);
-
-    let mut spans = Vec::with_capacity(kinds.len());
-    for (i, &kind) in kinds.iter().enumerate() {
-        if kind == oxc_lexer::TokenKind::Eof || kind.is_trivia() {
-            continue;
-        }
-        spans.push((token_spans[i].start, token_spans[i].end));
-    }
-    let mut diags = result.diagnostics().to_vec();
-    diags.sort_by_key(|d| d.off);
-    (spans, diags)
-}
-
-fn oracle_stream(
-    code: &str,
-    source_type: SourceType,
-) -> Option<(Vec<(u32, u32)>, Vec<OxcDiagnostic>)> {
-    let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, code, source_type).with_config(TokensParserConfig).parse();
-    if ret.panicked {
-        return None;
-    }
-    let spans = ret.tokens.iter().map(|t| (t.start(), t.end())).collect();
-    let errors = ret.diagnostics.errors().cloned().collect();
-    Some((spans, errors))
-}
-
-fn diag_key(d: &OxcDiagnostic) -> (String, Vec<(u32, u32)>) {
-    let labels = d
-        .labels
-        .as_ref()
-        .iter()
-        .map(|l| (l.offset(), l.offset().saturating_add(l.len())))
-        .collect();
-    (d.message.to_string(), labels)
-}
-
-fn label_start(d: &OxcDiagnostic) -> u32 {
-    d.labels.as_ref().first().map_or(0, |l| l.offset())
-}
-
-fn prefix_matches(ours: &[(u32, u32)], oracle: &[(u32, u32)], err_start: u32) -> bool {
-    for (a, b) in ours.iter().zip(oracle.iter()) {
-        if a.1 > err_start || b.1 > err_start {
-            break;
-        }
-        if a != b {
-            return false;
-        }
-    }
-    true
-}
-
-fn fmt_spans(spans: &[(u32, u32)], code: &str) -> String {
-    let mut out = String::new();
-    for &(start, end) in spans {
-        let slice = code.get(start as usize..end as usize).unwrap_or("<out-of-bounds>");
-        let _ = writeln!(out, "{start}..{end} {slice:?}");
-    }
-    out
-}
-
-/// One-line rendering of a diagnostic for mismatch output.
-fn fmt_diag(d: &OxcDiagnostic) -> String {
-    let (message, labels) = diag_key(d);
-    let spans = labels.iter().map(|(s, e)| format!("{s}..{e}")).collect::<Vec<_>>().join(", ");
-    format!("{message:?} @ [{spans}]")
-}
-
-/// Token-stream mismatch, with each side's first diagnostic appended so a
-/// failed error-case fallback shows *why* diagnostic parity did not hold.
-fn token_mismatch(
-    code: &str,
-    ours: &[(u32, u32)],
-    oracle: &[(u32, u32)],
-    ours_first: Option<&OxcDiagnostic>,
-    parser_first: Option<&OxcDiagnostic>,
-) -> TestResult {
-    let mut actual = fmt_spans(ours, code);
-    let mut expected = fmt_spans(oracle, code);
-    let none = || "(none)".to_string();
-    let _ = writeln!(actual, "first diagnostic: {}", ours_first.map_or_else(none, fmt_diag));
-    let _ = writeln!(expected, "first diagnostic: {}", parser_first.map_or_else(none, fmt_diag));
-    TestResult::Mismatch("Tokens", actual, expected)
-}
-
-fn lex_diff(code: &str, source_type: SourceType) -> TestResult {
-    let (oracle, parser_errors) =
-        match catch_unwind(AssertUnwindSafe(|| oracle_stream(code, source_type))) {
-            Ok(Some(stream)) => stream,
-            Ok(None) | Err(_) => return TestResult::Passed,
-        };
-
-    let (ours, our_diags) = match catch_unwind(AssertUnwindSafe(|| lexer_stream(code, source_type)))
-    {
-        Ok(stream) => stream,
-        Err(_) => return TestResult::ParseError("oxc_lexer panicked".to_string(), true),
-    };
-
-    let ours_first = our_diags.first().map(|d| oxc_lexer::diagnostics::to_oxc_diagnostic(d, code));
-    let parser_first =
-        parser_errors.iter().enumerate().min_by_key(|(i, e)| (label_start(e), *i)).map(|(_, e)| e);
-
-    if ours == oracle {
-        return match (&parser_first, &ours_first) {
-            (None, Some(diag)) => TestResult::Mismatch(
-                "Diagnostics",
-                format!("first diagnostic: {}\n", fmt_diag(diag)),
-                "(parser reported no errors)\n".to_string(),
-            ),
-            _ => TestResult::Passed,
-        };
-    }
-    if let (Some(parser_diag), Some(our_diag)) = (parser_first, &ours_first) {
-        if diag_key(our_diag) == diag_key(parser_diag)
-            && prefix_matches(&ours, &oracle, label_start(parser_diag))
-        {
-            return TestResult::Passed;
-        }
-    }
-
-    token_mismatch(code, &ours, &oracle, ours_first.as_ref(), parser_first)
-}
-
 pub fn run_lexer_test262(files: &[Test262File]) -> Vec<CoverageResult> {
     files
         .par_iter()
-        .map(|f| {
-            let mut source_type = SourceType::cjs().with_script(true);
-            if f.meta.flags.contains(&TestFlag::Module) {
+        .map(|file| {
+            let mut source_type = SourceType::script();
+            if file.meta.flags.contains(&TestFlag::Module) {
                 source_type = source_type.with_module(true);
             }
-            let result = lex_diff(&f.code, source_type);
-            CoverageResult { path: f.path.clone(), should_fail: false, result }
+            let result = lex_diff(&file.code, source_type);
+            CoverageResult { path: file.path.clone(), should_fail: false, result }
         })
         .collect()
 }
@@ -174,9 +42,9 @@ pub fn run_lexer_test262(files: &[Test262File]) -> Vec<CoverageResult> {
 pub fn run_lexer_babel(files: &[BabelFile]) -> Vec<CoverageResult> {
     files
         .par_iter()
-        .map(|f| {
-            let result = lex_diff(&f.code, f.source_type);
-            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        .map(|file| {
+            let result = lex_diff(&file.code, file.source_type);
+            CoverageResult { path: file.path.clone(), should_fail: false, result }
         })
         .collect()
 }
@@ -184,10 +52,10 @@ pub fn run_lexer_babel(files: &[BabelFile]) -> Vec<CoverageResult> {
 pub fn run_lexer_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
     files
         .par_iter()
-        .map(|f| {
-            let source_type = SourceType::from_path(&f.path).unwrap_or_default();
-            let result = lex_diff(&f.code, source_type);
-            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        .map(|file| {
+            let source_type = SourceType::from_path(&file.path).unwrap_or_default();
+            let result = lex_diff(&file.code, source_type);
+            CoverageResult { path: file.path.clone(), should_fail: false, result }
         })
         .collect()
 }
@@ -195,9 +63,158 @@ pub fn run_lexer_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
 pub fn run_lexer_misc(files: &[MiscFile]) -> Vec<CoverageResult> {
     files
         .par_iter()
-        .map(|f| {
-            let result = lex_diff(&f.code, f.source_type);
-            CoverageResult { path: f.path.clone(), should_fail: false, result }
+        .map(|file| {
+            let result = lex_diff(&file.code, file.source_type);
+            CoverageResult { path: file.path.clone(), should_fail: false, result }
         })
         .collect()
+}
+
+fn lex_diff(code: &str, source_type: SourceType) -> TestResult {
+    // If parser cannot parse `code`, there is nothing to compare against, so skip fixture
+    let Ok(Some((old_spans, old_error))) =
+        catch_unwind(AssertUnwindSafe(|| parser_stream(code, source_type)))
+    else {
+        return TestResult::Passed;
+    };
+
+    let Ok((new_spans, new_error)) =
+        catch_unwind(AssertUnwindSafe(|| lexer_stream(code, source_type)))
+    else {
+        return TestResult::ParseError("`oxc_lexer` panicked".to_string(), true);
+    };
+
+    if new_spans == old_spans {
+        return match (&old_error, &new_error) {
+            (None, Some(new_error)) => TestResult::Mismatch(
+                "Diagnostics",
+                format!("first error: {}\n", fmt_diagnostic(new_error)),
+                "(parser reported no errors)\n".to_string(),
+            ),
+            _ => TestResult::Passed,
+        };
+    }
+
+    if let (Some(old_error), Some(new_error)) = (&old_error, &new_error)
+        && diagnostic_key(new_error) == diagnostic_key(old_error)
+        && prefix_matches(&new_spans, &old_spans, label_start(old_error))
+    {
+        return TestResult::Passed;
+    }
+
+    token_mismatch(code, &new_spans, &old_spans, new_error.as_ref(), old_error.as_ref())
+}
+
+/// Get token stream from `oxc_lexer`, plus the first error (if any).
+fn lexer_stream(code: &str, source_type: SourceType) -> (Vec<Span>, Option<OxcDiagnostic>) {
+    let len = code.len();
+    let len_u32 = u32::try_from(len).expect("source longer than `u32::MAX`");
+
+    // `lex_utf8` requires at least `PAD` bytes of zeroed padding past the end of the source
+    let mut buf = Vec::with_capacity(len + PAD);
+    buf.extend_from_slice(code.as_bytes());
+    buf.resize(len + PAD, 0);
+
+    let options = LexOptions {
+        source_type_module: source_type.is_module(),
+        jsx: source_type.is_jsx(),
+        ts: source_type.is_typescript(),
+        ..Default::default()
+    };
+
+    let (result, arena) = oxc_lexer::lex_utf8(&buf, len_u32, options);
+    let kinds = result.tok_kinds(&arena);
+    let token_spans = result.tok_spans(&arena);
+    assert_eq!(kinds.len(), token_spans.len());
+
+    let spans = iter::zip(kinds, token_spans)
+        .filter_map(|(&kind, &span)| match kind {
+            TokenKind::Eof => None,
+            _ if kind.is_trivia() => None,
+            _ => Some(span),
+        })
+        .collect();
+
+    let error = result
+        .diagnostics()
+        .iter()
+        .min_by_key(|error| error.off)
+        .map(|error| to_oxc_diagnostic(error, code));
+
+    (spans, error)
+}
+
+/// Get token stream from `oxc_parser`, plus the first error (if any).
+fn parser_stream(
+    code: &str,
+    source_type: SourceType,
+) -> Option<(Vec<Span>, Option<OxcDiagnostic>)> {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, code, source_type).with_config(TokensParserConfig).parse();
+    if ret.panicked {
+        return None;
+    }
+
+    let spans = ret.tokens.iter().map(Token::span).collect();
+    let error = ret.diagnostics.into_iter().min_by_key(label_start);
+
+    Some((spans, error))
+}
+
+fn diagnostic_key(error: &OxcDiagnostic) -> (String, Vec<Span>) {
+    let labels = error.labels.iter().map(LabeledSpan::span).collect();
+    (error.message.to_string(), labels)
+}
+
+fn label_start(error: &OxcDiagnostic) -> u32 {
+    error.labels.as_ref().first().map_or(0, LabeledSpan::offset)
+}
+
+fn prefix_matches(new_spans: &[Span], old_spans: &[Span], err_start: u32) -> bool {
+    for (new_span, old_span) in iter::zip(new_spans, old_spans) {
+        if new_span.end > err_start || old_span.end > err_start {
+            break;
+        }
+        if new_span != old_span {
+            return false;
+        }
+    }
+    true
+}
+
+fn fmt_spans(spans: &[Span], code: &str) -> String {
+    let mut out = String::new();
+    for &span in spans {
+        let slice = code.get(span.start as usize..span.end as usize).unwrap_or("<out-of-bounds>");
+        writeln!(out, "{}..{} {:?}", span.start, span.end, slice).unwrap();
+    }
+    out
+}
+
+/// One-line rendering of a diagnostic for mismatch output.
+fn fmt_diagnostic(error: &OxcDiagnostic) -> String {
+    let (message, labels) = diagnostic_key(error);
+    let spans = labels
+        .iter()
+        .map(|&span| format!("{}..{}", span.start, span.end))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{message:?} @ [{spans}]")
+}
+
+/// Token-stream mismatch, with each side's first diagnostic appended so a
+/// failed error-case fallback shows *why* diagnostic parity did not hold.
+fn token_mismatch(
+    code: &str,
+    new_spans: &[Span],
+    old_spans: &[Span],
+    new_error: Option<&OxcDiagnostic>,
+    old_error: Option<&OxcDiagnostic>,
+) -> TestResult {
+    let mut actual = fmt_spans(new_spans, code);
+    let mut expected = fmt_spans(old_spans, code);
+    let none = || "(none)".to_string();
+    writeln!(actual, "first error: {}", new_error.map_or_else(none, fmt_diagnostic)).unwrap();
+    writeln!(expected, "first error: {}", old_error.map_or_else(none, fmt_diagnostic)).unwrap();
+    TestResult::Mismatch("Tokens", actual, expected)
 }


### PR DESCRIPTION
Refactor the conformance tester for lexer.

The diff is large, as I've reordered the code so it now reads top-to-bottom, but it's pure refactor. The actual logic is exactly as it was before - just moved things around, renamed vars, shortened code etc.

This also fixes some Clippy warnings which were present before, but hidden because this code is gated behind `target_feature = "avx2"`. That changes in next PR #26263, at which point CI would have started failing if the warnings weren't fixed here first.