### PR TITLE
ci(lexer): run lint, tests and conformance on both lexer implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,84 @@ jobs:
           just coverage
           git diff --exit-code
 
+  lexer:
+    # `oxc_lexer` compiles to one of two implementations, chosen at build time:
+    # 1. SIMD core on x86_64 with `avx2` + `bmi2`.
+    # 2. Scalar fallback everywhere else.
+    #
+    # Neither feature is in the x86_64 baseline on any platform, so the SIMD core is never built
+    # unless asked for explicitly - which means no other job here lints, tests or runs it.
+    #
+    # Both legs regenerate the committed conformance snapshots and fail on any diff,
+    # which ensures the 2 implementations behave identically to each other.
+    #
+    # See the LEXER section of `justfile` for the flags.
+    name: Lexer (${{ matrix.variant }})
+    runs-on: namespace-profile-linux-x64-default
+    env:
+      CARGO_BUILD_WARNINGS: deny
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: scalar
+            suffix: ""
+          - variant: SIMD
+            suffix: "-simd"
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Check if lexer checks should run
+        id: filter
+        uses: ./.github/actions/check-changes
+        with:
+          packages: oxc_lexer,oxc_coverage
+          paths: crates/oxc_lexer/,tasks/coverage/,.cargo/lexer-simd.toml,justfile,.github/workflows/ci.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+
+      - uses: ./.github/actions/clone-submodules
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          node-compat-table: false
+
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          path: /home/runner/.rustup
+          cache: rust
+
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          tool: just
+
+      - run: rustup component add clippy
+        # No need to run on scalar fallback - linting already covered by "Lint" job
+        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+
+      - name: Lint
+        # No need to run on scalar fallback - already covered by "Lint" job
+        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+        run: just lint-lexer-simd
+
+      - name: Test
+        # No need to run on scalar fallback - already covered by "Test Linux" job
+        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+        run: just test-lexer-simd
+
+      - name: Conformance
+        # Run on both SIMD and scalar fallback - neither is run anywhere else.
+        # The harness prints which implementation it was built with (`oxc_lexer::IS_SIMD`).
+        # Checking it here is what guarantees this leg exercised the build it asked for.
+        if: steps.filter.outputs.changed == 'true'
+        run: |
+          set -o pipefail
+          just conformance-lexer${{ matrix.suffix }} | tee "$RUNNER_TEMP/lexer.log"
+          grep -qxF "Lexer implementation: ${{ matrix.variant }}" "$RUNNER_TEMP/lexer.log" ||
+            { echo "::error::Expected ${{ matrix.variant }}, but the harness reported otherwise"; exit 1; }
+          git diff --exit-code
+
   test-codegen:
     name: Test Codegen
     runs-on: namespace-profile-linux-x64-default

--- a/crates/oxc_lexer/src/lib.rs
+++ b/crates/oxc_lexer/src/lib.rs
@@ -24,6 +24,11 @@ use core::cell::RefCell;
 
 pub const PAD: usize = 64;
 
+/// `true` if the SIMD core is compiled in, `false` if the scalar fallback is.
+/// Used by CI to ensure it's testing the implementation it thinks it is.
+pub const IS_SIMD: bool =
+    cfg!(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"));
+
 thread_local! {
     static SCRATCH: RefCell<Lexer> = RefCell::new(Lexer::new());
 }

--- a/justfile
+++ b/justfile
@@ -186,6 +186,19 @@ conformance-lexer *args='':
 conformance-lexer-simd *args='':
   cargo run -p oxc_coverage --profile coverage {{_lexer-simd}} --features lexer -- lexer {{args}}
 
+# Lint `oxc_lexer` and the conformance harness against the scalar fallback
+[unix]
+lint-lexer *args='':
+  CARGO_BUILD_WARNINGS=deny cargo clippy -p oxc_lexer -p oxc_coverage --all-targets --all-features {{args}}
+
+[windows]
+lint-lexer *args='':
+  $Env:CARGO_BUILD_WARNINGS='deny'; cargo clippy -p oxc_lexer -p oxc_coverage --all-targets --all-features {{args}}
+
+# Lint `oxc_lexer` and the conformance harness against the SIMD core
+lint-lexer-simd *args='':
+  just lint-lexer {{_lexer-simd}} {{args}}
+
 # ==================== LINTER ====================
 
 # oxlint release build

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -380,6 +380,11 @@ impl AppArgs {
     pub fn run_lexer(&self, data: &TestData) {
         #[cfg(all(feature = "lexer", target_endian = "little"))]
         {
+            // Report which implementation was built.
+            // CI checks this line to make sure the build it expected is the build it got.
+            let implementation = if oxc_lexer::IS_SIMD { "SIMD" } else { "scalar" };
+            println!("Lexer implementation: {implementation}");
+
             self.run_tool(
                 "lexer_test262",
                 TEST262_PATH,


### PR DESCRIPTION
#26263 added the ability to run tests and conformance for both versions of `oxc_lexer` (SIMD and scalar fallback) on any platform.

Run tests and conformance on CI (both SIMD and scalar) on any PR which touches `oxc_lexer` crate or other files which affect conformance runner.

Additionally, run Clippy on the SIMD version (main Lint CI task doesn't lint it, due to the `target_feature = "avx2"` gate on the code).

All of this sets up `oxc_lexer` crate for further development, catching any regressions in CI.