### PR TITLE
fix(linter): don't flag unused-disable-directives for skipped type-aware rules

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -355,6 +355,30 @@ impl ConfigStore {
         Some(builtin_rules.len() + external_rules.len())
     }
 
+    /// Returns all tsgolint (type-aware) rule names that are configured.
+    /// This includes rules from both the base config and overrides.
+    pub fn tsgolint_rules(&self) -> Vec<String> {
+        let mut tsgolint_rules = Vec::new();
+
+        // Collect tsgolint rules from base rules
+        for (rule, _) in &self.base.base.rules {
+            if rule.is_tsgolint_rule() {
+                tsgolint_rules.push(rule.name().to_string());
+            }
+        }
+
+        // Collect tsgolint rules from overrides
+        for override_config in &self.base.overrides {
+            for (rule, severity) in &override_config.rules.builtin_rules {
+                if severity.is_warn_deny() && rule.is_tsgolint_rule() {
+                    tsgolint_rules.push(rule.name().to_string());
+                }
+            }
+        }
+
+        tsgolint_rules
+    }
+
     pub fn rules(&self) -> &Arc<[(RuleEnum, AllowWarnDeny)]> {
         &self.base.base.rules
     }

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use oxc_ast::Comment;
 use oxc_span::Span;
 use rust_lapper::{Interval, Lapper};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{FixKind, fixer::Fix};
 
@@ -296,11 +296,25 @@ pub struct DisableDirectives {
     unused_enable_comments: Box<[(DirectivePrefix, Option<String>, Span)]>,
     /// Spans of used enable directives, to filter out unused
     used_disable_comments: RefCell<Vec<DisabledRule>>,
+    /// Rules that were not run (e.g., type-aware rules when type-aware mode is disabled).
+    /// Directives for these rules should not be flagged as unused.
+    skipped_rules: RefCell<FxHashSet<String>>,
 }
 
 impl DisableDirectives {
     fn mark_disable_directive_used(&self, disable_directive: DisabledRule) {
         self.used_disable_comments.borrow_mut().push(disable_directive);
+    }
+
+    /// Mark a rule as skipped (not run).
+    /// Directives for skipped rules should not be flagged as unused.
+    pub fn mark_rule_skipped(&self, rule_name: &str) {
+        self.skipped_rules.borrow_mut().insert(rule_name.to_string());
+    }
+
+    /// Check if a rule was marked as skipped.
+    pub fn is_rule_skipped(&self, rule_name: &str) -> bool {
+        self.skipped_rules.borrow().contains(rule_name)
     }
 
     pub fn contains(&self, rule_name: &str, span: Span) -> bool {
@@ -374,6 +388,7 @@ impl DisableDirectives {
 
     pub fn collect_unused_disable_comments(&self) -> Vec<DisableRuleComment> {
         let used = self.used_disable_comments.borrow();
+        let skipped = self.skipped_rules.borrow();
 
         self.intervals
             .iter()
@@ -401,17 +416,30 @@ impl DisableDirectives {
                         }
                         match &interval.val {
                             DisabledRule::Single { rule_name, name_span, .. } => {
+                                // If the rule was skipped (e.g., type-aware rule without --type-aware),
+                                // we cannot know if the directive is unused, so don't flag it.
+                                if skipped.contains(rule_name) {
+                                    return None;
+                                }
                                 Some(RuleCommentRule {
                                     directive_prefix: interval.val.directive_prefix(),
                                     rule_name: rule_name.clone(),
                                     name_span: *name_span,
                                 })
                             }
-                            DisabledRule::All { .. } => Some(RuleCommentRule {
-                                directive_prefix: interval.val.directive_prefix(),
-                                rule_name: "all".to_string(),
-                                name_span: *comment_span,
-                            }),
+                            DisabledRule::All { .. } => {
+                                // For `eslint-disable` (all rules), if there are any skipped rules,
+                                // we can't know if the directive is unused because it might have disabled
+                                // those skipped rules. So don't flag it.
+                                if !skipped.is_empty() {
+                                    return None;
+                                }
+                                Some(RuleCommentRule {
+                                    directive_prefix: interval.val.directive_prefix(),
+                                    rule_name: "all".to_string(),
+                                    name_span: *comment_span,
+                                })
+                            }
                         }
                     })
                     .collect::<Vec<_>>();
@@ -484,6 +512,7 @@ impl DisableDirectivesBuilder {
             disable_rule_comments: self.disable_rule_comments.into_boxed_slice(),
             unused_enable_comments: self.unused_enable_comments.into_boxed_slice(),
             used_disable_comments: RefCell::new(Vec::new()),
+            skipped_rules: RefCell::new(FxHashSet::default()),
         }
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -326,6 +326,12 @@ impl Linter {
         self.external_linter.is_some()
     }
 
+    /// Returns the list of tsgolint (type-aware) rule names that are configured.
+    /// These rules would be run if type-aware mode was enabled.
+    pub fn tsgolint_rules(&self) -> Vec<String> {
+        self.config.tsgolint_rules()
+    }
+
     /// # Panics
     /// Panics if running in debug mode and the number of diagnostics does not match when running with/without optimizations
     pub fn run<'a>(

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -26,6 +26,10 @@ pub struct LintRunner {
     /// Current working directory
     cwd: PathBuf,
     type_check_only: bool,
+    /// Type-aware (tsgolint) rules that would be run if type-aware mode was enabled.
+    /// This is used to mark these rules as skipped when type-aware mode is not enabled,
+    /// so that their disable directives are not flagged as unused.
+    tsgolint_rules: Vec<String>,
 }
 
 /// Manages disable directives across all linting engines.
@@ -135,6 +139,33 @@ impl DirectivesStore {
     pub fn take(&self, path: &Path) -> Option<DisableDirectives> {
         self.map.lock().expect("DirectivesStore mutex poisoned in take").remove(path)
     }
+
+    /// Mark a rule as skipped (not run) for all files.
+    /// This is used when type-aware linting is disabled to prevent
+    /// flagging directives for type-aware rules as unused.
+    ///
+    /// # Panics
+    /// Panics if the mutex is poisoned.
+    pub fn mark_rule_skipped(&self, rule_name: &str) {
+        let mut map = self.map.lock().expect("DirectivesStore mutex poisoned in mark_rule_skipped");
+        for directives in map.values() {
+            directives.mark_rule_skipped(rule_name);
+        }
+    }
+
+    /// Mark all type-aware (tsgolint) rules as skipped for all files.
+    /// This is called when type-aware linting is disabled.
+    ///
+    /// # Panics
+    /// Panics if the mutex is poisoned.
+    pub fn mark_all_tsgolint_rules_skipped(&self, tsgolint_rules: &[String]) {
+        let mut map = self.map.lock().expect("DirectivesStore mutex poisoned in mark_all_tsgolint_rules_skipped");
+        for directives in map.values() {
+            for rule_name in tsgolint_rules {
+                directives.mark_rule_skipped(rule_name);
+            }
+        }
+    }
 }
 
 impl Default for DirectivesStore {
@@ -237,6 +268,14 @@ impl LintRunnerBuilder {
             None
         };
 
+        // When type-aware linting is not enabled, capture the tsgolint rules
+        // so we can mark their directives as skipped (not unused).
+        let tsgolint_rules = if !self.type_aware_enabled {
+            self.regular_linter.tsgolint_rules()
+        } else {
+            vec![]
+        };
+
         let cwd = self.lint_service_options.cwd().to_path_buf();
         let mut lint_service = LintService::new(self.regular_linter, self.lint_service_options);
         lint_service.set_disable_directives_map(directives_coordinator.map());
@@ -247,6 +286,7 @@ impl LintRunnerBuilder {
             directives_store: directives_coordinator,
             cwd,
             type_check_only: self.type_check_only,
+            tsgolint_rules,
         })
     }
 }
