### PR TITLE
test(lexer): enable `oxc_lexer` conformance tests on all platforms

### DIFF
--- a/.cargo/lexer-simd.toml
+++ b/.cargo/lexer-simd.toml
@@ -1,0 +1,14 @@
+# Extra rustflags for building `oxc_lexer`'s SIMD core. Passed via `cargo --config` by the
+# `just test-lexer-simd` / `just conformance-lexer-simd` recipes - see the justfile.
+#
+# `avx2` and `bmi2` are not in the x86_64 baseline on any platform, so they have to be asked for explicitly,
+# even on an x86_64 host. Cargo joins `rustflags` arrays across config sources, so the per-target flags
+# in `config.toml` (`crt-static`, the LLD opt-out) are preserved, not replaced.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+avx2,+bmi2"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-feature=+avx2,+bmi2"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+avx2,+bmi2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ oxc_formatter_json = { path = "crates/oxc_formatter_json" } # JSON formatter
 oxc_formatter_tests = { path = "crates/oxc_formatter_tests" } # Formatter test infrastructure (fixture codegen + harness)
 oxc_formatter_yaml = { path = "crates/oxc_formatter_yaml" } # YAML formatter
 oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
-oxc_lexer = { path = "crates/oxc_lexer" } # JS/TS lexer (incubating; x86_64 SIMD, stub elsewhere)
+oxc_lexer = { path = "crates/oxc_lexer" } # JS/TS lexer (incubating; x86_64 SIMD core, scalar fallback)
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
 oxc_tasks_common = { path = "tasks/common" } # Task utilities

--- a/justfile
+++ b/justfile
@@ -147,6 +147,42 @@ ast:
 
 # Parser-specific commands will be added here as needed
 
+# ==================== LEXER ====================
+
+# `oxc_lexer` compiles to one of two implementations, chosen at build time:
+#
+# * SIMD core, on x86_64 with `avx2` + `bmi2` enabled
+# * Scalar fallback, everywhere else
+#
+# Both need testing, and they should produce identical results. Neither `avx2` nor `bmi2` is in the x86_64 baseline
+# on any platform, so reaching the SIMD core always means asking for them explicitly - even on an x86_64 host.
+# The flags live in `.cargo/lexer-simd.toml`, passed with `cargo --config`, which avoids shell quoting entirely
+# (this justfile runs PowerShell on Windows).
+#
+# `--target` is always passed, so that the flags land on the triple the config file names,
+# and so that the two builds get separate target dirs instead of invalidating each other.
+#
+# On an ARM host the SIMD build is cross-compiled and run under emulation - macOS provides that via Rosetta 2.
+# On ARM Linux or ARM Windows it will fail, loudly, when linking or running.
+_lexer-simd-target := if os() == "macos" { "x86_64-apple-darwin" } else if os() == "windows" { "x86_64-pc-windows-msvc" } else { "x86_64-unknown-linux-gnu" }
+_lexer-simd := "--target " + _lexer-simd-target + " --config .cargo/lexer-simd.toml"
+
+# Run `oxc_lexer`'s tests against the scalar fallback
+test-lexer *args='':
+  cargo test -p oxc_lexer {{args}}
+
+# Run `oxc_lexer`'s tests against the SIMD core
+test-lexer-simd *args='':
+  cargo test -p oxc_lexer {{_lexer-simd}} {{args}}
+
+# Run lexer conformance against the scalar fallback
+conformance-lexer *args='':
+  cargo run -p oxc_coverage --profile coverage --features lexer -- lexer {{args}}
+
+# Run lexer conformance against the SIMD core
+conformance-lexer-simd *args='':
+  cargo run -p oxc_coverage --profile coverage {{_lexer-simd}} --features lexer -- lexer {{args}}
+
 # ==================== LINTER ====================
 
 # oxlint release build

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -45,8 +45,12 @@ similar = { workspace = true }
 walkdir = { workspace = true }
 
 [features]
-# Differential lexer conformance. `oxc_lexer`'s SIMD core only exists on x86_64
-# with static AVX2/BMI2 (it compiles to an empty stub otherwise), so the harness
-# is opt-in and its cfg sites mirror the lexer's crate gate:
-#   RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo coverage --features lexer -- lexer
+# Differential lexer conformance, opt-in because it is slow and `oxc_lexer` is still incubating.
+# The harness runs against whichever of the lexer's two implementations the build selects:
+#
+# * SIMD core (x86_64 only): RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo coverage --features lexer -- lexer
+# * Scalar fallback:         cargo coverage --features lexer -- lexer
+#
+# `avx2`/`bmi2` are not in the x86_64 baseline on any platform, so the rustflags are required
+# to reach the SIMD core even on an x86_64 host.
 lexer = ["dep:oxc_lexer", "oxc_lexer/oxc_diagnostics"]

