### PR TITLE
fix(linter/vue): detect <script> blocks whose opening tag spans multiple lines

### DIFF
--- a/apps/oxlint/fixtures/cli/vue/multiline-script.vue
+++ b/apps/oxlint/fixtures/cli/vue/multiline-script.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+    debugger;
+</script>
+
+<script
+    setup
+    lang="ts"
+    generic="T extends Record<string, string>"
+>
+    let foo: T;
+    debugger;
+</script>

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1184,6 +1184,15 @@ mod test {
     }
 
     #[test]
+    fn lint_vue_multiline_script_open_tag() {
+        let output = Tester::new().test_output_verbose(&["fixtures/cli/vue/multiline-script.vue"]);
+
+        assert_eq!(output.matches("eslint(no-debugger)").count(), 2);
+        assert!(output.contains("fixtures/cli/vue/multiline-script.vue:2:5"));
+        assert!(output.contains("fixtures/cli/vue/multiline-script.vue:11:5"));
+    }
+
+    #[test]
     fn lint_astro_file() {
         let args = &["fixtures/cli/astro/debugger.astro"];
         Tester::new().test_and_snapshot(args);

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -41,18 +41,24 @@ impl<'a> VuePartialLoader<'a> {
         let script_start_finder = Finder::new(SCRIPT_START);
         let comment_start_finder = FinderRev::new(COMMENT_START);
         let comment_end_finder: Finder<'_> = Finder::new(COMMENT_END);
-        // find opening "<script"
-        *pointer += find_script_start(
-            self.source_text,
-            *pointer,
-            &script_start_finder,
-            &comment_start_finder,
-            &comment_end_finder,
-        )?;
+        loop {
+            // find opening "<script"
+            *pointer += find_script_start(
+                self.source_text,
+                *pointer,
+                &script_start_finder,
+                &comment_start_finder,
+                &comment_end_finder,
+            )?;
 
-        // skip `<script-`
-        if !self.source_text[*pointer..].starts_with([' ', '>']) {
-            return self.parse_script(pointer);
+            // skip `<script-...>` tags and keep searching for a real `<script>` block
+            let is_script_tag_boundary = self.source_text[*pointer..]
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_whitespace() || ch == '>');
+            if is_script_tag_boundary {
+                break;
+            }
         }
 
         // find closing ">"
@@ -288,6 +294,81 @@ mod test {
         <script>a</script>
         ";
         let sources = VuePartialLoader::new(source_text).parse();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_text, "a");
+    }
+
+    #[test]
+    fn test_parse_vue_script_tag_allows_newline_after_script_name() {
+        let source_text = r#"
+        <script
+          lang="ts">
+          debugger;
+        </script>
+        "#;
+
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text.trim(), "debugger;");
+        assert!(result.source_type.is_typescript());
+        assert!(result.source_type.is_module());
+    }
+
+    #[test]
+    fn test_parse_vue_script_tag_allows_tab_after_script_name() {
+        let source_text = "<script\tlang=\"ts\">\n  debugger;\n</script>\n";
+
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text.trim(), "debugger;");
+        assert!(result.source_type.is_typescript());
+        assert!(result.source_type.is_module());
+    }
+
+    #[test]
+    fn test_parse_vue_script_tag_with_gt_in_generic_attribute() {
+        let source_text = r#"
+        <script
+            setup
+            lang="ts"
+            generic="Item extends Record<string, string>"
+            >
+            debugger;
+        </script>
+        "#;
+
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text.trim(), "debugger;");
+        assert!(result.source_type.is_typescript());
+        assert!(result.source_type.is_module());
+    }
+
+    #[test]
+    fn test_multiple_scripts_with_multiline_setup_open_tag() {
+        let source_text = r#"
+        <script lang="ts">
+        export interface Props { a: string }
+        </script>
+
+        <script
+            setup
+            lang="ts"
+            generic="Item extends Record<string, string>"
+        >
+        debugger;
+        </script>
+        "#;
+
+        let sources = VuePartialLoader::new(source_text).parse();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].source_text.trim(), "export interface Props { a: string }");
+        assert_eq!(sources[1].source_text.trim(), "debugger;");
+    }
+
+    #[test]
+    fn test_parse_vue_with_many_script_like_tags() {
+        let mut source_text = "<script-setup>noop</script-setup>\n".repeat(2_000);
+        source_text.push_str("<script>a</script>\n");
+
+        let sources = VuePartialLoader::new(&source_text).parse();
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].source_text, "a");
     }


### PR DESCRIPTION
## Summary

`VuePartialLoader::parse_script` has two defects. #20819 already fixed both of them for Svelte. This applies the same two fixes to the Vue loader and mirrors that PR's regression tests.

### 1. A multiline opening tag makes the loader skip the block silently

It only accepted `<script` when the very next byte was a space or `>`, so it missed this:

```vue
<script
    setup
    lang="ts"
>
const by = (a: unknown, b: unknown) => areItemsEquals(a, b);
</script>
```

The check failed, the loader went looking for another `<script`, found none, and the file produced no diagnostics at all. No error, no warning. The HTML spec's space characters are TAB, LF, FF, CR and SPACE, and `@vue/compiler-sfc` accepts all five.

An SFC carrying `<script lang="ts">` and `<script setup>` together is worse than a skipped file. The first block parses. The loader drops the multiline second one, so `parse_scripts` returns a single source and the file looks linted while half of it never was. `test_multiple_scripts_with_multiline_setup_open_tag` pins that case.

### 2. Skipping `<script-...>` tags recurses, and overflows the stack

`parse_script` called itself to keep searching, so many `<script-...>`-like tags exhausted the stack. It overflows reproducibly from around 2000 of them, the size `test_parse_svelte_with_many_script_like_tags` already guards against. A loop replaces the recursion.

Neither check loses the `<script-...>` skip it was written for. A hyphen is neither whitespace nor `>`, and `test_script_in_template` covers it.

## Validation

- `cargo test -p oxc_linter --lib partial_loader::`, 44 passed
- `cargo test -p oxlint --lib -- lint::test::lint_`, 9 passed. The existing `fixtures/cli/vue/debugger.vue` already carries a `<script setup>` with a `generic` attribute, so the CLI suite covered this exact feature and missed the bug on formatting alone. `lint_vue_multiline_script_open_tag` adds the multiline variant, and reports `1` instead of `2` against the current loader
- I ran every new test against the current loader first, and each one fails there: the boundary tests panic on `sources.first().unwrap()`, the dual-block test asserts `1 == 2`, and the many-tags test aborts on stack overflow
- `cargo fmt --check -p oxc_linter -p oxlint` and `cargo clippy` on both crates, clean

## AI usage disclosure

This PR was prepared with AI assistance (Claude Code). I reviewed and take responsibility for the final changes.
