### PR TITLE
feat(linter): implement nextjs/no-location-assign-relative-destination

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1107,6 +1107,7 @@ export interface DummyRuleMap {
   "nextjs/no-head-import-in-document"?: RuleNoConfig;
   "nextjs/no-html-link-for-pages"?: RuleNoConfig;
   "nextjs/no-img-element"?: RuleNoConfig;
+  "nextjs/no-location-assign-relative-destination"?: RuleNoConfig;
   "nextjs/no-page-custom-font"?: RuleNoConfig;
   "nextjs/no-script-component-in-head"?: RuleNoConfig;
   "nextjs/no-styled-jsx-in-document"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4503,6 +4503,11 @@ impl RuleRunner for crate::rules::nextjs::no_img_element::NoImgElement {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::nextjs::no_location_assign_relative_destination::NoLocationAssignRelativeDestination {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression, AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::nextjs::no_page_custom_font::NoPageCustomFont {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -363,6 +363,7 @@ pub use crate::rules::nextjs::no_head_element::NoHeadElement as NextjsNoHeadElem
 pub use crate::rules::nextjs::no_head_import_in_document::NoHeadImportInDocument as NextjsNoHeadImportInDocument;
 pub use crate::rules::nextjs::no_html_link_for_pages::NoHtmlLinkForPages as NextjsNoHtmlLinkForPages;
 pub use crate::rules::nextjs::no_img_element::NoImgElement as NextjsNoImgElement;
+pub use crate::rules::nextjs::no_location_assign_relative_destination::NoLocationAssignRelativeDestination as NextjsNoLocationAssignRelativeDestination;
 pub use crate::rules::nextjs::no_page_custom_font::NoPageCustomFont as NextjsNoPageCustomFont;
 pub use crate::rules::nextjs::no_script_component_in_head::NoScriptComponentInHead as NextjsNoScriptComponentInHead;
 pub use crate::rules::nextjs::no_styled_jsx_in_document::NoStyledJsxInDocument as NextjsNoStyledJsxInDocument;
@@ -1590,6 +1591,7 @@ pub enum RuleEnum {
     NextjsNoHeadImportInDocument(NextjsNoHeadImportInDocument),
     NextjsNoHtmlLinkForPages(NextjsNoHtmlLinkForPages),
     NextjsNoImgElement(NextjsNoImgElement),
+    NextjsNoLocationAssignRelativeDestination(NextjsNoLocationAssignRelativeDestination),
     NextjsNoPageCustomFont(NextjsNoPageCustomFont),
     NextjsNoScriptComponentInHead(NextjsNoScriptComponentInHead),
     NextjsNoStyledJsxInDocument(NextjsNoStyledJsxInDocument),
@@ -2556,7 +2558,9 @@ const NEXTJS_NO_HEAD_ELEMENT_ID: usize = NEXTJS_NO_DUPLICATE_HEAD_ID + 1usize;
 const NEXTJS_NO_HEAD_IMPORT_IN_DOCUMENT_ID: usize = NEXTJS_NO_HEAD_ELEMENT_ID + 1usize;
 const NEXTJS_NO_HTML_LINK_FOR_PAGES_ID: usize = NEXTJS_NO_HEAD_IMPORT_IN_DOCUMENT_ID + 1usize;
 const NEXTJS_NO_IMG_ELEMENT_ID: usize = NEXTJS_NO_HTML_LINK_FOR_PAGES_ID + 1usize;
-const NEXTJS_NO_PAGE_CUSTOM_FONT_ID: usize = NEXTJS_NO_IMG_ELEMENT_ID + 1usize;
+const NEXTJS_NO_LOCATION_ASSIGN_RELATIVE_DESTINATION_ID: usize = NEXTJS_NO_IMG_ELEMENT_ID + 1usize;
+const NEXTJS_NO_PAGE_CUSTOM_FONT_ID: usize =
+    NEXTJS_NO_LOCATION_ASSIGN_RELATIVE_DESTINATION_ID + 1usize;
 const NEXTJS_NO_SCRIPT_COMPONENT_IN_HEAD_ID: usize = NEXTJS_NO_PAGE_CUSTOM_FONT_ID + 1usize;
 const NEXTJS_NO_STYLED_JSX_IN_DOCUMENT_ID: usize = NEXTJS_NO_SCRIPT_COMPONENT_IN_HEAD_ID + 1usize;
 const NEXTJS_NO_SYNC_SCRIPTS_ID: usize = NEXTJS_NO_STYLED_JSX_IN_DOCUMENT_ID + 1usize;
@@ -2748,7 +2752,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3443,6 +3447,7 @@ static RULE_NAMES: [&str; 870usize] = [
     NextjsNoHeadImportInDocument::NAME,
     NextjsNoHtmlLinkForPages::NAME,
     NextjsNoImgElement::NAME,
+    NextjsNoLocationAssignRelativeDestination::NAME,
     NextjsNoPageCustomFont::NAME,
     NextjsNoScriptComponentInHead::NAME,
     NextjsNoStyledJsxInDocument::NAME,
@@ -4435,6 +4440,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NEXTJS_NO_HEAD_IMPORT_IN_DOCUMENT_ID,
             Self::NextjsNoHtmlLinkForPages(_) => NEXTJS_NO_HTML_LINK_FOR_PAGES_ID,
             Self::NextjsNoImgElement(_) => NEXTJS_NO_IMG_ELEMENT_ID,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NEXTJS_NO_LOCATION_ASSIGN_RELATIVE_DESTINATION_ID
+            }
             Self::NextjsNoPageCustomFont(_) => NEXTJS_NO_PAGE_CUSTOM_FONT_ID,
             Self::NextjsNoScriptComponentInHead(_) => NEXTJS_NO_SCRIPT_COMPONENT_IN_HEAD_ID,
             Self::NextjsNoStyledJsxInDocument(_) => NEXTJS_NO_STYLED_JSX_IN_DOCUMENT_ID,
@@ -5476,6 +5484,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::CATEGORY,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::CATEGORY,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::CATEGORY,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::CATEGORY
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::CATEGORY,
             Self::NextjsNoScriptComponentInHead(_) => NextjsNoScriptComponentInHead::CATEGORY,
             Self::NextjsNoStyledJsxInDocument(_) => NextjsNoStyledJsxInDocument::CATEGORY,
@@ -6479,6 +6490,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::FIX,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::FIX,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::FIX,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::FIX
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::FIX,
             Self::NextjsNoScriptComponentInHead(_) => NextjsNoScriptComponentInHead::FIX,
             Self::NextjsNoStyledJsxInDocument(_) => NextjsNoStyledJsxInDocument::FIX,
@@ -7684,6 +7698,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::documentation(),
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::documentation(),
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::documentation(),
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::documentation()
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::documentation(),
             Self::NextjsNoScriptComponentInHead(_) => {
                 NextjsNoScriptComponentInHead::documentation()
@@ -9936,6 +9953,10 @@ impl RuleEnum {
                 .or_else(|| NextjsNoHtmlLinkForPages::schema(generator)),
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::config_schema(generator)
                 .or_else(|| NextjsNoImgElement::schema(generator)),
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::config_schema(generator)
+                    .or_else(|| NextjsNoLocationAssignRelativeDestination::schema(generator))
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::config_schema(generator)
                 .or_else(|| NextjsNoPageCustomFont::schema(generator)),
             Self::NextjsNoScriptComponentInHead(_) => {
@@ -11123,6 +11144,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => "nextjs",
             Self::NextjsNoHtmlLinkForPages(_) => "nextjs",
             Self::NextjsNoImgElement(_) => "nextjs",
+            Self::NextjsNoLocationAssignRelativeDestination(_) => "nextjs",
             Self::NextjsNoPageCustomFont(_) => "nextjs",
             Self::NextjsNoScriptComponentInHead(_) => "nextjs",
             Self::NextjsNoStyledJsxInDocument(_) => "nextjs",
@@ -13131,6 +13153,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.run(node, ctx),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.run(node, ctx),
             Self::NextjsNoImgElement(rule) => rule.run(node, ctx),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => rule.run(node, ctx),
             Self::NextjsNoPageCustomFont(rule) => rule.run(node, ctx),
             Self::NextjsNoScriptComponentInHead(rule) => rule.run(node, ctx),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.run(node, ctx),
@@ -14018,6 +14041,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.run_once(ctx),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.run_once(ctx),
             Self::NextjsNoImgElement(rule) => rule.run_once(ctx),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => rule.run_once(ctx),
             Self::NextjsNoPageCustomFont(rule) => rule.run_once(ctx),
             Self::NextjsNoScriptComponentInHead(rule) => rule.run_once(ctx),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.run_once(ctx),
@@ -15014,6 +15038,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsNoImgElement(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::NextjsNoPageCustomFont(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsNoScriptComponentInHead(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15910,6 +15937,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.should_run(ctx),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.should_run(ctx),
             Self::NextjsNoImgElement(rule) => rule.should_run(ctx),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => rule.should_run(ctx),
             Self::NextjsNoPageCustomFont(rule) => rule.should_run(ctx),
             Self::NextjsNoScriptComponentInHead(rule) => rule.should_run(ctx),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.should_run(ctx),
@@ -17106,6 +17134,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::IS_TSGOLINT_RULE,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::IS_TSGOLINT_RULE,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::IS_TSGOLINT_RULE,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::IS_TSGOLINT_RULE
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::IS_TSGOLINT_RULE,
             Self::NextjsNoScriptComponentInHead(_) => {
                 NextjsNoScriptComponentInHead::IS_TSGOLINT_RULE
@@ -18200,6 +18231,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::VERSION,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::VERSION,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::VERSION,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::VERSION
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::VERSION,
             Self::NextjsNoScriptComponentInHead(_) => NextjsNoScriptComponentInHead::VERSION,
             Self::NextjsNoStyledJsxInDocument(_) => NextjsNoStyledJsxInDocument::VERSION,
@@ -19281,6 +19315,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::HAS_CONFIG,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::HAS_CONFIG,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::HAS_CONFIG,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::HAS_CONFIG
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::HAS_CONFIG,
             Self::NextjsNoScriptComponentInHead(_) => NextjsNoScriptComponentInHead::HAS_CONFIG,
             Self::NextjsNoStyledJsxInDocument(_) => NextjsNoStyledJsxInDocument::HAS_CONFIG,
@@ -20293,6 +20330,9 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(_) => NextjsNoHeadImportInDocument::INFO,
             Self::NextjsNoHtmlLinkForPages(_) => NextjsNoHtmlLinkForPages::INFO,
             Self::NextjsNoImgElement(_) => NextjsNoImgElement::INFO,
+            Self::NextjsNoLocationAssignRelativeDestination(_) => {
+                NextjsNoLocationAssignRelativeDestination::INFO
+            }
             Self::NextjsNoPageCustomFont(_) => NextjsNoPageCustomFont::INFO,
             Self::NextjsNoScriptComponentInHead(_) => NextjsNoScriptComponentInHead::INFO,
             Self::NextjsNoStyledJsxInDocument(_) => NextjsNoStyledJsxInDocument::INFO,
@@ -21180,6 +21220,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.types_info(),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.types_info(),
             Self::NextjsNoImgElement(rule) => rule.types_info(),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => rule.types_info(),
             Self::NextjsNoPageCustomFont(rule) => rule.types_info(),
             Self::NextjsNoScriptComponentInHead(rule) => rule.types_info(),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.types_info(),
@@ -22054,6 +22095,7 @@ impl RuleEnum {
             Self::NextjsNoHeadImportInDocument(rule) => rule.run_info(),
             Self::NextjsNoHtmlLinkForPages(rule) => rule.run_info(),
             Self::NextjsNoImgElement(rule) => rule.run_info(),
+            Self::NextjsNoLocationAssignRelativeDestination(rule) => rule.run_info(),
             Self::NextjsNoPageCustomFont(rule) => rule.run_info(),
             Self::NextjsNoScriptComponentInHead(rule) => rule.run_info(),
             Self::NextjsNoStyledJsxInDocument(rule) => rule.run_info(),
@@ -23056,6 +23098,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NextjsNoHeadImportInDocument(NextjsNoHeadImportInDocument::default()),
         RuleEnum::NextjsNoHtmlLinkForPages(NextjsNoHtmlLinkForPages::default()),
         RuleEnum::NextjsNoImgElement(NextjsNoImgElement::default()),
+        RuleEnum::NextjsNoLocationAssignRelativeDestination(
+            NextjsNoLocationAssignRelativeDestination::default(),
+        ),
         RuleEnum::NextjsNoPageCustomFont(NextjsNoPageCustomFont::default()),
         RuleEnum::NextjsNoScriptComponentInHead(NextjsNoScriptComponentInHead::default()),
         RuleEnum::NextjsNoStyledJsxInDocument(NextjsNoStyledJsxInDocument::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -785,6 +785,7 @@ pub(crate) mod nextjs {
     pub mod no_head_import_in_document;
     pub mod no_html_link_for_pages;
     pub mod no_img_element;
+    pub mod no_location_assign_relative_destination;
     pub mod no_page_custom_font;
     pub mod no_script_component_in_head;
     pub mod no_styled_jsx_in_document;

--- a/crates/oxc_linter/src/rules/nextjs/no_location_assign_relative_destination.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_location_assign_relative_destination.rs
@@ -1,0 +1,523 @@
+use std::borrow::Cow;
+
+use oxc_ast::{
+    AstKind,
+    ast::{AssignmentTarget, Expression, IdentifierReference, MemberExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::{GlobalContext, ToBoolean, ToJsString};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::BinaryOperator;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_location_assign_relative_destination_diagnostic(
+    span: Span,
+    expression: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Do not use `{expression}` to navigate to internal Next.js pages."
+    ))
+        .with_help(
+            "Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoLocationAssignRelativeDestination;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents assignments to `location.href` and calls to `location.assign()`
+    /// with relative URLs.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Next.js cannot apply client-side routing optimizations when browser location
+    /// APIs navigate directly to an internal page. Use Next.js navigation APIs to
+    /// avoid a full page reload.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// location.href = "/dashboard";
+    /// window.location.assign("/profile");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// location.href = "https://example.com";
+    /// window.location.assign(externalUrl);
+    /// ```
+    NoLocationAssignRelativeDestination,
+    nextjs,
+    correctness,
+    version = "next",
+    short_description = "Prevents browser location APIs from navigating to internal Next.js pages.",
+);
+
+impl Rule for NoLocationAssignRelativeDestination {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::CallExpression(call) => {
+                let Some(callee) = call.callee.as_member_expression() else {
+                    return;
+                };
+                if !is_named_property(callee, "assign") {
+                    return;
+                }
+
+                let Some(root) = get_location_root_identifier(callee.object()) else {
+                    return;
+                };
+                if !ctx.is_reference_to_global_variable(root) {
+                    return;
+                }
+
+                let Some(argument) = call.arguments.first().and_then(|arg| arg.as_expression())
+                else {
+                    return;
+                };
+                if !has_relative_url_prefix(argument, ctx) {
+                    return;
+                }
+
+                let expression = format!("{}()", ctx.source_range(callee.span()));
+                ctx.diagnostic(no_location_assign_relative_destination_diagnostic(
+                    call.span,
+                    &expression,
+                ));
+            }
+            AstKind::AssignmentExpression(assignment) => {
+                let Some(target) = assignment.left.as_member_expression() else {
+                    return;
+                };
+                if !is_named_property(target, "href") {
+                    return;
+                }
+
+                let Some(root) = get_location_root_identifier(target.object()) else {
+                    return;
+                };
+                if !ctx.is_reference_to_global_variable(root)
+                    || !has_relative_url_prefix(&assignment.right, ctx)
+                {
+                    return;
+                }
+
+                ctx.diagnostic(no_location_assign_relative_destination_diagnostic(
+                    assignment.span,
+                    ctx.source_range(target.span()),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+const GLOBAL_LOCATION_PREFIXES: [&str; 4] = ["window", "globalThis", "document", "self"];
+
+fn is_named_property(member: &MemberExpression<'_>, name: &str) -> bool {
+    match member {
+        MemberExpression::StaticMemberExpression(member) => member.property.name == name,
+        MemberExpression::ComputedMemberExpression(member) => {
+            matches!(&member.expression, Expression::StringLiteral(literal) if literal.value == name)
+        }
+        MemberExpression::PrivateFieldExpression(_) => false,
+    }
+}
+
+fn get_location_root_identifier<'a>(
+    object: &'a Expression<'a>,
+) -> Option<&'a IdentifierReference<'a>> {
+    let object = object.get_inner_expression();
+    if let Expression::Identifier(identifier) = object
+        && identifier.name == "location"
+    {
+        return Some(identifier);
+    }
+
+    let location = object.as_member_expression()?;
+    if !is_named_property(location, "location") {
+        return None;
+    }
+
+    let root = location.object().get_inner_expression().get_identifier_reference()?;
+    GLOBAL_LOCATION_PREFIXES.contains(&root.name.as_str()).then_some(root)
+}
+
+fn has_relative_url_prefix<'a>(expression: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    static_string_prefix(expression, ctx, 0).is_some_and(|value| !is_absolute_url(&value))
+}
+
+struct RuleGlobalContext<'c, 'a>(&'c LintContext<'a>);
+
+impl<'a> GlobalContext<'a> for RuleGlobalContext<'_, 'a> {
+    fn is_global_reference(&self, reference: &IdentifierReference<'a>) -> bool {
+        self.0.is_reference_to_global_variable(reference)
+    }
+}
+
+fn static_string_prefix<'a>(
+    expression: &Expression<'a>,
+    ctx: &LintContext<'a>,
+    depth: u8,
+) -> Option<Cow<'a, str>> {
+    if depth >= 16 {
+        return None;
+    }
+
+    if let Some(value) = static_string_value(expression, ctx, depth) {
+        return Some(value);
+    }
+
+    match expression.get_inner_expression() {
+        Expression::TemplateLiteral(template) => {
+            let quasi = template.quasis.first()?;
+            let value = quasi.value.cooked.as_ref().unwrap_or(&quasi.value.raw);
+            Some(Cow::Borrowed(value.as_str()))
+        }
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+            static_string_prefix(&binary.left, ctx, depth + 1)
+        }
+        Expression::Identifier(identifier) => last_write_expression(identifier, ctx)
+            .and_then(|value| static_string_prefix(value, ctx, depth + 1)),
+        _ => None,
+    }
+}
+
+fn static_string_value<'a>(
+    expression: &Expression<'a>,
+    ctx: &LintContext<'a>,
+    depth: u8,
+) -> Option<Cow<'a, str>> {
+    if depth >= 16 {
+        return None;
+    }
+
+    let expression = expression.get_inner_expression();
+    match expression {
+        Expression::Identifier(identifier) => last_write_expression(identifier, ctx)
+            .and_then(|value| static_string_value(value, ctx, depth + 1)),
+        Expression::TemplateLiteral(template) => {
+            let first = template.quasis.first()?.value.cooked.as_ref()?;
+            if template.expressions.is_empty() {
+                return Some(Cow::Borrowed(first.as_str()));
+            }
+
+            let mut value = first.as_str().to_owned();
+            for (substitution, quasi) in
+                template.expressions.iter().zip(template.quasis.iter().skip(1))
+            {
+                value.push_str(&static_string_value(substitution, ctx, depth + 1)?);
+                value.push_str(quasi.value.cooked.as_ref()?.as_str());
+            }
+            Some(Cow::Owned(value))
+        }
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+            if !is_definitely_string(&binary.left, ctx, depth + 1)
+                && !is_definitely_string(&binary.right, ctx, depth + 1)
+            {
+                return None;
+            }
+            let left = static_string_value(&binary.left, ctx, depth + 1)?;
+            let right = static_string_value(&binary.right, ctx, depth + 1)?;
+            let mut value = left.into_owned();
+            value.push_str(&right);
+            Some(Cow::Owned(value))
+        }
+        Expression::ConditionalExpression(conditional) => {
+            let branch = if static_truthiness(&conditional.test, ctx, depth + 1)? {
+                &conditional.consequent
+            } else {
+                &conditional.alternate
+            };
+            static_string_value(branch, ctx, depth + 1)
+        }
+        Expression::SequenceExpression(sequence) => {
+            sequence.expressions.last().and_then(|value| static_string_value(value, ctx, depth + 1))
+        }
+        Expression::CallExpression(call) => {
+            let callee = call.callee.get_identifier_reference()?;
+            if callee.name != "String" || !ctx.is_reference_to_global_variable(callee) {
+                return None;
+            }
+
+            call.arguments.first().map_or(Some(Cow::Borrowed("")), |argument| {
+                static_string_value(argument.as_expression()?, ctx, depth + 1)
+            })
+        }
+        _ => expression.to_js_string(&RuleGlobalContext(ctx)),
+    }
+}
+
+fn is_definitely_string<'a>(expression: &Expression<'a>, ctx: &LintContext<'a>, depth: u8) -> bool {
+    if depth >= 16 {
+        return false;
+    }
+
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => true,
+        Expression::Identifier(identifier) => last_write_expression(identifier, ctx)
+            .is_some_and(|value| is_definitely_string(value, ctx, depth + 1)),
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+            is_definitely_string(&binary.left, ctx, depth + 1)
+                || is_definitely_string(&binary.right, ctx, depth + 1)
+        }
+        Expression::ConditionalExpression(conditional) => {
+            let Some(test) = static_truthiness(&conditional.test, ctx, depth + 1) else {
+                return false;
+            };
+            let branch = if test { &conditional.consequent } else { &conditional.alternate };
+            is_definitely_string(branch, ctx, depth + 1)
+        }
+        Expression::SequenceExpression(sequence) => sequence
+            .expressions
+            .last()
+            .is_some_and(|value| is_definitely_string(value, ctx, depth + 1)),
+        Expression::CallExpression(call) => {
+            call.callee.get_identifier_reference().is_some_and(|callee| {
+                callee.name == "String" && ctx.is_reference_to_global_variable(callee)
+            })
+        }
+        _ => false,
+    }
+}
+
+fn static_truthiness<'a>(
+    expression: &Expression<'a>,
+    ctx: &LintContext<'a>,
+    depth: u8,
+) -> Option<bool> {
+    if depth >= 16 {
+        return None;
+    }
+
+    let expression = expression.get_inner_expression();
+    match expression {
+        Expression::Identifier(identifier) => last_write_expression(identifier, ctx)
+            .and_then(|value| static_truthiness(value, ctx, depth + 1)),
+        Expression::SequenceExpression(sequence) => {
+            sequence.expressions.last().and_then(|value| static_truthiness(value, ctx, depth + 1))
+        }
+        _ => expression.to_boolean(&RuleGlobalContext(ctx)),
+    }
+}
+
+fn last_write_expression<'a>(
+    identifier: &IdentifierReference<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<&'a Expression<'a>> {
+    let symbol_id = ctx.scoping().get_reference(identifier.reference_id()).symbol_id()?;
+    let declaration = ctx.symbol_declaration(symbol_id);
+    let AstKind::VariableDeclarator(declarator) = declaration.kind() else {
+        return None;
+    };
+
+    let mut latest = declarator.init.as_ref().map(|initial| (declarator.span.start, initial));
+    for reference in ctx.symbol_references(symbol_id) {
+        if !reference.is_write() {
+            continue;
+        }
+
+        let reference_span = ctx.nodes().get_node(reference.node_id()).kind().span();
+        if reference_span.start >= identifier.span.start {
+            continue;
+        }
+
+        let AstKind::AssignmentExpression(assignment) =
+            ctx.nodes().parent_kind(reference.node_id())
+        else {
+            continue;
+        };
+        let AssignmentTarget::AssignmentTargetIdentifier(target) = &assignment.left else {
+            continue;
+        };
+        if ctx.scoping().get_reference(target.reference_id()).symbol_id() != Some(symbol_id) {
+            continue;
+        }
+
+        if latest.is_none_or(|(position, _)| reference_span.start > position) {
+            latest = Some((reference_span.start, &assignment.right));
+        }
+    }
+
+    latest.map(|(_, expression)| expression)
+}
+
+fn is_absolute_url(value: &str) -> bool {
+    if value.starts_with("//") {
+        return true;
+    }
+
+    let mut chars = value.chars();
+    if !chars.next().is_some_and(|first| first.is_ascii_alphabetic()) {
+        return false;
+    }
+
+    for character in chars {
+        if character == ':' {
+            return true;
+        }
+        if !(character.is_ascii_alphanumeric() || matches!(character, '+' | '.' | '-')) {
+            return false;
+        }
+    }
+
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // no-location-assign-relative-destination
+        "location.href = 'https://example.com'",
+        "location.href = 'https://example.com/path?q=1'",
+        "window.location.href = 'https://example.com'",
+        "globalThis.location.href = 'https://example.com'",
+        "location.assign('https://example.com')",
+        "window.location.assign('https://example.com')",
+        "globalThis.location.assign('https://example.com')",
+        "location.href = '//example.com/path'",
+        "location.assign('//cdn.example.com/file.js')",
+        "location.href = 'ftp://files.example.com'",
+        "location.href = 'mailto:user@example.com'",
+        "location.href = 'CUSTOM+SCHEME:value'",
+        "location.href = 'https' + '://example.com/path'",
+        "location.href = `https://example.com/${path}`",
+        "location.href = `${'https://example.com'}`",
+        "location.href = true ? 'https://example.com' : '/dashboard'",
+        "location.href = String('https://example.com')",
+        "location.assign(`https://example.com/${path}`)",
+        "location.href = someVariable",
+        "location.assign(someVariable)",
+        "window.location.href = computedUrl()",
+        "window.location.assign(computedUrl())",
+        "location.assign()",
+        "location.assign(...urls)",
+        "location[`assign`]('/foo')",
+        "location[`href`] = '/foo'",
+        "
+                  const url = 'https://example.com';
+                  location.href = url;
+                  location.assign(url);
+                ",
+        "
+                  const url = 'https://example.com/' + someVariable;
+                  location.href = url;
+                  location.assign(url);
+                ",
+        "
+                  const url = `https://example.com/${someVariable}`;
+                  location.href = url;
+                  location.assign(url);
+                ",
+        "foo.location.href = '/path'",
+        "foo.location.assign('/path')",
+        "
+                  let url = '/dashboard';
+                  url = 'https://example.com';
+                  location.href = url;
+                ",
+        "
+                  const location = { href: '' };
+                  location.href = '/foo'
+                ",
+        "function handler(location) { location.href = '/foo'; location.assign('/foo') }",
+        "
+                  const window = { location: { href: '' } };
+                  window.location.href = '/foo'
+                ",
+        "
+                  function handler(globalThis) {
+                    globalThis.location.assign('/foo')
+                  }
+                ",
+        "function handler(document) { document.location.href = '/foo' }",
+        "function handler(self) { self.location.assign('/foo') }",
+        "function handler(String) { location.href = String('/foo') }",
+        "const protocol = 'https'; location.href = `${protocol}://example.com`",
+        "
+                  import { location } from './my-module';
+                  location.href = '/foo'
+                ",
+    ];
+
+    let fail = vec![
+        // no-location-assign-relative-destination
+        "location.href = '/foo'",
+        "location['href'] = '/foo'",
+        "location.href = `/users/${id}`",
+        "window.location.href = '/foo'",
+        "window.location.href = '/dashboard'",
+        "window.location['href'] = '/foo'",
+        "window.location['href'] = '/dashboard'",
+        "globalThis.location.href = '/foo'",
+        "globalThis.location.href = '/dashboard'",
+        "document.location.href = '/foo'",
+        "self.location.href = '/foo'",
+        "window['location'].href = '/foo'",
+        "location.assign('/foo')",
+        "location.assign('/dashboard')",
+        "location['assign']('/foo')",
+        "location['assign']('/dashboard')",
+        "location.assign(`/users/${id}/profile`)",
+        "window.location.assign('/foo')",
+        "window.location.assign('/dashboard')",
+        "window.location['assign']('/foo')",
+        "globalThis.location.assign('/foo')",
+        "globalThis.location.assign('/dashboard')",
+        "document.location.assign('/foo')",
+        "self.location.assign('/foo')",
+        "globalThis['location']['assign']('/foo')",
+        "location.href = './page'",
+        "location.href = '../page'",
+        "location.assign('?tab=settings')",
+        "location.assign('#section')",
+        "location.href = true ? '/dashboard' : 'https://example.com'",
+        "location.href = (0, '/dashboard')",
+        "location.href = String('/dashboard')",
+        "location.href = String()",
+        "location.href = (true + false) + ':'",
+        "const useInternal = true; const url = useInternal ? '/dashboard' : 'https://example.com'; location.href = url",
+        "
+                      const url = '/dashboard';
+                      location.href = url;",
+        "
+                      const url = '/dashboard/' + someVariable;
+                      location.href = url;",
+        "
+                      const url = `/dashboard/${someVariable}`;
+                      location.href = url;",
+        "
+                      let url = 'https://example.com';
+                      url = '/other-path';
+                      location.href = url;",
+        "
+                      let url = '/dashboard';
+                      location.href = url;
+                      url = 'https://example.com';",
+        "
+                      function handleClick() {
+                        window.location.href = '/dashboard'
+                      }",
+        "
+                      function handleClick() {
+                        location.assign('/dashboard')
+                      }",
+    ];
+
+    Tester::new(
+        NoLocationAssignRelativeDestination::NAME,
+        NoLocationAssignRelativeDestination::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/nextjs_no_location_assign_relative_destination.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_location_assign_relative_destination.snap
@@ -1,0 +1,307 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = '/foo'
+   · ──────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location['href']` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location['href'] = '/foo'
+   · ─────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = `/users/${id}`
+   · ──────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location.href = '/foo'
+   · ─────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location.href = '/dashboard'
+   · ───────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location['href']` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location['href'] = '/foo'
+   · ────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location['href']` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location['href'] = '/dashboard'
+   · ──────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `globalThis.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ globalThis.location.href = '/foo'
+   · ─────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `globalThis.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ globalThis.location.href = '/dashboard'
+   · ───────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `document.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ document.location.href = '/foo'
+   · ───────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `self.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ self.location.href = '/foo'
+   · ───────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window['location'].href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window['location'].href = '/foo'
+   · ────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.assign('/foo')
+   · ───────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.assign('/dashboard')
+   · ─────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location['assign']()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location['assign']('/foo')
+   · ──────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location['assign']()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location['assign']('/dashboard')
+   · ────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.assign(`/users/${id}/profile`)
+   · ───────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location.assign('/foo')
+   · ──────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location.assign('/dashboard')
+   · ────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location['assign']()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ window.location['assign']('/foo')
+   · ─────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `globalThis.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ globalThis.location.assign('/foo')
+   · ──────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `globalThis.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ globalThis.location.assign('/dashboard')
+   · ────────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `document.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ document.location.assign('/foo')
+   · ────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `self.location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ self.location.assign('/foo')
+   · ────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `globalThis['location']['assign']()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ globalThis['location']['assign']('/foo')
+   · ────────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = './page'
+   · ────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = '../page'
+   · ─────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.assign('?tab=settings')
+   · ────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.assign('#section')
+   · ───────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = true ? '/dashboard' : 'https://example.com'
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = (0, '/dashboard')
+   · ─────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = String('/dashboard')
+   · ────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = String()
+   · ────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:1]
+ 1 │ location.href = (true + false) + ':'
+   · ────────────────────────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:1:91]
+ 1 │ const useInternal = true; const url = useInternal ? '/dashboard' : 'https://example.com'; location.href = url
+   ·                                                                                           ───────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:23]
+ 2 │                       const url = '/dashboard';
+ 3 │                       location.href = url;
+   ·                       ───────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:23]
+ 2 │                       const url = '/dashboard/' + someVariable;
+ 3 │                       location.href = url;
+   ·                       ───────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:23]
+ 2 │                       const url = `/dashboard/${someVariable}`;
+ 3 │                       location.href = url;
+   ·                       ───────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:4:23]
+ 3 │                       url = '/other-path';
+ 4 │                       location.href = url;
+   ·                       ───────────────────
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:23]
+ 2 │                       let url = '/dashboard';
+ 3 │                       location.href = url;
+   ·                       ───────────────────
+ 4 │                       url = 'https://example.com';
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `window.location.href` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:25]
+ 2 │                       function handleClick() {
+ 3 │                         window.location.href = '/dashboard'
+   ·                         ───────────────────────────────────
+ 4 │                       }
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.
+
+  ⚠ next(no-location-assign-relative-destination): Do not use `location.assign()` to navigate to internal Next.js pages.
+   ╭─[no_location_assign_relative_destination.tsx:3:25]
+ 2 │                       function handleClick() {
+ 3 │                         location.assign('/dashboard')
+   ·                         ─────────────────────────────
+ 4 │                       }
+   ╰────
+  help: Use `redirect()` during rendering, or `useRouter().push()` in a Client Component event handler.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -4441,6 +4441,9 @@
         "nextjs/no-img-element": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "nextjs/no-location-assign-relative-destination": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "nextjs/no-page-custom-font": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -349,6 +349,7 @@ nextjs/no-duplicate-head                                   |    103
 nextjs/no-head-element                                     |    452
 nextjs/no-html-link-for-pages                              |    452
 nextjs/no-img-element                                      |    452
+nextjs/no-location-assign-relative-destination             |  75611
 nextjs/no-page-custom-font                                 |    452
 nextjs/no-script-component-in-head                         |    103
 nextjs/no-styled-jsx-in-document                           |    452


### PR DESCRIPTION
## Summary

- implement `nextjs/no-location-assign-relative-destination` as a native Oxlint rule
- port the Next.js 16.3.0 rule corpus and add coverage for global aliases, computed members, shadowing, reassignment, and statically known URL prefixes
- register the rule and regenerate configuration schemas, TypeScript types, snapshots, and linter timings

Follows up on #1929.

## Validation

- `cargo fmt --all -- --check`
- `cargo lintgen`
- `cargo lint-timings`
- `cargo clippy -p oxc_linter --all-targets --all-features -- -D warnings`
- `cargo test -p oxc_linter`
- `pnpm --filter oxlint-app generate-config-types`

## AI usage

Codex assisted with comparing the upstream Next.js implementation, implementing the rule, adapting the tests, and reviewing the final diff. The changes were validated against the imported upstream corpus plus the additional edge cases above, and the full `oxc_linter` test suite passes.