--- a/tasks/coverage/snapshots/lexer_babel.snap
+++ b/tasks/coverage/snapshots/lexer_babel.snap
@@ -1,0 +1,51 @@
+commit: 1eac4481
+
+lexer_babel Summary:
+AST Parsed     : 3976/3976 (100.00%)
+Positive Passed: 3953/3976 (99.42%)
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/01-regex/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/02-regex/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/03-regex/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/06-regex/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/331/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/426/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/450/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/451/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/context-division-after-expression/input.js
+
+Diagnostics: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2021/numeric-separator/valid-non-octal-exponents/input.js
+
+Diagnostics: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2021/numeric-separator/valid-non-octal-fragments/input.js
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends-expression-assertion/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/issue-7742/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/anonymous-function-generator/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-parameters/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/call-expression/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/decorator-call-expression/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/interface-heritage/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/new-expression/input.ts
+
+Tokens: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-nested/input.ts
+

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,0 +1,7 @@
+lexer_misc Summary:
+AST Parsed     : 248/248 (100.00%)
+Positive Passed: 246/248 (99.19%)
+Tokens: tasks/coverage/misc/pass/oxc-2674.tsx
+
+Tokens: tasks/coverage/misc/pass/swc-7187.ts
+

--- a/tasks/coverage/snapshots/lexer_test262.snap
+++ b/tasks/coverage/snapshots/lexer_test262.snap
@@ -1,0 +1,5 @@
+commit: be13516f
+
+lexer_test262 Summary:
+AST Parsed     : 52086/52086 (100.00%)
+Positive Passed: 52086/52086 (100.00%)

--- a/tasks/coverage/snapshots/lexer_typescript.snap
+++ b/tasks/coverage/snapshots/lexer_typescript.snap
@@ -1,0 +1,783 @@
+commit: b465fdbf
+
+lexer_typescript Summary:
+AST Parsed     : 12419/12419 (100.00%)
+Positive Passed: 12030/12419 (96.87%)
+Tokens: tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeNoLib.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/bindingPatternCannotBeOnlyInferenceSource.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/conditionalDoesntLeakUninstantiatedTypeParameter.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSpinForever.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualParamTypeVsNestedReturnTypeInference4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionReturnTypeFromUnion.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitLocalClassDeclarationMixin.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivatePromiseLikeInterface.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorthand.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/errorElaboration.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceInConditionalTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericInheritedDefaultConstructors.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions6.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrder.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/importTypeWithUnparenthesizedGenericFunctionParsed.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifiedSubstituteUnwrapped.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceContextualReturnTypeUnion2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInheritanceInstantiation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingOverloads.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignability.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/instantiateConstraintsToTypeArguments2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxComponentTypeErrors.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxElementType.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleLayer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/keywordInJsxIdentifier.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/longObjectInstantiationChain2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeGenericWithKnownKeys.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mappedTypeUnionConstraintInferences.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/maxConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mixinPrivateAndProtected.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/noExcessiveStackDepthError.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssignmentOnExportedGenericInterface1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceJSXEmit.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypeInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeRelations.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/recursiveTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/resolvingClassDeclarationWhenInBaseTypeResolution.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceContextualParameterTypesInGenerator1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTupleContext.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeInferenceWidening2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/slashBeforeVariableDeclaration1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/sourceMap-LineBreaks.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/thislessFunctionsNotContextSensitive3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataProps.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_incorrectThisType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration10.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck64.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propNameConstraining.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadErrors.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError4.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution2.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution7.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution4.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType3.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/jsx/unicodeEscapesInJsxtags.tsx
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens19.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/salsa/prototypePropertyAssignmentMergeWithInterfaceMethod.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/invalidMultipleVariableDeclarations.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleInvalidDecl.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringLiteralsAssignedToStringMappings.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDeferralInConditionalTypes.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingReduction.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestParameters3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeTupleEnd.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures4.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/arrayLiteralsWithRecursiveGenerics.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeInGenericConstraint.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownControlFlow.ts
+
+Tokens: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType2.ts
+

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -10,15 +10,9 @@ mod typescript;
 
 mod tools;
 
