### PR TITLE
fix(formatter_css): preserve comments around SCSS/Less variable values

### DIFF
--- a/crates/oxc_formatter_core/FORMATTER_POLICY.md
+++ b/crates/oxc_formatter_core/FORMATTER_POLICY.md
@@ -44,6 +44,8 @@ Every reason is OUR decision factor; Prettier's mechanism (comment attachment, `
   - Mandatory: Formatting must NEVER do that
   - Verify semantics claims with the reference compiler/parser (tsc, dart-sass, lessc, ...), not intuition
 - (2) `invariant`: Prettier's output breaks one of our formatter contract invariants; that set is closed, extending it is a policy change
+  - Lossless: every comment is printed, exactly once; comments are the user's, and losing one outranks moving one
+    (whatever the compiler makes of it: a comment may carry tool meaning, `/*! */`, `-disable`, etc)
   - The comment placement invariants (see "Comment placement invariants" below): the output moves content the user owns
   - Idempotency: a second pass must reproduce the first, layout included; a formatter with no fixpoint has no defined output
   - Mandatory: the output is inadmissible whatever its layout merits
@@ -87,7 +89,7 @@ Two layers of rules; know which one you are editing:
 - Invariants hold uniformly: violating one is a bug even where Prettier disagrees
 - Compat tables record measured Prettier behavior that is not derivable from principle: extend them by measuring Prettier, never by analogy, and pin every entry in a fixture
 
-The invariants:
+The invariants (placement only; losing a comment is the lossless contract under reason (2), above all of these):
 
 - A comment never crosses user content (code, other comments, other tokens): it stays on its source side of every token
   - When Prettier relocates a comment across tokens, that is a divergence under reason (2) `invariant` (see "Known divergences"), not a rule to emulate

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -49,14 +49,14 @@ The shared policy applies; CSS specifics:
 `oxc-css-parser` does not attach comments to the AST;
 they are collected via `ParserBuilder::comments()` into a positional cursor over `CssComment { span, inline }` (`inline` = `//`).
 
-- Statement-level comments: flushed before each statement (`flush_leading_comments`);
-  consecutive same-line comments stay glued (`*/ /*!`), but a comment is always followed by a line break before a node
-- Value-level comments: block comments between fill runs are standalone fill items (own-line or not);
-  the rest (leads before the first component, own-line `//`) flush at the next entry's head (`flush_value_comments`),
-  where `//` comments expand the parent group and force a hardline after
-- Trailing (`value /* c */;`): flushed by `write_declaration` with the source gap before `;` preserved
-- After each statement, the sequence DISCARDS unclaimed comments inside the statement span
-  (cursor must never point before a printed position)
+Ownership is a claim discipline, not attachment: each printer claims the comments inside what it prints, in source order.
+
+- Statement level: `flush_leading_comments` before the statement, `write_terminator_tail_comments` before its `;`
+- Value level: a comma group claims its own head (`write_comma_group`); a bare value has no group to do so,
+  its CALLER claims (`write_list_element` / `write_top_level_list_element`), never `write_component_value` itself (a `//` hardline would land inside the indent an arm opens)
+- After each statement, the sequence DISCARDS unclaimed comments inside the statement span:
+  a monotonicity guard (the cursor must never point before a printed position), not a placement rule.
+  A comment reaching it is LOST (the lossless contract), so every new value position must claim its leads
 
 #### Placement invariants
 
@@ -70,6 +70,9 @@ The shared invariants (FORMATTER_POLICY.md "Comment placement invariants") apply
   - Adopted by every comma writer (function/include args, maps, paren/sass lists, `@mixin` params, `@each` bindings, keyframe selectors)
 - `;` is a declaration TERMINATOR, but unlike JS statements Prettier does NOT move comments behind it:
   - `value /* c */;` keeps the comment before `;` (measured behavior, not principle, may change in the future)
