### PR TITLE
fix(formatter_css): print SCSS map consisntent with and without comment

### DIFF
--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -517,9 +517,9 @@ and in paren lists, call/`@include` arguments and `@mixin` parameters
 Prettier's output changes line, own-line to the last item's line, a `lineSuffix` artifact of its comma-group printing.
 Same-line trailing comments still glue (matching Prettier); moving an own-line comment up would destroy the author's visual grouping.
 
-## map-leading-comment-forced-break
+## map-leading-comment-layout
 
-- Why: cost
+- Why: uniform-rule (comment presence never changes layout)
 - Pin: `tests/fixtures/format/scss/map-comment-only.scss`
 
 ```scss
@@ -528,17 +528,17 @@ $b: (/* c */ a: 1,);
 
 /* ours */
 $b: (
-  /* c */ a: 1
+  /* c */ a: 1,
 );
 
 /* prettier */
 $b: (/* c */ a: 1);
 ```
 
-A map whose FIRST item is preceded by a block comment loses map-item-ness in Prettier
-(the comment becomes `groups[0]`, so `isKeyValuePairInParenGroupNode` fails) and inlines when it fits.
-We reproduce the loss for the trailing comma (dropped, like Prettier) but keep the forced break;
-matching the inline layout needs comment support in the soft map path.
+A map whose FIRST item is preceded by a block comment loses map-item-ness in Prettier:
+it inlines when it fits and drops the trailing comma.
+We print it as the same map without the comment (`$b: (a: 1,)`): one item per line, comma per `trailingComma`.
+A comment before a LATER item keeps both in Prettier too.
 
 ## comment-only-map-indent
 

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -273,7 +273,6 @@ pub(super) fn write_sass_map<'a>(
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         write!(f, hard_line_break());
         let source = f.context().source_text();
-        let mut first_item_has_leading_comment = false;
         for (i, item) in map.items.iter().enumerate() {
             if i > 0 {
                 value::write_group_comma(map.comma_spans.get(i - 1).map(|sp| to_span(sp).start), f);
@@ -305,9 +304,7 @@ pub(super) fn write_sass_map<'a>(
             // `//` comments and pairs that don't fit keep their own line.
             let item_start = to_span(item.span()).start;
             let item_width = to_span(item.span()).end - item_start;
-            let mut had_leading_comment = false;
             for &comment in f.context().comments().take_before(item_start) {
-                had_leading_comment = true;
                 let comment_width = comment.span.end - comment.span.start;
                 let fits = !value_is_block
                     && u32::from(f.options().indent_width.value()) + comment_width + 2 + item_width
@@ -318,9 +315,6 @@ pub(super) fn write_sass_map<'a>(
                 } else {
                     write!(f, " ");
                 }
-            }
-            if i == 0 {
-                first_item_has_leading_comment = had_leading_comment;
             }
             let key_is_block = is_paren_block(&item.key);
             if key_is_block && !value_is_block {
@@ -370,13 +364,9 @@ pub(super) fn write_sass_map<'a>(
                 write!(f, group(&indent(&pair)));
             }
         }
