### PR TITLE
feat(linter): implement vitestImports setting

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -7436,5 +7436,28 @@ export interface VitestPluginSettings {
    * to accommodate TypeScript type checking scenarios.
    */
   typecheck?: boolean;
+  /**
+   * Import sources whose exported `test`/`describe`/`it`/`expect` bindings
+   * should be treated as Vitest functions, in addition to the built-in
+   * Vitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`).
+   *
+   * Useful when tests import their test functions from a custom fixture or
+   * wrapper module instead of `vitest` directly, for example:
+   *
+   * ```jsonc
+   * {
+   * "settings": {
+   * "vitest": {
+   * "vitestImports": ["@/test/fixtures"]
+   * }
+   * }
+   * }
+   * ```
+   *
+   * See the [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures)
+   * documentation of `eslint-plugin-vitest`. Note that regular expressions
+   * are not supported yet, only exact module names.
+   */
+  vitestImports?: string[];
   [k: string]: unknown | undefined;
 }

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -371,6 +371,24 @@ mod test {
     }
 
     #[test]
+    fn test_parse_vitest_imports_settings() {
+        let json_value = serde_json::json!({
+            "vitest": {
+                "typecheck": true,
+                "vitestImports": ["@/test/fixtures"]
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert!(settings.vitest.typecheck);
+        assert_eq!(settings.vitest.vitest_imports, vec!["@/test/fixtures".to_string()]);
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["vitest"]["vitestImports"][0], "@/test/fixtures");
+    }
+
+    #[test]
     fn test_negative_integer_jest_version_fail() {
         let json_value = serde_json::json!({
             "jest": {

--- a/crates/oxc_linter/src/config/settings/vitest.rs
+++ b/crates/oxc_linter/src/config/settings/vitest.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::utils::is_vitest_import_source;
+
 /// Configure Vitest plugin rules.
 ///
 /// See [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s
@@ -12,4 +14,79 @@ pub struct VitestPluginSettings {
     /// to accommodate TypeScript type checking scenarios.
     #[serde(default)]
     pub typecheck: bool,
+
+    /// Import sources whose exported `test`/`describe`/`it`/`expect` bindings
+    /// should be treated as Vitest functions, in addition to the built-in
+    /// Vitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`).
+    ///
+    /// Useful when tests import their test functions from a custom fixture or
+    /// wrapper module instead of `vitest` directly, for example:
+    ///
+    /// ```jsonc
+    /// {
+    ///   "settings": {
+    ///     "vitest": {
+    ///       "vitestImports": ["@/test/fixtures"]
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// See the [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures)
+    /// documentation of `eslint-plugin-vitest`. Note that regular expressions
+    /// are not supported yet, only exact module names.
+    #[serde(default, rename = "vitestImports")]
+    pub vitest_imports: Vec<String>,
+}
+
+impl VitestPluginSettings {
+    /// Returns `true` if `source` is a Vitest import source, either one of the
+    /// built-in sources (`vitest`, `vite-plus/test`, `@effect/vitest`) or one
+    /// configured via the `vitestImports` setting.
+    pub fn is_vitest_import_source(&self, source: &str) -> bool {
+        is_vitest_import_source(source)
+            || self.vitest_imports.iter().any(|import| import.as_str() == source)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::VitestPluginSettings;
+
+    #[test]
+    fn test_parse_vitest_imports() {
+        let settings: VitestPluginSettings = serde_json::from_value(json!({
+            "typecheck": true,
+            "vitestImports": ["@/test/fixtures", "$test/setup/fixtures"]
+        }))
+        .unwrap();
+
+        assert!(settings.typecheck);
+        assert_eq!(
+            settings.vitest_imports,
+            vec!["@/test/fixtures".to_string(), "$test/setup/fixtures".to_string()]
+        );
+
+        // Built-in sources are always recognized.
+        assert!(settings.is_vitest_import_source("vitest"));
+        assert!(settings.is_vitest_import_source("vite-plus/test"));
+        assert!(settings.is_vitest_import_source("@effect/vitest"));
+        // Configured sources are recognized too.
+        assert!(settings.is_vitest_import_source("@/test/fixtures"));
+        assert!(settings.is_vitest_import_source("$test/setup/fixtures"));
+        // Unrelated sources are not.
+        assert!(!settings.is_vitest_import_source("some-other-module"));
+    }
+
+    #[test]
+    fn test_parse_vitest_imports_default() {
+        let settings: VitestPluginSettings = serde_json::from_value(json!({})).unwrap();
+
+        assert!(!settings.typecheck);
+        assert!(settings.vitest_imports.is_empty());
+        assert!(settings.is_vitest_import_source("vitest"));
+        assert!(!settings.is_vitest_import_source("./fixtures"));
+    }
 }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -528,7 +528,7 @@ impl<'a> ContextHost<'a> {
         if self.plugins().has_test() {
             // let mut test_flags = FrameworkFlags::empty();
 
-            let vitest_like = has_vitest_imports(self.module_record());
+            let vitest_like = has_vitest_imports(self.module_record(), &self.config.settings);
             let jest_like =
                 is_jestlike_file(&self.file_path) || has_jest_imports(self.module_record());
 

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -4,8 +4,7 @@ use std::path::Path;
 
 use bitflags::bitflags;
 
-#[cfg(not(test))]
-use crate::ModuleRecord;
+use crate::{ModuleRecord, OxlintSettings};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,12 +91,11 @@ pub fn is_jestlike_file(path: &Path) -> bool {
         .is_some_and(|name_or_first_ext| name_or_first_ext == "test" || name_or_first_ext == "spec")
 }
 
-#[cfg(not(test))]
-pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
-    module_record.import_entries.iter().any(|entry| {
-        let name = entry.module_request.name();
-        name == "vitest" || name == "vite-plus/test" || name == "@effect/vitest"
-    })
+pub fn has_vitest_imports(module_record: &ModuleRecord, settings: &OxlintSettings) -> bool {
+    module_record
+        .import_entries
+        .iter()
+        .any(|entry| settings.vitest.is_vitest_import_source(entry.module_request.name()))
 }
 
 #[cfg(not(test))]
@@ -110,4 +108,55 @@ pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
 pub enum FrameworkOptions {
     Default,  // default
     VueSetup, // context is inside `<script setup>`
+}
+
+#[cfg(test)]
+mod test {
+    use serde::Deserialize;
+    use serde_json::json;
+
+    use oxc_span::Span;
+
+    use super::has_vitest_imports;
+    use crate::{
+        OxlintSettings,
+        module_record::{ImportEntry, ImportImportName, ModuleRecord, NameSpan},
+    };
+
+    fn import_entry(module_request: &str) -> ImportEntry {
+        let span = Span::new(0, 0);
+        ImportEntry {
+            statement_span: span,
+            module_request: NameSpan::new(module_request.into(), span),
+            import_name: ImportImportName::Name(NameSpan::new("test".into(), span)),
+            local_name: NameSpan::new("test".into(), span),
+            is_type: false,
+        }
+    }
+
+    fn settings_with_vitest_imports(module: &str) -> OxlintSettings {
+        OxlintSettings::deserialize(json!({
+            "vitest": { "vitestImports": [module] }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_has_vitest_imports() {
+        let default_settings = OxlintSettings::default();
+
+        // Built-in sources are recognized with default settings.
+        for source in ["vitest", "vite-plus/test", "@effect/vitest"] {
+            let mut module_record = ModuleRecord::default();
+            module_record.import_entries.push(import_entry(source));
+            assert!(has_vitest_imports(&module_record, &default_settings));
+        }
+
+        // A custom fixture source is only recognized when configured via `vitestImports`.
+        let mut custom_module = ModuleRecord::default();
+        custom_module.import_entries.push(import_entry("$test/setup/fixtures"));
+        assert!(!has_vitest_imports(&custom_module, &default_settings));
+        let custom_settings = settings_with_vitest_imports("$test/setup/fixtures");
+        assert!(has_vitest_imports(&custom_module, &custom_settings));
+    }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -175,9 +175,10 @@ thread_local! {
     });
 }
 
-fn execute_rules<'a, const TIMINGS: bool>(
+fn execute_rules<'a, 'c, const TIMINGS: bool>(
     rules: &[(&RuleEnum, LintContext<'a>)],
-    semantic: &Semantic<'a>,
+    semantic: &'c Semantic<'a>,
+    settings: &'c OxlintSettings,
     should_run_on_jest_node: bool,
     with_runtime_optimization: bool,
     mut timing_recorder: Option<&mut RuleTimingRecorder>,
@@ -225,7 +226,7 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
 
             if should_run_on_jest_node {
-                for jest_node in iter_possible_jest_call_node(semantic) {
+                for jest_node in iter_possible_jest_call_node(semantic, settings) {
                     for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
                         if rule.run_info().is_run_on_jest_node_implemented() {
                             let timing_stat =
@@ -249,7 +250,7 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
 
             if should_run_on_jest_node {
-                for jest_node in iter_possible_jest_call_node(semantic) {
+                for jest_node in iter_possible_jest_call_node(semantic, settings) {
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
                 }
@@ -414,6 +415,7 @@ impl Linter {
             execute_rules::<TIMINGS>(
                 &rules,
                 semantic,
+                ctx_host.settings(),
                 should_run_on_jest_node,
                 true,
                 timing_recorder.as_mut(),
@@ -422,7 +424,14 @@ impl Linter {
             #[cfg(debug_assertions)]
             {
                 let diagnostics_after_optimized = ctx_host.diagnostic_count();
-                execute_rules::<false>(&rules, semantic, should_run_on_jest_node, false, None);
+                execute_rules::<false>(
+                    &rules,
+                    semantic,
+                    ctx_host.settings(),
+                    should_run_on_jest_node,
+                    false,
+                    None,
+                );
                 let diagnostics_after_unoptimized = ctx_host.diagnostic_count();
                 ctx_host.get_diagnostics(|diagnostics| {
                     let optimized_diagnostics = &diagnostics[current_diagnostic_index..diagnostics_after_optimized];

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -60,15 +60,17 @@ impl Rule for NoExport {
         // `iter_possible_jest_call_node` yields uses of `JEST_METHOD_NAMES`.
         // We focus on "fit", "it", "test", "xit", and "xtest" (JestGeneralFnKind::Test).
         // Presence of any of these is taken to mean the module has tests, and the rule should enforce no exports.
-        let has_tests = iter_possible_jest_call_node(ctx).any(|possible_node| {
-            let AstKind::CallExpression(call_expr) = possible_node.node.kind() else {
-                return false;
-            };
-            let Some(general) = parse_general_jest_fn_call(call_expr, &possible_node, ctx) else {
-                return false;
-            };
-            matches!(general.kind, JestFnKind::General(JestGeneralFnKind::Test))
-        });
+        let has_tests =
+            iter_possible_jest_call_node(ctx.semantic(), ctx.settings()).any(|possible_node| {
+                let AstKind::CallExpression(call_expr) = possible_node.node.kind() else {
+                    return false;
+                };
+                let Some(general) = parse_general_jest_fn_call(call_expr, &possible_node, ctx)
+                else {
+                    return false;
+                };
+                matches!(general.kind, JestFnKind::General(JestGeneralFnKind::Test))
+            });
 
         if has_tests {
             for span in ctx.module_record().exported_bindings.values() {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
@@ -193,7 +193,7 @@ impl NoLargeSnapshotsConfig {
                 }
             }
         } else {
-            for possible_jest_node in iter_possible_jest_call_node(ctx.semantic()) {
+            for possible_jest_node in iter_possible_jest_call_node(ctx.semantic(), ctx.settings()) {
                 self.run(&possible_jest_node, ctx);
             }
         }

--- a/crates/oxc_linter/src/rules/vitest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_test_it.rs
@@ -215,3 +215,50 @@ fn test() {
         .expect_fix(fix)
         .test_and_snapshot();
 }
+
+#[test]
+fn test_vitest_imports() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // `test` and `it` imported from a module that is NOT configured via
+        // `settings.vitest.vitestImports` stay invisible to the rule.
+        (
+            r"
+            import { test, it } from './fixtures';
+            test('a', () => {});
+            it('b', () => {});
+            ",
+            Some(serde_json::json!([{ "fn": "test" }])),
+            None,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // With `vitestImports` configured, both bindings are recognized as
+        // Vitest functions, so mixing `test` and `it` is reported.
+        (
+            r"
+            import { test, it } from '$test/setup/fixtures';
+            test('a', () => {});
+            it('b', () => {});
+            ",
+            Some(serde_json::json!([{ "fn": "test" }])),
+            Some(serde_json::json!({
+                "settings": {
+                    "vitest": {
+                        "vitestImports": ["$test/setup/fixtures"]
+                    }
+                }
+            })),
+            None,
+        ),
+    ];
+
+    Tester::new(ConsistentTestIt::NAME, ConsistentTestIt::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .intentionally_allow_no_fix_tests()
+        .with_snapshot_suffix("vitest_imports")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_focused_tests.rs
@@ -148,3 +148,48 @@ fn test() {
         .expect_fix(fix)
         .test_and_snapshot();
 }
+
+#[test]
+fn test_vitest_imports() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Importing `it` from a module that is NOT configured via
+        // `settings.vitest.vitestImports` stays invisible to the rule.
+        (
+            r#"
+            import { it } from '$test/setup/fixtures';
+            it.only("test", () => {});
+            "#,
+            None,
+            None,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // A `vitestImports`-configured module is a Vitest import source, so the
+        // `it` binding imported from it is recognized as a Vitest function.
+        (
+            r#"
+            import { it } from '$test/setup/fixtures';
+            it.only("test", () => {});
+            "#,
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "vitest": {
+                        "vitestImports": ["$test/setup/fixtures"]
+                    }
+                }
+            })),
+            None,
+        ),
+    ];
+
+    Tester::new(NoFocusedTests::NAME, NoFocusedTests::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .intentionally_allow_no_fix_tests()
+        .with_snapshot_suffix("vitest_imports")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
@@ -386,3 +386,66 @@ fn test() {
     Tester::new(NoStandaloneExpect::NAME, NoStandaloneExpect::PLUGIN, pass, fail)
         .test_and_snapshot();
 }
+
+#[test]
+fn test_vitest_imports() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // `expect` imported from a module that is NOT configured via
+        // `settings.vitest.vitestImports` stays invisible to the rule.
+        (
+            r"
+            import { expect } from './fixtures';
+            expect(1).toBe(1);
+            ",
+            None,
+            None,
+            None,
+        ),
+        // With `vitestImports` configured, `expect` inside a test imported from
+        // the same fixture module is no longer flagged as standalone.
+        // See https://github.com/oxc-project/oxc/issues/22323
+        (
+            r"
+            import { test, expect } from '$test/setup/fixtures';
+            test('does not show banner', () => {
+                expect(1).toBe(1);
+            });
+            ",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "vitest": {
+                        "vitestImports": ["$test/setup/fixtures"]
+                    }
+                }
+            })),
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // A `vitestImports`-configured module is a Vitest import source, so a
+        // top-level `expect` imported from it is reported as standalone.
+        (
+            r"
+            import { expect } from '$test/setup/fixtures';
+            expect(1).toBe(1);
+            ",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "vitest": {
+                        "vitestImports": ["$test/setup/fixtures"]
+                    }
+                }
+            })),
+            None,
+        ),
+    ];
+
+    Tester::new(NoStandaloneExpect::NAME, NoStandaloneExpect::PLUGIN, pass, fail)
+        .with_snapshot_suffix("vitest_imports")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
@@ -137,7 +137,11 @@ impl Rule for PreferImportingVitestGlobals {
                 continue;
             };
 
-            if is_vitest_import_source(import_decl.source.value.as_str())
+            // Bindings imported from a Vitest import source are already explicitly
+            // imported, so nothing to report. This covers both the built-in
+            // sources (`vitest`, `vite-plus/test`, `@effect/vitest`) and any
+            // custom sources configured via `settings.vitest.vitestImports`.
+            if ctx.settings().vitest.is_vitest_import_source(import_decl.source.value.as_str())
                 && import_decl.import_kind == ImportOrExportKind::Value
             {
                 continue;
@@ -475,5 +479,63 @@ fn test() {
     )
     .with_vitest_plugin(true)
     .expect_fix(fix)
+    .test_and_snapshot();
+}
+
+#[test]
+fn test_vitest_imports() {
+    use crate::tester::Tester;
+
+    let settings = || {
+        Some(serde_json::json!({
+            "settings": {
+                "vitest": {
+                    "vitestImports": ["$test/setup/fixtures"]
+                }
+            }
+        }))
+    };
+
+    let pass = vec![
+        // When `$test/setup/fixtures` is configured via `vitestImports`, its
+        // bindings count as explicit Vitest imports, so nothing is reported.
+        (
+            r"
+            import { describe, it } from '$test/setup/fixtures';
+            describe('suite', () => {
+                it('test', () => {});
+            });
+            ",
+            None,
+            settings(),
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // Without the `vitestImports` configuration the same module is not a
+        // Vitest import source, so its bindings are still reported.
+        (
+            r"
+            import { describe, it } from '$test/setup/fixtures';
+            describe('suite', () => {
+                it('test', () => {});
+            });
+            ",
+            None,
+            None,
+            None,
+        ),
+    ];
+
+    Tester::new(
+        PreferImportingVitestGlobals::NAME,
+        PreferImportingVitestGlobals::PLUGIN,
+        pass,
+        fail,
+    )
+    .with_vitest_plugin(true)
+    .intentionally_allow_no_fix_tests()
+    .with_snapshot_suffix("vitest_imports")
     .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_test_it@vitest_imports.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_test_it@vitest_imports.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(consistent-test-it): Enforce `test` and `it` usage conventions
+   ╭─[consistent_test_it.tsx:4:13]
+ 3 │             test('a', () => {});
+ 4 │             it('b', () => {});
+   ·             ──
+ 5 │             
+   ╰────
+  help: Prefer using "test" instead of "it"

--- a/crates/oxc_linter/src/snapshots/vitest_no_focused_tests@vitest_imports.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_focused_tests@vitest_imports.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(no-focused-tests): Unexpected focused test.
+   ╭─[no_focused_tests.tsx:3:16]
+ 2 │             import { it } from '$test/setup/fixtures';
+ 3 │             it.only("test", () => {});
+   ·                ────
+ 4 │             
+   ╰────
+  help: Remove focus from test.

--- a/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect@vitest_imports.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect@vitest_imports.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:3:13]
+ 2 │             import { expect } from '$test/setup/fixtures';
+ 3 │             expect(1).toBe(1);
+   ·             ──────
+ 4 │             
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals@vitest_imports.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_importing_vitest_globals@vitest_imports.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-importing-vitest-globals): Do not use Vitest global functions
+   ╭─[prefer_importing_vitest_globals.tsx:3:13]
+ 2 │                 import { describe, it } from '$test/setup/fixtures';
+ 3 │ ╭─▶             describe('suite', () => {
+ 4 │ │                   it('test', () => {});
+   · │                   ──────────┬─────────
+   · │                             ╰── Add this global vitest import
+ 5 │ ├─▶             });
+   · ╰──── Add this global vitest import
+ 6 │                 
+   ╰────
+  help: Import global functions `describe, it` from `vitest` package instead of using globals.

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -15,6 +15,7 @@ use oxc_semantic::{AstNode, ReferenceId, Semantic, SymbolId};
 use oxc_str::CompactStr;
 
 use crate::LintContext;
+use crate::OxlintSettings;
 pub use crate::utils::jest::parse_jest_fn::{
     ExpectError, KnownMemberExpressionParentKind, KnownMemberExpressionProperty,
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
@@ -165,13 +166,14 @@ pub struct PossibleJestNode<'a, 'b> {
 pub fn collect_possible_jest_call_node<'a, 'c>(
     ctx: &'c LintContext<'a>,
 ) -> Vec<PossibleJestNode<'a, 'c>> {
-    iter_possible_jest_call_node(ctx.semantic()).collect()
+    iter_possible_jest_call_node(ctx.semantic(), ctx.settings()).collect()
 }
 
 /// Iterate over all possible Jest fn Call Expression,
 /// for `expect(1).toBe(1)`, the result will be an iter over node `expect(1)` and node `expect(1).toBe(1)`.
 pub fn iter_possible_jest_call_node<'a, 'c>(
     semantic: &'c Semantic<'a>,
+    settings: &'c OxlintSettings,
 ) -> impl Iterator<Item = PossibleJestNode<'a, 'c>> + 'c {
     // Some people may write codes like below, we need lookup imported test function and global test function.
     // ```
@@ -181,11 +183,12 @@ pub fn iter_possible_jest_call_node<'a, 'c>(
     //     expect(1 + 2).toEqual(3);
     // });
     // ```
-    let reference_id_with_original_list = collect_ids_referenced_to_import(semantic).chain(
-        collect_ids_referenced_to_global(semantic)
-            // set the original of global test function to None
-            .map(|id| (id, None)),
-    );
+    let reference_id_with_original_list = collect_ids_referenced_to_import(semantic, settings)
+        .chain(
+            collect_ids_referenced_to_global(semantic)
+                // set the original of global test function to None
+                .map(|id| (id, None)),
+        );
 
     // get the longest valid chain of Jest Call Expression
     reference_id_with_original_list.flat_map(move |(reference_id, original)| {
@@ -216,6 +219,7 @@ pub fn iter_possible_jest_call_node<'a, 'c>(
 
 fn collect_ids_referenced_to_import<'a, 'c>(
     semantic: &'c Semantic<'a>,
+    settings: &'c OxlintSettings,
 ) -> impl Iterator<Item = (ReferenceId, Option<&'a str>)> + 'c {
     semantic
         .scoping()
@@ -231,10 +235,13 @@ fn collect_ids_referenced_to_import<'a, 'c>(
                 };
                 let name = semantic.scoping().symbol_name(symbol_id);
 
-                if matches!(
-                    import_decl.source.value.as_str(),
-                    "@jest/globals" | "vitest" | "vite-plus/test" | "@effect/vitest"
-                ) {
+                let source = import_decl.source.value.as_str();
+                // Bindings imported from `@jest/globals` or from a Vitest import
+                // source (either a built-in one or one configured via the
+                // `settings.vitest.vitestImports` setting) are candidates for
+                // Jest/Vitest function calls. The framework is determined later
+                // by `parse_jest_fn_call` via the file's framework flags.
+                if source == "@jest/globals" || settings.vitest.is_vitest_import_source(source) {
                     let original = find_original_name(import_decl, name);
                     return Some(
                         reference_ids.iter().map(move |&reference_id| (reference_id, original)),

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -138,7 +138,8 @@
           "tagNamePreference": {}
         },
         "vitest": {
-          "typecheck": false
+          "typecheck": false,
+          "vitestImports": []
         },
         "jest": {
           "version": null
@@ -17250,7 +17251,8 @@
         },
         "vitest": {
           "default": {
-            "typecheck": false
+            "typecheck": false,
+            "vitestImports": []
           },
           "allOf": [
             {
@@ -19661,6 +19663,15 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios."
+        },
+        "vitestImports": {
+          "description": "Import sources whose exported `test`/`describe`/`it`/`expect` bindings\nshould be treated as Vitest functions, in addition to the built-in\nVitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`).\n\nUseful when tests import their test functions from a custom fixture or\nwrapper module instead of `vitest` directly, for example:\n\n```jsonc\n{\n\"settings\": {\n\"vitest\": {\n\"vitestImports\": [\"@/test/fixtures\"]\n}\n}\n}\n```\n\nSee the [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures)\ndocumentation of `eslint-plugin-vitest`. Note that regular expressions\nare not supported yet, only exact module names.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Import sources whose exported `test`/`describe`/`it`/`expect` bindings\nshould be treated as Vitest functions, in addition to the built-in\nVitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`).\n\nUseful when tests import their test functions from a custom fixture or\nwrapper module instead of `vitest` directly, for example:\n\n```jsonc\n{\n\"settings\": {\n\"vitest\": {\n\"vitestImports\": [\"@/test/fixtures\"]\n}\n}\n}\n```\n\nSee the [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures)\ndocumentation of `eslint-plugin-vitest`. Note that regular expressions\nare not supported yet, only exact module names."
         }
       },
       "markdownDescription": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference."

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -1132,3 +1132,31 @@ default: `false`
 Whether to enable typecheck mode for Vitest rules.
 When enabled, some rules will skip certain checks for describe blocks
 to accommodate TypeScript type checking scenarios.
+
+
+#### settings.vitest.vitestImports
+
+type: `string[]`
+
+default: `[]`
+
+Import sources whose exported `test`/`describe`/`it`/`expect` bindings
+should be treated as Vitest functions, in addition to the built-in
+Vitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`).
+
+Useful when tests import their test functions from a custom fixture or
+wrapper module instead of `vitest` directly, for example:
+
+```jsonc
+{
+"settings": {
+"vitest": {
+"vitestImports": ["@/test/fixtures"]
+}
+}
+}
+```
+
+See the [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures)
+documentation of `eslint-plugin-vitest`. Note that regular expressions
+are not supported yet, only exact module names.


### PR DESCRIPTION
## Summary

Adds the `settings.vitest.vitestImports` setting to oxlint's native Vitest plugin, mirroring `eslint-plugin-vitest`'s [custom fixtures](https://github.com/vitest-dev/eslint-plugin-vitest#custom-fixtures). Import sources listed there are treated as Vitest import sources, so rules recognize `test`/`describe`/`it`/`expect`/`vi` bindings imported from wrapper/fixture modules.

This closes #22323. For example, this no longer reports `no-standalone-expect`:

```jsonc
{
  "settings": {
    "vitest": {
      "vitestImports": ["$test/setup/fixtures"]
    }
  }
}
```

```ts
import { test, expect } from '$test/setup/fixtures';
test('does not show banner', () => {
  expect(1).toBe(1);
});
```

## Behavior

- `vitestImports` is deserialized from `.oxlintrc.json` (`settings.vitest.vitestImports`), with `#[serde(default)]` and schema/types/docs regenerated.
- Configured sources participate in **framework detection** (`has_vitest_imports`, which sets `FrameworkFlags::Vitest`) and in **jest-node collection** (`collect_ids_referenced_to_import`), so `run_on_jest_node`-based and `collect_possible_jest_call_node`-based Vitest rules see fixture-imported test functions.
- The built-in Vitest import sources (`vitest`, `vite-plus/test`, `@effect/vitest`) are unchanged; unconfigured custom sources behave exactly as before.

## Design

The effective "is a Vitest import source" predicate lives in one place — `VitestPluginSettings::is_vitest_import_source`, combining the built-in literal list with the configured `vitestImports`. It is threaded (rather than cached on `ContextHost`) into `utils::jest::{iter_possible_jest_call_node, collect_ids_referenced_to_import}` (which previously took only `&Semantic`) and into `frameworks::has_vitest_imports`. `lib.rs::execute_rules` passes the file's resolved settings into both the optimized and the debug-assertion runs so they always agree.

## Deliberate decisions (please review)

1. **`no_importing_vitest_globals` and `consistent_vitest_vi` keep matching the literal package names only.** These rules police imports *of* the Vitest package itself; the setting is about detection of test functions, not those rules' subject matter. We kept their behavior unchanged.
2. **`prefer_importing_vitest_globals` respects `vitestImports`** in its "binding imported from a non-Vitest module" loop: bindings imported from a configured source are treated as explicit Vitest imports and not reported. Rationale: with `vitestImports` configured these are deliberate test-function imports, and the rule's fix would add a duplicate named import (redeclaration) of the same binding. Open to feedback if you'd rather keep that loop literal-only.
3. **ESM-only scope.** Detection runs off `ModuleRecord::import_entries` / import declarations. `require('vitest')` detection remains per-rule (off AST literals) and is out of scope here. Also note the upstream plugin accepts regexes in `vitestImports`; this PR supports exact module-name strings only.

## Testing

- Unit tests for settings deserialization and `has_vitest_imports` (framework sniffing).
- New rule tests (with snapshots) for `no-focused-tests`, `no-standalone-expect`, `consistent-test-it`, and `prefer-importing-vitest-globals`, each covering: configured source recognized / unconfigured source stays invisible.
- `cargo test -p oxc_linter`, `cargo test -p website_linter`, clippy, and rustfmt are clean; schema JSON, TS config types, and docs snapshots regenerated.
- Manually verified end-to-end with the oxlint CLI against a fixture-module project (feature tested by a human reviewer, not only by automated tests).

> [!NOTE]
> This PR was authored with the assistance of an AI coding agent (opencode). The human contributor has reviewed and tested the changes, including running the new linter against their own real-world TypeScript project, and takes full responsibility for this contribution per Oxc's AI Usage Policy.