+  - `oxc_formatter` prints `1; /* c */` (comment behind the terminator); CSS keeps it before, uniformly for declarations, `$var` / `@var` values and `!flag`s (`write_terminator_tail_comments`).
+    - Revisit together with JS if the policy ever picks one side
+  - The gap before the `;` is the formatter's and is dropped (`/* c */ ;` -> `/* c */;`), see DIVERGENCES.md "terminator-gap-normalized"
 - The positional cursor makes ownership a bounds discipline, not an attachment one:
   - a flush's upper bound must never extend past the next piece of user content,
   - and a declaration's `tail_bound` may only be consumed by the LAST comma group (`write_value_groups` clears it for every other group)
@@ -197,8 +200,8 @@ The harness snapshots both `--print-width 80` and `100`; verify fixtures at both
 
 At the current version (v3.9.6), these divergences have been confirmed and are intentional (see DIVERGENCES.md):
 
-- CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`, `css/stylefmt-repo/media-queries-ranges/media-queries-ranges.css`, `css/postcss-plugins/postcss-nesting.css`
-- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`, `scss/trailing-comma/comments.scss`, `scss/trailing-comma/list.scss`, `scss/trailing-comma/variable.scss`, `scss/function/arbitrary-arguments-comment.scss`, `scss/map/15193.scss`
+- CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`, `css/stylefmt-repo/media-queries-ranges/media-queries-ranges.css`, `css/postcss-plugins/postcss-nesting.css`, `css/comments/declaration.css` (terminator-gap-normalized)
+- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`, `scss/trailing-comma/comments.scss`, `scss/trailing-comma/list.scss`, `scss/trailing-comma/variable.scss`, `scss/function/arbitrary-arguments-comment.scss`, `scss/map/15193.scss`, `scss/comments/variable-declaration.scss` (terminator-gap-normalized)
 
 Two more files fail with MIXED hunks; they can't pass as files (the intentional hunks alone keep them failing), so the remaining diffs are itemized here:
 

--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -364,7 +364,7 @@ Prettier double-indents it (closing `)` floating between levels) when the neares
 ## comment-preceded-map-indent
 
 - Why: uniform-rule (comment presence never changes layout)
-- Pin: `tests/fixtures/format/scss/map-comment-block-value-comma.scss`
+- Pin: `tests/fixtures/format/scss/map-comment-block-value-comma.scss`, `tests/fixtures/format/scss/variable-inline-comment.scss`
 
 ```scss
 /* input */
@@ -394,6 +394,7 @@ A comment-preceded block map value prints at the normal nested-map indent;
 Prettier double-indents it (+6 body / +4 `)`) because its dedent applies only when the pair doc is a plain `group(indent(fill))` and a leading comment changes the doc shape.
 Comment presence must not change layout: same dedent-skip artifact class as `nested-map-context-indent`
 (paren-block KEYS still keep the pair indent, matching Prettier: that trigger is content, not trivia).
+The other direction of the same artifact: a map value after `$v: // c` keeps its shape under the continuation indent (`(\n    k: v,\n  )`), Prettier dedents it to `(\n  k: v,\n)` with the body level with the `(`.
 
 ## map-item-break-comma-lists-only
 
@@ -481,6 +482,30 @@ Prettier's value parser has no bracket node: `[1,` and `2]` are words of the OUT
 so a comment, a sibling token or an overflow hard-breaks that outer list around the brackets
 (and `[1, 2, ]` keeps a trailing comma with a space).
 `[1,]` keeps its comma for the same reason as `(1,)` (see `single-item-list-trailing-comma`).
+
+## terminator-gap-normalized
+
+- Why: uniform-rule (the formatter owns the trivia up to a terminator)
+- Pin: `tests/fixtures/format/scss/terminator-gap.scss`
+
+```scss
+/* input */
+a { color: red !important /* c */ ; }
+
+/* ours */
+a {
+  color: red !important /* c */;
+}
+
+/* prettier */
+a {
+  color: red !important /* c */ ;
+}
+```
+
+A comment before the `;` keeps its place; the gap between it and the `;` is the formatter's (FORMATTER_POLICY.md "Comment placement invariants": terminators and the trivia up to them),
+so it is dropped as after any other value (`color: red /* c */ ;` -> `red /* c */;`, matching Prettier).
+Prettier keeps the source gap only after `!important` / `!default` / `!global`: postcss stores the text after the flag verbatim in `raws.important`.
 
 ## trailing-comma-none-before-tail-comment
 
