### PR TITLE
ci(labeler): label lexer PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,6 +44,10 @@ A-transformer:
             "napi/transform-relay/**",
           ]
 
+A-lexer:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/oxc_lexer/**"]
+
 A-linter:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary

- automatically apply `A-lexer` to changes under `crates/oxc_lexer`
- keep parser-internal lexer changes covered by the existing `A-parser` rule
