### PR TITLE
fix(formatter_css): preserve comment in SCSS paren comma list

### DIFF
--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -468,7 +468,7 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
                             if !in_tight {
                                 write!(f, " ");
                             }
-                            value::write_component_value(
+                            value::write_list_element(
                                 &expr_elements[0],
                                 ValueContext::default(),
                                 f,
@@ -500,7 +500,7 @@ pub(super) fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 
         for (i, el) in expr_elements.iter().enumerate().skip(1) {
             let is_last = i + 1 == expr_elements.len();
             let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                value::write_component_value(el, ValueContext::default(), f);
+                value::write_list_element(el, ValueContext::default(), f);
                 if !is_last {
                     value::write_group_comma(expr_comma_start(i), f);
                 }

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -837,6 +837,19 @@ pub(super) fn is_single_sass_interpolation(values: &[ComponentValue<'_>]) -> boo
         )
 }
 
+/// One bare element of a comma list (`/* c */ 1,`).
+/// Leading comments belong to the element and flush BEFORE any group/indent it opens
+/// (same reason as the head flush in [`write_comma_group`]);
+/// a bare scalar has no comma group of its own to do this.
+pub(super) fn write_list_element<'a>(
+    el: &ComponentValue<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    flush_value_comments(to_span(el.span()).start, f);
+    write_component_value(el, ctx, f);
+}
+
 /// Mirrors Prettier's `printCommaSeparatedValueGroup`.
 /// Joins components with `line`, except for pairs that must stay tight.
 pub(super) fn write_comma_group<'a>(
@@ -1342,6 +1355,8 @@ fn base_separator(values: &[ComponentValue<'_>], i: usize, ctx: ValueContext<'_>
 }
 
 /// Dispatch a single component value.
+/// Leading comments are the CALLER's job (`write_list_element` / `write_comma_group`):
+/// flushing here would land a `//` hardline inside the group/indent an arm opens.
 pub(super) fn write_component_value<'a>(
     value: &ComponentValue<'a>,
     ctx: ValueContext<'a>,
@@ -1447,7 +1462,7 @@ pub(super) fn write_component_value<'a>(
                         if i > 0 {
                             write!(f, hard_line_break());
                         }
-                        write_component_value(el, inner_ctx, f);
+                        write_list_element(el, inner_ctx, f);
                         let is_last = i + 1 == list.elements.len();
                         if !is_last || keep_trailing_comma {
                             write_group_comma(scss::list_comma_start(list, i), f);
@@ -1469,7 +1484,7 @@ pub(super) fn write_component_value<'a>(
                         if i > 0 {
                             write!(f, soft_line_break_or_space());
                         }
-                        write_component_value(el, inner_ctx, f);
+                        write_list_element(el, inner_ctx, f);
                         let is_last = i + 1 == list.elements.len();
                         if !is_last || keep_trailing_comma {
                             write_group_comma(scss::list_comma_start(list, i), f);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss
@@ -1,0 +1,21 @@
+// A comment before a bare scalar element of a comma list leads that element
+// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// Where the source put a block comment (same line, own line) makes no difference.
+// Multi-token elements (`1 2`) already did this through their comma group.
+$first: (k: (/* c */ 1, 2));
+$later: (k: (1, /* c */ 2));
+$line: (k: (
+  // c
+  1, 2));
+$after-comma: (k: (1, // c
+  2));
+$after-comma-block: (k: (1, /* c */
+  2));
+$multi-token: (k: (/* c */ 1 2, 3));
+$flat: (/* c */ 1, 2);
+$bare: 1, /* c */ 2;
+@include m((/* c */ 1, 2));
+@each $k in /* c */ a, b {}
+@each $k in a, /* c */ b {}
+@each $k in a, // c
+  b {}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss.snap
@@ -1,0 +1,148 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment before a bare scalar element of a comma list leads that element
+// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// Where the source put a block comment (same line, own line) makes no difference.
+// Multi-token elements (`1 2`) already did this through their comma group.
+$first: (k: (/* c */ 1, 2));
+$later: (k: (1, /* c */ 2));
+$line: (k: (
+  // c
+  1, 2));
+$after-comma: (k: (1, // c
+  2));
+$after-comma-block: (k: (1, /* c */
+  2));
+$multi-token: (k: (/* c */ 1 2, 3));
+$flat: (/* c */ 1, 2);
+$bare: 1, /* c */ 2;
+@include m((/* c */ 1, 2));
+@each $k in /* c */ a, b {}
+@each $k in a, /* c */ b {}
+@each $k in a, // c
+  b {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment before a bare scalar element of a comma list leads that element
+// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// Where the source put a block comment (same line, own line) makes no difference.
+// Multi-token elements (`1 2`) already did this through their comma group.
+$first: (
+  k: (
+    /* c */ 1,
+    2,
+  ),
+);
+$later: (
+  k: (
+    1,
+    /* c */ 2,
+  ),
+);
+$line: (
+  k: (
+    // c
+    1,
+    2,
+  ),
+);
+$after-comma: (
+  k: (
+    1,
+    // c
+    2,
+  ),
+);
+$after-comma-block: (
+  k: (
+    1,
+    /* c */ 2,
+  ),
+);
+$multi-token: (
+  k: (
+    /* c */ 1 2,
+    3,
+  ),
+);
+$flat: (/* c */ 1, 2);
+$bare:
+  1,
+  /* c */ 2;
+@include m((/* c */ 1, 2));
+@each $k in /* c */ a, b {
+}
+@each $k in a, /* c */ b {
+}
+@each $k in a,
+  // c
+  b
+{
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment before a bare scalar element of a comma list leads that element
+// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// Where the source put a block comment (same line, own line) makes no difference.
+// Multi-token elements (`1 2`) already did this through their comma group.
+$first: (
+  k: (
+    /* c */ 1,
+    2,
+  ),
+);
+$later: (
+  k: (
+    1,
+    /* c */ 2,
+  ),
+);
+$line: (
+  k: (
+    // c
+    1,
+    2,
+  ),
+);
+$after-comma: (
+  k: (
+    1,
+    // c
+    2,
+  ),
+);
+$after-comma-block: (
+  k: (
+    1,
+    /* c */ 2,
+  ),
+);
+$multi-token: (
+  k: (
+    /* c */ 1 2,
+    3,
+  ),
+);
+$flat: (/* c */ 1, 2);
+$bare:
+  1,
+  /* c */ 2;
+@include m((/* c */ 1, 2));
+@each $k in /* c */ a, b {
+}
+@each $k in a, /* c */ b {
+}
+@each $k in a,
+  // c
+  b
+{
+}
+
+===================== End =====================


### PR DESCRIPTION
Keep comment position for consistency.