@@ -634,6 +659,29 @@ Prettier keeps the whole run verbatim (postcss swallows everything past the `}` 
 This falls out of the AST shape: SCSS parses `{...}` declaration values as `SassNestingDeclaration`;
 CSS/Less don't structure them, so their token-soup fallback incidentally matches Prettier.
 The value syntax's only intended consumer was the dropped CSS Apply Rule proposal, so the cross-mode difference is theoretical.
+
+## less-variable-value-comments
+
+- Why: invariant
+- Pin: `tests/fixtures/format/less/variable-value-comments.less`
+
+```less
+/* input */
+@a: /* c */ 1;
+@c: 1 /* c */;
+
+/* ours */
+@a: /* c */ 1;
+@c: 1 /* c */;
+
+/* prettier */
+@a: 1;
+@c: 1/* c */ ;
+```
+
+A comment inside a variable's value stays in place, as in a declaration (`color: /* c */ red`).
+Prettier loses it (the lossless contract): postcss-less parses `@a: 1` as an at-rule with the value as a params string,
+and its at-rule printer drops the block comments in there (a trailing one survives glued to the value, in front of the `;` gap).
 
 ## less-extend-statement-break
 

--- a/crates/oxc_formatter_css/src/print/less.rs
+++ b/crates/oxc_formatter_css/src/print/less.rs
@@ -8,7 +8,8 @@ use oxc_css_parser::ast::{
 use oxc_formatter_core::{
     Buffer,
     builders::{
-        group, hard_line_break, soft_line_break_or_space, soft_line_indent_or_space, space, text,
+        group, hard_line_break, indent, soft_line_break_or_space, soft_line_indent_or_space, space,
+        text,
     },
     write,
 };
@@ -17,8 +18,10 @@ use crate::{
     comments::write_single_comment,
     format::to_span,
     print::{
-        CssFormatter, format_with, selector,
-        statement::{write_block, write_verbatim_prelude_rule},
+        CssFormatter, format_with,
+        scss::write_top_level_list_element,
+        selector,
+        statement::{write_block, write_terminator_tail_comments, write_verbatim_prelude_rule},
         value::{self, ValueContext},
     },
 };
@@ -38,26 +41,14 @@ pub(super) fn write_less_variable_declaration<'a>(
     let colon_end = to_span(&decl.colon_span).end;
     // Inline comments around the colon make postcss-less treat this as a plain at-rule:
     // the raw text is kept and the block loses its `;`.
-    let value_start_pos = to_span(decl.value.span()).start;
+    let value_start = to_span(decl.value.span()).start;
     let inline_before_colon = f.context().comments().iter_before(colon_end).any(|c| c.inline);
     let inline_after_colon = f
         .context()
         .comments()
-        .iter_before(value_start_pos)
+        .iter_before(value_start)
         .any(|c| c.inline && c.span.start >= colon_end);
-    // Inline comment AFTER the colon only: still a variable;
-    // the comment and line structure are kept (`@var: // c\n{`).
-    if !inline_before_colon && inline_after_colon {
-        write!(f, [":", space()]);
-        for &comment in f.context().comments().take_before(value_start_pos) {
-            write_single_comment(comment, f);
-            write!(f, hard_line_break());
-        }
-        crate::print::scss::write_top_level_value(&decl.value, value_ctx, f);
-        return true;
-    }
-    if inline_before_colon {
-        let value_start = to_span(decl.value.span()).start;
+    let indented = if inline_before_colon {
         let _ = f.context().comments().take_before(value_start);
         let raw = source.slice_range(name_span.end, value_start);
         write!(f, text(raw.trim_end()));
@@ -72,13 +63,35 @@ pub(super) fn write_less_variable_declaration<'a>(
             return false;
         }
         write!(f, space());
-        crate::print::scss::write_top_level_value(&decl.value, value_ctx, f);
-        return true;
+        false
+    } else if inline_after_colon {
+        // Inline comment AFTER the colon only: still a variable;
+        // the comment and line structure are kept (`@var: // c\n{`),
+        // and a plain value continues one level under the name (Prettier's at-rule params indent).
+        // A detached ruleset keeps its `{` under the name.
+        write!(f, [":", space()]);
+        !matches!(&decl.value, ComponentValue::LessDetachedRuleset(_))
+    } else {
+        let _ = f.context().comments().take_before(colon_end);
+        write!(f, [":", space()]);
+        false
+    };
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        if inline_after_colon {
+            for &comment in f.context().comments().take_before(value_start) {
+                write_single_comment(comment, f);
+                write!(f, hard_line_break());
+            }
+        }
+        write_top_level_list_element(&decl.value, value_ctx, f);
+    });
+    if indented {
+        // No `dedent` unlike `write_declaration`: the value opens no indent of its own (`no_leading_softline`)
+        write!(f, indent(&body));
+    } else {
+        write!(f, body);
     }