-        // A comment before the FIRST item drops the trailing comma:
-        // the comment becomes `groups[0]` of the paren group,
-        // so `isKeyValuePairInParenGroupNode` no longer sees a key-value pair and the group stops being an SCSS map item.
-        // A comment before a LATER item never does
-        // (Prettier keeps the comma there whether or not the source had one — required for idempotency).
-        let printed_comma = trailing && !first_item_has_leading_comment;
-        if printed_comma {
+        // NOTE: Comment presence never changes the comma (Prettier drops it after a leading comment on the FIRST item);
+        // see DIVERGENCES.md "map-leading-comment-layout".
+        if trailing {
             write!(f, ",");
         }
         // The comment goes to its own line only when BOTH a comma is printed
@@ -386,7 +376,7 @@ pub(super) fn write_sass_map<'a>(
                 map.comma_spans.get(map.items.len() - 1).map_or(u32::MAX, |sp| to_span(sp).start);
             // Only inside function/include arguments does the comment move
             // to the next slot; `$map:` declarations keep it attached.
-            let next_slot = printed_comma
+            let next_slot = trailing
                 && ctx.in_args
                 && f.context().comments().peek().is_some_and(|c| c.span.start > source_comma_start);
             if !next_slot {

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss
@@ -13,11 +13,17 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally. A comment before the FIRST item makes
-// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
-// being an SCSS map item and loses its trailing comma.
+// renders its leading comment normally. A comment before the FIRST item changes
+// nothing: `$with-block` prints like `$no-comment`. Prettier inlines it and drops
+// the trailing comma (DIVERGENCES.md "map-leading-comment-layout").
 $empty: ();
 $with-items: (
   // comment
   a: 1,
+);
+$no-comment: (a: 1);
+$with-block: (/* c */ a: 1);
+$later-item: (
+  a: 1,
+  /* c */ b: 2,
 );

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-only.scss.snap
@@ -17,13 +17,19 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally. A comment before the FIRST item makes
-// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
-// being an SCSS map item and loses its trailing comma.
+// renders its leading comment normally. A comment before the FIRST item changes
+// nothing: `$with-block` prints like `$no-comment`. Prettier inlines it and drops
+// the trailing comma (DIVERGENCES.md "map-leading-comment-layout").
 $empty: ();
 $with-items: (
   // comment
   a: 1,
+);
+$no-comment: (a: 1);
+$with-block: (/* c */ a: 1);
+$later-item: (
+  a: 1,
+  /* c */ b: 2,
 );
 
 ==================== Output ====================
@@ -43,13 +49,23 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally. A comment before the FIRST item makes
-// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
-// being an SCSS map item and loses its trailing comma.
+// renders its leading comment normally. A comment before the FIRST item changes
+// nothing: `$with-block` prints like `$no-comment`. Prettier inlines it and drops
+// the trailing comma (DIVERGENCES.md "map-leading-comment-layout").
 $empty: ();
 $with-items: (
   // comment
-  a: 1
+  a: 1,
+);
+$no-comment: (
+  a: 1,
+);
+$with-block: (
+  /* c */ a: 1,
+);
+$later-item: (
+  a: 1,
+  /* c */ b: 2,
 );
 
 -------------------
@@ -68,13 +84,23 @@ $multi: (
   // b
 );
 // Regression guards: a truly empty map stays `()`, and a map WITH items still
-// renders its leading comment normally. A comment before the FIRST item makes
-// the group `groups[0]` a non-key-value pair in Prettier, so the map stops
-// being an SCSS map item and loses its trailing comma.
+// renders its leading comment normally. A comment before the FIRST item changes
+// nothing: `$with-block` prints like `$no-comment`. Prettier inlines it and drops
+// the trailing comma (DIVERGENCES.md "map-leading-comment-layout").
 $empty: ();
 $with-items: (
   // comment
-  a: 1
+  a: 1,
+);
+$no-comment: (
+  a: 1,
+);
+$with-block: (
+  /* c */ a: 1,
+);
+$later-item: (
+  a: 1,
+  /* c */ b: 2,
 );
 
 ===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss
@@ -21,3 +21,6 @@ $map-item-own-line-comment: (k: (1, 2,
 $map-item-own-line-block: (k: (1, 2,
   /* own */
 ));
+
+// A comment before the FIRST item changes nothing either: the comma follows the option.
+$map-leading-comment: (/* c */ a: 1,);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/trailing-comma-none/single-item-list.scss.snap
@@ -26,6 +26,9 @@ $map-item-own-line-block: (k: (1, 2,
   /* own */
 ));
 
+// A comment before the FIRST item changes nothing either: the comma follows the option.
+$map-leading-comment: (/* c */ a: 1,);
+
 ==================== Output ====================
 -----------------------------------------
 { printWidth: 80, trailingComma: "none" }
@@ -80,6 +83,11 @@ $map-item-own-line-block: (
   )
 );
 
+// A comment before the FIRST item changes nothing either: the comma follows the option.
+$map-leading-comment: (
+  /* c */ a: 1
+);
+
 ------------------------------------------
 { printWidth: 100, trailingComma: "none" }
 ------------------------------------------
@@ -131,6 +139,11 @@ $map-item-own-line-block: (
     2
     /* own */
   )
+);
+
+// A comment before the FIRST item changes nothing either: the comma follows the option.
+$map-leading-comment: (
+  /* c */ a: 1
 );
 
 ===================== End =====================


### PR DESCRIPTION
```scss
$no-comment: (
  a: 1,
);
$with-block: (
  /* c */ a: 1,
);
```

These should be formatted in the same way.