@@ -291,6 +331,10 @@ impl LintRunner {
                 rule_timing_store,
             )?;
         } else {
+            // Mark all tsgolint rules as skipped so their disable directives
+            // are not flagged as unused. We can't know if these directives
+            // would have been used or not since the rules were not run.
+            self.directives_store.mark_all_tsgolint_rules_skipped(&self.tsgolint_rules);
             drop(tx_error);
         }
 


### PR DESCRIPTION
## Fix oxc-project/oxc#26281

When a type-aware rule (e.g., `typescript/require-await`) is enabled in config but the run does NOT pass `--type-aware`, the rule is skipped — but `--report-unused-disable-directives` was still judging disable directives referencing it as unused.

### Bug

The issue is that skipped rules are treated as "produced no problems" and directives are flagged as unused. A directive referencing a rule that was not executed cannot be known to be unused.

### Solution

1. Track skipped rules (type-aware rules when `--type-aware` is not passed) in `DisableDirectives`
2. When collecting unused disable directives, exclude directives for skipped rules
3. Add `mark_all_tsgolint_rules_skipped` method to `DirectivesStore` to mark all tsgolint rules as skipped when type-aware linting is disabled

### Changes

- **disable_directives.rs**: Added `skipped_rules` field and `mark_rule_skipped`/`is_rule_skipped` methods. Modified `collect_unused_disable_comments` to exclude directives for skipped rules.
- **lint_runner.rs**: Added `mark_all_tsgolint_rules_skipped` method to `DirectivesStore`. Added `tsgolint_rules` field to `LintRunner` to track which rules would be skipped. Modified `lint_files` to mark tsgolint rules as skipped when type-aware linting is not enabled.
- **config_store.rs**: Added `tsgolint_rules()` method to return all configured tsgolint rule names.
- **lib.rs**: Added `tsgolint_rules()` method to `Linter` struct.

### Testing

Added logic to handle this edge case. The fix ensures that when type-aware linting is disabled, directives for type-aware rules are not flagged as unused.