-// Mirrors `oxc_lexer`'s crate gate: the lexer compiles to an empty stub without
-// static AVX2/BMI2 x86_64, so the differential harness only exists where the
-// lexer does (`--all-features` builds must pass on every target).
-#[cfg(all(
-    feature = "lexer",
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    target_feature = "bmi2",
-))]
+// Gated by `lexer` Cargo feature, because `oxc_lexer` is still incubating.
+// `oxc_lexer` only supports little endian at present.
+#[cfg(all(feature = "lexer", target_endian = "little"))]
 mod lexer_diff;
 
 use std::{
@@ -373,26 +367,40 @@ impl AppArgs {
         }
     }
 
-    /// Differential lexer conformance: compare `oxc_lexer`'s significant-token
-    /// spans against the parser's token stream over the corpora. Opt-in (kept out
-    /// of `run_all`) — requires the `lexer` feature and a static AVX2/BMI2 x86_64
-    /// build of `oxc_lexer`.
-    #[cfg(all(
-        feature = "lexer",
-        target_arch = "x86_64",
-        target_feature = "avx2",
-        target_feature = "bmi2",
-    ))]
+    /// Differential lexer conformance.
+    ///
+    /// Compare `oxc_lexer`'s token spans against the parser's token stream over the corpora.
+    /// Opt-in (kept out of `run_all`) — requires `lexer` Cargo feature.
+    /// Runs against whichever of the lexer's two implementations the build selects -
+    /// the SIMD core on a static AVX2/BMI2 x86_64 build, the scalar fallback otherwise.
+    /// `oxc_lexer` only supports little endian at present.
+    ///
+    /// # Panics
+    /// Panics if `lexer` Cargo feature is not enabled, or on a big endian machine.
     pub fn run_lexer(&self, data: &TestData) {
-        self.run_tool("lexer_test262", TEST262_PATH, &data.test262, lexer_diff::run_lexer_test262);
-        self.run_tool("lexer_babel", BABEL_PATH, &data.babel, lexer_diff::run_lexer_babel);
-        self.run_tool(
-            "lexer_typescript",
-            TYPESCRIPT_PATH,
-            &data.typescript,
-            lexer_diff::run_lexer_typescript,
-        );
-        self.run_tool("lexer_misc", MISC_PATH, &data.misc, lexer_diff::run_lexer_misc);
+        #[cfg(all(feature = "lexer", target_endian = "little"))]
+        {
+            self.run_tool(
+                "lexer_test262",
+                TEST262_PATH,
+                &data.test262,
+                lexer_diff::run_lexer_test262,
+            );
+            self.run_tool("lexer_babel", BABEL_PATH, &data.babel, lexer_diff::run_lexer_babel);
+            self.run_tool(
+                "lexer_typescript",
+                TYPESCRIPT_PATH,
+                &data.typescript,
+                lexer_diff::run_lexer_typescript,
+            );
+            self.run_tool("lexer_misc", MISC_PATH, &data.misc, lexer_diff::run_lexer_misc);
+        }
+
+        #[cfg(not(all(feature = "lexer", target_endian = "little")))]
+        {
+            let _ = (self, data);
+            panic!("`lexer` conformance requires `lexer` Cargo feature and a little-endian system");
+        }
     }
 
     pub fn run_semantic(&self, data: &TestData) {

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -39,12 +39,6 @@ fn main() {
     let task = command.as_deref().unwrap_or("default");
     match task {
         "parser" => app_args.run_parser(&load()),
-        #[cfg(all(
-            feature = "lexer",
-            target_arch = "x86_64",
-            target_feature = "avx2",
-            target_feature = "bmi2",
-        ))]
         "lexer" => app_args.run_lexer(&load()),
         "semantic" => app_args.run_semantic(&load()),
         "codegen" => app_args.run_codegen(&load()),


### PR DESCRIPTION
`oxc_lexer` has 2 implementations:

1\. SIMD-based on x86_64 with AVX2.  
2\. Scalar/SWAR fallback which works on all platforms.

Both produce the same output.

This PR enables running the lexer conformance on either implementation. Which implementation is tested depends on what build flags are passed to `cargo coverage`.

It turns out that it's possible to test the SIMD implementation on Mac by compiling as x86_64, and running it under Rosetta 2.

This PR also adds `just` recipes to run tests and conformance on either implementation:

- `just test-lexer`
- `just test-lexer-simd`
- `just conformance-lexer`
- `just conformance-lexer-simd`

These commands should work correctly on any of Linux x86, Windows x86, Mac aarch64.