-    // postcss-less drops (block) comments between the name and the colon
-    let _ = f.context().comments().take_before(colon_end);
-    write!(f, [":", space()]);
-    crate::print::scss::write_top_level_value(&decl.value, value_ctx, f);
+    write_terminator_tail_comments(to_span(&decl.span).end, f);
     true
 }
 

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -51,21 +51,34 @@ pub(super) fn write_sass_variable_declaration<'a>(
     write!(f, space());
 
     let ctx = ValueContext { decl_prop: Some("$"), map_break: true, ..ValueContext::default() };
-    // Comments between the colon and the value:
-    // inline ones get their own line under the colon (`$x:\n  // c\n  value`).
+    // Comments between the colon and the value keep their line:
+    // a same-line `//` stays on the colon's (`$x: // c`), an own-line one stays own-line,
+    // and the value then continues one level under the name.
+    // A hard-broken comma list indents itself and claims an own-line lead inside that indent.
     let value_start = to_span(decl.value.span()).start;
-    if f.context().comments().peek().is_some_and(|c| c.inline && c.span.end <= value_start) {
-        let lead = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-            for &comment in f.context().comments().take_before(value_start) {
-                write!(f, hard_line_break());
-                comments::write_single_comment(comment, f);
-            }
-        });
-        write!(f, indent(&lead));
+    let inline_lead = f.context().comments().iter_before(value_start).any(|c| c.inline);
+    let own_line_lead = f
+        .context()
+        .comments()
+        .iter_before(value_start)
+        .next()
+        .is_some_and(|c| value::comment_is_own_line(c, source));
+    let hard_list = top_level_value_breaks_hard(&decl.value, ctx, f);
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        if own_line_lead {
+            write!(f, hard_line_break());
+        }
+        if hard_list && own_line_lead {
+            write_top_level_value(&decl.value, ctx, f);
+        } else {
+            write_top_level_list_element(&decl.value, ctx, f);
+        }
+    });
+    if (inline_lead || own_line_lead) && !hard_list {
+        write!(f, indent(&body));
     } else {
-        value::flush_value_comments(value_start, f);
+        write!(f, body);
     }
-    write_top_level_value(&decl.value, ctx, f);
 
     for flag in &decl.flags {
         let span = to_span(flag.span());
@@ -73,16 +86,7 @@ pub(super) fn write_sass_variable_declaration<'a>(
         write!(f, space());
         write!(f, text(source.text_for(&span)));
     }
-    // Comments between the value/flags and the `;`.
-    let decl_end = to_span(decl.span()).end;
-    let end = statement::end_with_semicolon(decl_end, f);
-    let bound = if end > decl_end { end - 1 } else { decl_end };
-    if let Some(comment_end) = value::flush_trailing_value_comments(bound, f)
-        && end > decl_end
-        && comment_end < end - 1
-    {
-        write!(f, space());
-    }
+    statement::write_terminator_tail_comments(to_span(decl.span()).end, f);
 }
 
 /// `("a",)` / `$x: "a",`: a single element followed by a comma is a one-element LIST in Sass,
@@ -97,6 +101,43 @@ pub(super) fn is_single_item_list(list: &SassList<'_>) -> bool {
 /// Start offset of the source comma after element `i` (for [`value::write_group_comma`]).
 pub(super) fn list_comma_start(list: &SassList<'_>, i: usize) -> Option<u32> {
     list.comma_spans.as_ref().and_then(|s| s.get(i)).map(|sp| to_span(sp).start)
+}
+
+/// Whether [`write_top_level_value`] prints `value` one comma entry per line:
+/// a comma list whose entries have multiple parts or carry comments, except under a custom property.
+/// Such a list indents itself, callers must not add a level.
+pub(super) fn top_level_value_breaks_hard<'a>(
+    value: &ComponentValue<'a>,
+    ctx: ValueContext<'a>,
+    f: &CssFormatter<'_, 'a>,
+) -> bool {
+    let elements = match value {
+        ComponentValue::SassList(list) if list.comma_spans.is_some() => &list.elements,
+        ComponentValue::LessList(list) if list.comma_spans.is_some() => &list.elements,
+        _ => return false,
+    };
+    if elements.len() < 2 || ctx.decl_prop.is_some_and(|p| p.starts_with("--")) {
+        return false;
+    }
+    let value_span = to_span(value.span());
+    let has_comments = f
+        .context()
+        .comments()
+        .iter_before(value_span.end)
+        .any(|c| c.span.start >= value_span.start);
+    has_comments
+        || elements.iter().enumerate().any(|(i, el)| {
+            let group = match el {
+                ComponentValue::SassList(inner) if inner.comma_spans.is_none() => {
+                    &inner.elements[..]
+                }
+                ComponentValue::LessList(inner) if inner.comma_spans.is_none() => {
+                    &inner.elements[..]
+                }
+                other => std::slice::from_ref(other),
+            };
+            value::comma_group_is_multi(group, i == 0)
+        })
 }
 
 /// A single `ComponentValue` in declaration-value position:
@@ -138,18 +179,7 @@ pub(super) fn write_top_level_value<'a>(
                 (group, comma_spans.get(i).map(|sp| to_span(sp).start))
             })
             .collect();
-        let value_span = to_span(value.span());
-        let has_comments = f
-            .context()
-            .comments()
-            .iter_before(value_span.end)
-            .any(|c| c.span.start >= value_span.start);
-        let force_hard_line = !ctx.decl_prop.is_some_and(|p| p.starts_with("--"))
-            && (groups
-                .iter()
-                .enumerate()
-                .any(|(i, (g, _))| value::comma_group_is_multi(g, i == 0))
-                || has_comments);
+        let force_hard_line = top_level_value_breaks_hard(value, ctx, f);
         value::write_value_groups(&groups, ctx, force_hard_line, keep_trailing_comma, f);
     } else {
         value::write_comma_group(elements, ctx, f);

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -530,17 +530,16 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
         value::flush_trailing_value_comments(to_span(important.span()).start, f);
         write!(f, [space(), "!important"]);
     }
-    // Comments between the value and the `;`.
-    // NOTE: the `;` position is the flush bound, so a comment after `;` stays for the trailing-comment pass.
-    let decl_end = to_span(decl.span()).end;
-    let end = end_with_semicolon(decl_end, f);
-    let bound = if end > decl_end { end - 1 } else { decl_end };
-    if let Some(comment_end) = value::flush_trailing_value_comments(bound, f) {
-        // Preserve a source gap between the last comment and the `;`
-        if end > decl_end && comment_end < end - 1 {
-            write!(f, space());
-        }
-    }
+    write_terminator_tail_comments(to_span(decl.span()).end, f);
+}
+
+/// Comments between a declaration's content and its `;` (`value /* c */;`), kept in place.
+/// The `;` position bounds the flush, so a comment after `;` stays for the trailing-comment pass;
+/// the trivia up to the `;` is the formatter's, so a source gap before it (`/* c */ ;`) is not kept.
+pub(super) fn write_terminator_tail_comments(content_end: u32, f: &mut CssFormatter<'_, '_>) {
+    let end = end_with_semicolon(content_end, f);
+    let bound = if end > content_end { end - 1 } else { content_end };
+    value::flush_trailing_value_comments(bound, f);
 }
 
 /// Prints a `--prop: { a: b; c: d }` rule-block value by re-flowing the raw text:

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/variable-value-comments.less
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/variable-value-comments.less
@@ -1,0 +1,26 @@
+// Comments in a variable's value stay where they are, like in a declaration.
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"): Prettier DROPS the
+// block comments of `@a`, `@e`, `@b`, `@g` and glues `@c`'s as `1/* c */ ;`.
+@a: /* c */ 1;
+@e: /* c */ 1 2;
+@b: 1 /* c */ 2;
+@c: 1 /* c */;
+// The gap before `;` is the formatter's: normalized away, as in a declaration.
+@c2: 1 /* c */ ;
+// A `//` after the colon: the value continues one level under the name,
+// a detached ruleset keeps its `{` under the name.
+@d: // c
+  1;
+@d2: // c
+  1 2;
+@r: // c
+{
+  a: b;
+};
+.x {
+  @f: // c
+    1;
+  @g: /* c */ 1;
+  color: /* c */ red;
+}
+@h: 1; /* after */

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/variable-value-comments.less.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/variable-value-comments.less.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments in a variable's value stay where they are, like in a declaration.
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"): Prettier DROPS the
+// block comments of `@a`, `@e`, `@b`, `@g` and glues `@c`'s as `1/* c */ ;`.
+@a: /* c */ 1;
+@e: /* c */ 1 2;
+@b: 1 /* c */ 2;
+@c: 1 /* c */;
+// The gap before `;` is the formatter's: normalized away, as in a declaration.
+@c2: 1 /* c */ ;
+// A `//` after the colon: the value continues one level under the name,
+// a detached ruleset keeps its `{` under the name.
+@d: // c
+  1;
+@d2: // c
+  1 2;
+@r: // c
+{
+  a: b;
+};
+.x {
+  @f: // c
+    1;
+  @g: /* c */ 1;
+  color: /* c */ red;
+}
+@h: 1; /* after */
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments in a variable's value stay where they are, like in a declaration.
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"): Prettier DROPS the
+// block comments of `@a`, `@e`, `@b`, `@g` and glues `@c`'s as `1/* c */ ;`.
+@a: /* c */ 1;
+@e: /* c */ 1 2;
+@b: 1 /* c */ 2;
+@c: 1 /* c */;
+// The gap before `;` is the formatter's: normalized away, as in a declaration.
+@c2: 1 /* c */;
+// A `//` after the colon: the value continues one level under the name,
+// a detached ruleset keeps its `{` under the name.
+@d: // c
+  1;
+@d2: // c
+  1 2;
+@r: // c
+{
+  a: b;
+};
+.x {
+  @f: // c
+    1;
+  @g: /* c */ 1;
+  color: /* c */ red;
+}
+@h: 1; /* after */
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments in a variable's value stay where they are, like in a declaration.
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"): Prettier DROPS the
+// block comments of `@a`, `@e`, `@b`, `@g` and glues `@c`'s as `1/* c */ ;`.
+@a: /* c */ 1;
+@e: /* c */ 1 2;
+@b: 1 /* c */ 2;
+@c: 1 /* c */;
+// The gap before `;` is the formatter's: normalized away, as in a declaration.
+@c2: 1 /* c */;
+// A `//` after the colon: the value continues one level under the name,
+// a detached ruleset keeps its `{` under the name.
+@d: // c
+  1;
+@d2: // c
+  1 2;
+@r: // c
+{
+  a: b;
+};
+.x {
+  @f: // c
+    1;
+  @g: /* c */ 1;
+  color: /* c */ red;
+}
+@h: 1; /* after */
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/terminator-gap.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/terminator-gap.scss
@@ -1,0 +1,12 @@
+// The trivia up to a `;` is the formatter's: a comment before it keeps its place,
+// the gap between the comment and the `;` does not.
+// DIVERGENCE (DIVERGENCES.md "terminator-gap-normalized"): after `!important` /
+// `!default` / `!global` Prettier keeps the source gap (`/* c */ ;`).
+$a: 1 /* c */ ;
+$b: 1 !default /* c */ ;
+$c: 1 !global /* c */;
+a {
+  color: red /* c */ ;
+  width: 1px !important /* c */ ;
+  height: 1px !important /* c */;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/terminator-gap.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/terminator-gap.scss.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The trivia up to a `;` is the formatter's: a comment before it keeps its place,
+// the gap between the comment and the `;` does not.
+// DIVERGENCE (DIVERGENCES.md "terminator-gap-normalized"): after `!important` /
+// `!default` / `!global` Prettier keeps the source gap (`/* c */ ;`).
+$a: 1 /* c */ ;
+$b: 1 !default /* c */ ;
+$c: 1 !global /* c */;
+a {
+  color: red /* c */ ;
+  width: 1px !important /* c */ ;
+  height: 1px !important /* c */;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// The trivia up to a `;` is the formatter's: a comment before it keeps its place,
+// the gap between the comment and the `;` does not.
+// DIVERGENCE (DIVERGENCES.md "terminator-gap-normalized"): after `!important` /
+// `!default` / `!global` Prettier keeps the source gap (`/* c */ ;`).
+$a: 1 /* c */;
+$b: 1 !default /* c */;
+$c: 1 !global /* c */;
+a {
+  color: red /* c */;
+  width: 1px !important /* c */;
+  height: 1px !important /* c */;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// The trivia up to a `;` is the formatter's: a comment before it keeps its place,
+// the gap between the comment and the `;` does not.
+// DIVERGENCE (DIVERGENCES.md "terminator-gap-normalized"): after `!important` /
+// `!default` / `!global` Prettier keeps the source gap (`/* c */ ;`).
+$a: 1 /* c */;
+$b: 1 !default /* c */;
+$c: 1 !global /* c */;
+a {
+  color: red /* c */;
+  width: 1px !important /* c */;
+  height: 1px !important /* c */;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/variable-inline-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/variable-inline-comment.scss
@@ -1,0 +1,49 @@
+// Comments between a variable's colon and its value keep their line:
+// a same-line `//` stays on the colon's line, an own-line comment stays own-line,
+// and the value continues one level under the name.
+// A hard-broken comma list indents itself instead (one entry per line).
+$s1: // c
+  1;
+$s2: /* c */ 1;
+$s3:
+  // c
+  1;
+$s4:
+  /* c */
+  1;
+$p1: // c
+  1 2;
+$p3:
+  // c
+  1 2;
+$f1: // c
+  a, b;
+$f2: /* c */ a, b;
+$f3:
+  // c
+  a, b;
+$f4:
+  /* c */
+  a, b;
+$h1: // c
+  a b, c d;
+$h3:
+  // c
+  a b, c d;
+$h5: // c
+  a,
+  // d
+  b;
+$z: // c
+  1 !default;
+.a {
+  $n: // c
+    1;
+}
+// DIVERGENCE (DIVERGENCES.md "comment-preceded-map-indent"): the map keeps its
+// shape under the continuation indent; Prettier dedents it to `(\n  k: v,\n);`.
+$m1: // c
+  (k: v);
+$m3:
+  // c
+  (k: v);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/variable-inline-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/variable-inline-comment.scss.snap
@@ -1,0 +1,170 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between a variable's colon and its value keep their line:
+// a same-line `//` stays on the colon's line, an own-line comment stays own-line,
+// and the value continues one level under the name.
+// A hard-broken comma list indents itself instead (one entry per line).
+$s1: // c
+  1;
+$s2: /* c */ 1;
+$s3:
+  // c
+  1;
+$s4:
+  /* c */
+  1;
+$p1: // c
+  1 2;
+$p3:
+  // c
+  1 2;
+$f1: // c
+  a, b;
+$f2: /* c */ a, b;
+$f3:
+  // c
+  a, b;
+$f4:
+  /* c */
+  a, b;
+$h1: // c
+  a b, c d;
+$h3:
+  // c
+  a b, c d;
+$h5: // c
+  a,
+  // d
+  b;
+$z: // c
+  1 !default;
+.a {
+  $n: // c
+    1;
+}
+// DIVERGENCE (DIVERGENCES.md "comment-preceded-map-indent"): the map keeps its
+// shape under the continuation indent; Prettier dedents it to `(\n  k: v,\n);`.
+$m1: // c
+  (k: v);
+$m3:
+  // c
+  (k: v);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between a variable's colon and its value keep their line:
+// a same-line `//` stays on the colon's line, an own-line comment stays own-line,
+// and the value continues one level under the name.
+// A hard-broken comma list indents itself instead (one entry per line).
+$s1: // c
+  1;
+$s2: /* c */ 1;
+$s3:
+  // c
+  1;
+$s4:
+  /* c */ 1;
+$p1: // c
+  1 2;
+$p3:
+  // c
+  1 2;
+$f1: // c
+  a, b;
+$f2: /* c */ a, b;
+$f3:
+  // c
+  a, b;
+$f4:
+  /* c */ a, b;
+$h1: // c
+  a b,
+  c d;
+$h3:
+  // c
+  a b,
+  c d;
+$h5: // c
+  a,
+  // d
+  b;
+$z: // c
+  1 !default;
+.a {
+  $n: // c
+    1;
+}
+// DIVERGENCE (DIVERGENCES.md "comment-preceded-map-indent"): the map keeps its
+// shape under the continuation indent; Prettier dedents it to `(\n  k: v,\n);`.
+$m1: // c
+  (
+    k: v,
+  );
+$m3:
+  // c
+  (
+    k: v,
+  );
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between a variable's colon and its value keep their line:
+// a same-line `//` stays on the colon's line, an own-line comment stays own-line,
+// and the value continues one level under the name.
+// A hard-broken comma list indents itself instead (one entry per line).
+$s1: // c
+  1;
+$s2: /* c */ 1;
+$s3:
+  // c
+  1;
+$s4:
+  /* c */ 1;
+$p1: // c
+  1 2;
+$p3:
+  // c
+  1 2;
+$f1: // c
+  a, b;
+$f2: /* c */ a, b;
+$f3:
+  // c
+  a, b;
+$f4:
+  /* c */ a, b;
+$h1: // c
+  a b,
+  c d;
+$h3:
+  // c
+  a b,
+  c d;
+$h5: // c
+  a,
+  // d
+  b;
+$z: // c
+  1 !default;
+.a {
+  $n: // c
+    1;
+}
+// DIVERGENCE (DIVERGENCES.md "comment-preceded-map-indent"): the map keeps its
+// shape under the continuation indent; Prettier dedents it to `(\n  k: v,\n);`.
+$m1: // c
+  (
+    k: v,
+  );
+$m3:
+  // c
+  (
+    k: v,
+  );
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-css.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-css.snap
@@ -2,12 +2,13 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-css compatibility: 145/151 (96.03%), 15 files skipped
+css compatibility: 144/151 (95.36%), 15 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| css/comments/declaration.css | 💥 | 98.88% |
 | css/fill-value/fill.css | 💥 | 96.36% |
 | css/parens/parens.css | 💥 | 93.12% |
 | css/postcss-plugins/postcss-nesting.css | 💥 | 97.66% |

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
@@ -2,13 +2,14 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-scss compatibility: 79/90 (87.78%), 6 files skipped
+scss compatibility: 78/90 (86.67%), 6 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | scss/comments/4878.scss | 💥 | 89.39% |
+| scss/comments/variable-declaration.scss | 💥 | 81.25% |
 | scss/function/arbitrary-arguments-comment.scss | 💥💥 | 72.73% |
 | scss/map/15193.scss | 💥✨ | 42.86% |
 | scss/map/comment.scss | 💥💥 | 73.91% |


### PR DESCRIPTION
```less
// input
@a: /* c */ 1;

// before
@a: 1;

// after
@a: /* c */ 1;
```

Comment should be preserved.

```scss
// input
$x: // c
  1;

// before
$x:
  // c1;

// after
$x: // c
  1;
```

Content should be preserved.
