### PR TITLE
feat(minifier): conflate assignments with equal values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "oxc_traverse",
  "pico-args",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -38,6 +38,7 @@ cow-utils = { workspace = true }
 itoa = { workspace = true }
 lazy-regex = { workspace = true }
 rustc-hash = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 oxc_codegen = { workspace = true, features = ["sourcemap"] }

--- a/crates/oxc_minifier/src/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/src/peephole/conflate_assignments.rs
@@ -363,8 +363,17 @@ fn symbol_is_stable(
     let may_be_mapped_parameter = symbol_flags.is_function_scoped_declaration()
         && !symbol_flags.is_catch_variable()
         && !scope_flags.is_strict_mode();
+    // Later declaration initializers are not write references. A setter can
+    // resume a generator and execute one between the original evaluations.
+    let has_multiple_value_declarations = scoping
+        .symbol_redeclarations(symbol_id)
+        .iter()
+        .filter(|declaration| declaration.flags.is_value())
+        .nth(1)
+        .is_some();
     let stable = !(scope_flags.contains(ScopeFlags::DirectEval)
         || may_be_mapped_parameter
+        || has_multiple_value_declarations
         || PeepholeOptimizations::symbol_value_may_change(symbol_id, ctx));
     cache.entries[cache.next] = Some((symbol_id, stable));
     cache.next = (cache.next + 1) % cache.entries.len();

--- a/crates/oxc_minifier/src/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/src/peephole/conflate_assignments.rs
@@ -1,0 +1,372 @@
+use smallvec::SmallVec;
+
+use oxc_allocator::ArenaVec;
+use oxc_ast::ast::*;
+use oxc_ast_visit::{VisitJs, walk_js};
+use oxc_ecmascript::{
+    constant_evaluation::{DetermineValueType, ValueType},
+    side_effects::MayHaveSideEffects,
+};
+use oxc_span::ContentEq;
+use oxc_syntax::{scope::ScopeFlags, symbol::SymbolId};
+
+use crate::TraverseCtx;
+
+use super::PeepholeOptimizations;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AssignmentGroup {
+    Identifiers,
+    StaticMembers(StableObject),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StableObject {
+    Symbol(SymbolId),
+    This,
+}
+
+struct StableIdentifierVisitor<'c, 'a> {
+    ctx: &'c TraverseCtx<'a>,
+    cache: &'c mut StableSymbolCache,
+    stable: bool,
+}
+
+#[derive(Default)]
+struct StableSymbolCache {
+    entries: [Option<(SymbolId, bool)>; 8],
+    next: usize,
+}
+
+impl<'a> VisitJs<'a> for StableIdentifierVisitor<'_, 'a> {
+    fn visit_expression(&mut self, expr: &Expression<'a>) {
+        if !self.stable {
+            return;
+        }
+
+        match expr {
+            Expression::Identifier(ident) => self.visit_identifier_reference(ident),
+            Expression::ThisExpression(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::StringLiteral(_) => {}
+            Expression::BinaryExpression(binary) => {
+                let coerces_operands = matches!(
+                    binary.operator,
+                    BinaryOperator::Equality
+                        | BinaryOperator::Inequality
+                        | BinaryOperator::LessThan
+                        | BinaryOperator::LessEqualThan
+                        | BinaryOperator::GreaterThan
+                        | BinaryOperator::GreaterEqualThan
+                );
+                if coerces_operands
+                    && [&binary.left, &binary.right].iter().any(|operand| {
+                        matches!(
+                            operand.value_type(self.ctx),
+                            ValueType::Object | ValueType::Undetermined
+                        )
+                    })
+                {
+                    self.stable = false;
+                } else {
+                    walk_js::walk_expression(self, expr);
+                }
+            }
+            Expression::TemplateLiteral(_)
+            | Expression::ConditionalExpression(_)
+            | Expression::LogicalExpression(_)
+            | Expression::ParenthesizedExpression(_)
+            | Expression::SequenceExpression(_)
+            | Expression::UnaryExpression(_)
+            | Expression::PrivateInExpression(_) => walk_js::walk_expression(self, expr),
+            _ => self.stable = false,
+        }
+    }
+
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.stable = symbol_for_identifier(ident, self.ctx)
+            .is_some_and(|symbol_id| symbol_is_stable(symbol_id, self.ctx, self.cache));
+    }
+}
+
+impl<'a> PeepholeOptimizations {
+    /// Statement fusion creates sequence expressions after their expression-exit hook has run.
+    /// Finish assignment-specific sequence rewrites at the statement-list boundary so they share
+    /// fusion's follow-up pass instead of forcing another whole-program iteration.
+    pub(super) fn conflate_assignments_after_statement_fusion(
+        statements: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if ctx.is_tree_shake_only() || ctx.current_scope_flags().contains(ScopeFlags::DirectEval) {
+            return;
+        }
+        for statement in statements {
+            if let Statement::ExpressionStatement(expr_stmt) = statement
+                && let Expression::SequenceExpression(sequence) = &mut expr_stmt.expression
+                && Self::conflate_assignments(sequence, ctx)
+            {
+                Self::remove_sequence_expression(&mut expr_stmt.expression, ctx);
+            }
+        }
+    }
+
+    /// `x = value, y = value` -> `y = x = value`
+    ///
+    /// The outer assignment target moves before the inner assignment, so this is restricted to
+    /// bound identifiers or static properties on the same stable object. The duplicated value
+    /// must also be repeatable: evaluating it once must produce the same value as evaluating it
+    /// twice, even when an intervening property setter can run arbitrary code.
+    pub(super) fn conflate_assignments(
+        sequence: &mut SequenceExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        if sequence.expressions.len() < 2
+            || ctx.current_scope_flags().contains(ScopeFlags::DirectEval)
+        {
+            return false;
+        }
+
+        // `symbol_is_mutated` scans a symbol's references when no `SymbolValue` cache exists
+        // (notably for parameters). Memoize those queries so long assignment runs stay linear.
+        let mut stable_symbol_cache = StableSymbolCache::default();
+
+        // Keep short run lists on the stack. Large sequence expressions with more than eight
+        // disjoint conflation runs spill once, instead of allocating once per transformed run.
+        let mut ranges: SmallVec<[std::ops::Range<usize>; 8]> = SmallVec::new();
+        let mut start = 0;
+        while start + 1 < sequence.expressions.len() {
+            let Some((group, rhs)) = can_start_run(
+                &sequence.expressions[start],
+                &sequence.expressions[start + 1],
+                ctx,
+                &mut stable_symbol_cache,
+            ) else {
+                start += 1;
+                continue;
+            };
+            let mut end = start + 2;
+            while end < sequence.expressions.len()
+                && assignment_chain(&sequence.expressions[end], ctx).is_some_and(
+                    |(next_group, next_rhs)| next_group == group && rhs.content_eq(next_rhs),
+                )
+            {
+                end += 1;
+            }
+            ranges.push(start..end);
+            start = end;
+        }
+        if ranges.is_empty() {
+            return false;
+        }
+
+        // Move each preceding assignment into the next assignment's RHS with a swap. The duplicate
+        // RHS moves into the now-dead preceding slot, so no dummy AST nodes or arena allocations are
+        // needed. All dead slots are compacted out of the existing vector in one retain pass below.
+        for range in &ranges {
+            for index in range.start + 1..range.end {
+                let (before, current_and_after) = sequence.expressions.split_at_mut(index);
+                let previous = &mut before[index - 1];
+                let current_rhs = assignment_chain_rhs_mut(&mut current_and_after[0]);
+                std::mem::swap(previous, current_rhs);
+                ctx.drop_expression(previous);
+            }
+        }
+
+        let mut index = 0;
+        let mut ranges = ranges.into_iter().peekable();
+        sequence.expressions.retain(|_| {
+            let keep =
+                ranges.peek().is_none_or(|range| index < range.start || index + 1 == range.end);
+            index += 1;
+            if ranges.peek().is_some_and(|range| index == range.end) {
+                ranges.next();
+            }
+            keep
+        });
+        true
+    }
+
+    /// Merge the equal assignments at the boundary of two sequences without flattening either
+    /// arena vector. Codegen prints nested sequences flat, so leaving an eligible boundary for a
+    /// reparse would make compression non-idempotent.
+    pub(super) fn conflate_assignment_sequence_boundary(
+        previous: &mut SequenceExpression<'a>,
+        current: &mut SequenceExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        if ctx.current_scope_flags().contains(ScopeFlags::DirectEval) {
+            return false;
+        }
+        let Some(previous_expression) = previous.expressions.last() else { return false };
+        let Some(current_expression) = current.expressions.first() else { return false };
+        let mut stable_symbol_cache = StableSymbolCache::default();
+        if can_start_run(previous_expression, current_expression, ctx, &mut stable_symbol_cache)
+            .is_none()
+        {
+            return false;
+        }
+
+        let previous_expression = previous.expressions.last_mut().unwrap();
+        let current_rhs = assignment_chain_rhs_mut(current.expressions.first_mut().unwrap());
+        std::mem::swap(previous_expression, current_rhs);
+        ctx.drop_expression(previous_expression);
+        previous.expressions.pop();
+        true
+    }
+}
+
+fn can_start_run<'b, 'a>(
+    previous: &'b Expression<'a>,
+    current: &Expression<'a>,
+    ctx: &TraverseCtx<'a>,
+    stable_symbol_cache: &mut StableSymbolCache,
+) -> Option<(AssignmentGroup, &'b Expression<'a>)> {
+    let (group, rhs) = assignment_chain(previous, ctx)?;
+    let (next_group, next_rhs) = assignment_chain(current, ctx)?;
+    (group == next_group
+        && rhs.content_eq(next_rhs)
+        && assignment_group_is_stable(group, ctx, stable_symbol_cache)
+        && rhs_is_repeatable(rhs, ctx, stable_symbol_cache))
+    .then_some((group, rhs))
+}
+
+fn assignment_chain<'b, 'a>(
+    expression: &'b Expression<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> Option<(AssignmentGroup, &'b Expression<'a>)> {
+    let Expression::AssignmentExpression(assignment) = expression else { return None };
+    if assignment.operator != AssignmentOperator::Assign {
+        return None;
+    }
+    let group = assignment_group(&assignment.left, ctx)?;
+    let mut rhs = &assignment.right;
+    while let Expression::AssignmentExpression(assignment) = rhs {
+        if assignment.operator != AssignmentOperator::Assign {
+            return None;
+        }
+        let next_group = assignment_group(&assignment.left, ctx)?;
+        if group != next_group {
+            return None;
+        }
+        rhs = &assignment.right;
+    }
+    Some((group, rhs))
+}
+
+fn assignment_chain_rhs_mut<'b, 'a>(expression: &'b mut Expression<'a>) -> &'b mut Expression<'a> {
+    if matches!(expression, Expression::AssignmentExpression(assignment) if assignment.operator == AssignmentOperator::Assign)
+    {
+        let Expression::AssignmentExpression(assignment) = expression else { unreachable!() };
+        return assignment_chain_rhs_mut(&mut assignment.right);
+    }
+    expression
+}
+
+fn assignment_group<'a>(
+    target: &AssignmentTarget<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> Option<AssignmentGroup> {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(ident) => {
+            symbol_for_identifier(ident, ctx).map(|_| AssignmentGroup::Identifiers)
+        }
+        AssignmentTarget::StaticMemberExpression(member) => {
+            stable_object(&member.object, ctx).map(AssignmentGroup::StaticMembers)
+        }
+        _ => None,
+    }
+}
+
+fn stable_object<'a>(object: &Expression<'a>, ctx: &TraverseCtx<'a>) -> Option<StableObject> {
+    match object {
+        Expression::Identifier(ident) => {
+            symbol_for_identifier(ident, ctx).map(StableObject::Symbol)
+        }
+        Expression::ThisExpression(_)
+            if !PeepholeOptimizations::member_part_blocks_reorder(object, ctx) =>
+        {
+            Some(StableObject::This)
+        }
+        _ => None,
+    }
+}
+
+fn assignment_group_is_stable(
+    group: AssignmentGroup,
+    ctx: &TraverseCtx<'_>,
+    stable_symbol_cache: &mut StableSymbolCache,
+) -> bool {
+    match group {
+        AssignmentGroup::Identifiers | AssignmentGroup::StaticMembers(StableObject::This) => true,
+        AssignmentGroup::StaticMembers(StableObject::Symbol(symbol_id)) => {
+            symbol_is_stable(symbol_id, ctx, stable_symbol_cache)
+        }
+    }
+}
+
+fn rhs_is_repeatable<'a>(
+    expression: &Expression<'a>,
+    ctx: &TraverseCtx<'a>,
+    stable_symbol_cache: &mut StableSymbolCache,
+) -> bool {
+    if expression.may_have_side_effects(ctx) {
+        return false;
+    }
+
+    match expression {
+        Expression::Identifier(ident) => symbol_for_identifier(ident, ctx)
+            .is_some_and(|symbol_id| symbol_is_stable(symbol_id, ctx, stable_symbol_cache)),
+        Expression::ThisExpression(_) => true,
+        _ => {
+            if matches!(expression.value_type(ctx), ValueType::Object | ValueType::Undetermined) {
+                return false;
+            }
+
+            let mut visitor =
+                StableIdentifierVisitor { ctx, cache: stable_symbol_cache, stable: true };
+            visitor.visit_expression(expression);
+            visitor.stable
+        }
+    }
+}
+
+fn symbol_for_identifier(
+    ident: &IdentifierReference<'_>,
+    ctx: &TraverseCtx<'_>,
+) -> Option<SymbolId> {
+    ctx.scoping().get_reference(ident.reference_id()).symbol_id()
+}
+
+fn symbol_is_stable(
+    symbol_id: SymbolId,
+    ctx: &TraverseCtx<'_>,
+    cache: &mut StableSymbolCache,
+) -> bool {
+    if let Some(stable) = cache
+        .entries
+        .iter()
+        .flatten()
+        .find_map(|&(cached_id, stable)| (cached_id == symbol_id).then_some(stable))
+    {
+        return stable;
+    }
+    let scoping = ctx.scoping();
+    let symbol_flags = scoping.symbol_flags(symbol_id);
+    let symbol_scope_id = scoping.symbol_scope_id(symbol_id);
+    let scope_flags = scoping.scope_flags(symbol_scope_id);
+    // In sloppy functions, parameters may be rebound through the mapped `arguments` object.
+    // Symbols do not currently distinguish parameters from `var` declarations, so reject all
+    // function-scoped variables conservatively.
+    let may_be_mapped_parameter = symbol_flags.is_function_scoped_declaration()
+        && !symbol_flags.is_catch_variable()
+        && !scope_flags.is_strict_mode();
+    let stable = !(scope_flags.contains(ScopeFlags::DirectEval)
+        || may_be_mapped_parameter
+        || PeepholeOptimizations::symbol_value_may_change(symbol_id, ctx));
+    cache.entries[cache.next] = Some((symbol_id, stable));
+    cache.next = (cache.next + 1) % cache.entries.len();
+    stable
+}

--- a/crates/oxc_minifier/src/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/src/peephole/conflate_assignments.rs
@@ -363,6 +363,16 @@ fn symbol_is_stable(
     let may_be_mapped_parameter = symbol_flags.is_function_scoped_declaration()
         && !symbol_flags.is_catch_variable()
         && !scope_flags.is_strict_mode();
+    // Even a sole `var` initializer can run after a closure's first read: a
+    // setter may resume the enclosing generator while it is suspended before
+    // that initializer. Write references do not account for initialization.
+    let may_have_delayed_initializer = symbol_flags.is_function_scoped_declaration()
+        && !symbol_flags.is_catch_variable()
+        && PeepholeOptimizations::read_crosses_function_boundary(
+            ctx.current_scope_id(),
+            symbol_scope_id,
+            ctx,
+        );
     // Later declaration initializers are not write references. A setter can
     // resume a generator and execute one between the original evaluations.
     let has_multiple_value_declarations = scoping
@@ -373,6 +383,7 @@ fn symbol_is_stable(
         .is_some();
     let stable = !(scope_flags.contains(ScopeFlags::DirectEval)
         || may_be_mapped_parameter
+        || may_have_delayed_initializer
         || has_multiple_value_declarations
         || PeepholeOptimizations::symbol_value_may_change(symbol_id, ctx));
     cache.entries[cache.next] = Some((symbol_id, stable));

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -390,7 +390,7 @@ impl<'a> PeepholeOptimizations {
         {
             let a = &mut prev_expr_stmt.expression;
             let b = &mut expr_stmt.expression;
-            expr_stmt.expression = Self::join_sequence(a, b, ctx);
+            expr_stmt.expression = Self::join_sequence_and_conflate(a, b, ctx);
             let dropped = result.pop().unwrap();
             ctx.drop_statement(&dropped);
         }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -48,6 +48,14 @@ impl<'a> PeepholeOptimizations {
     /// ## MinimizeExitPoints:
     /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/MinimizeExitPoints.java>
     pub fn minimize_statements(stmts: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+        Self::minimize_statements_inner(stmts, ctx);
+        Self::conflate_assignments_after_statement_fusion(stmts, ctx);
+    }
+
+    fn minimize_statements_inner(
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         let mut old_stmts = stmts.take_in(ctx);
         let mut is_control_flow_dead = false;
         let mut keep_var = KeepVar::new();
@@ -222,6 +230,51 @@ impl<'a> PeepholeOptimizations {
             ArenaVec::from_array_in([a, b], ctx)
         };
         Expression::new_sequence_expression(span, exprs, ctx)
+    }
+
+    fn join_sequence_and_conflate(
+        a: &mut Expression<'a>,
+        b: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        // `join_sequence` deliberately nests the right side when both operands are sequences.
+        // Finish each sequence and their shared boundary without extending either arena vector:
+        // flattening here would add reallocations on this statement-fusion hot path.
+        if !ctx.is_tree_shake_only()
+            && matches!(a, Expression::SequenceExpression(_))
+            && matches!(b, Expression::SequenceExpression(_))
+        {
+            let Expression::SequenceExpression(mut previous) = a.take_in(ctx) else {
+                unreachable!()
+            };
+            let Expression::SequenceExpression(mut current) = b.take_in(ctx) else {
+                unreachable!()
+            };
+            let mut changed = Self::conflate_assignments(&mut previous, ctx);
+            changed |= Self::conflate_assignments(&mut current, ctx);
+            changed |=
+                Self::conflate_assignment_sequence_boundary(&mut previous, &mut current, ctx);
+
+            let mut expression = if previous.expressions.is_empty() {
+                Expression::SequenceExpression(current)
+            } else {
+                previous.expressions.push(Expression::SequenceExpression(current));
+                Expression::SequenceExpression(previous)
+            };
+            if changed {
+                Self::remove_sequence_expression(&mut expression, ctx);
+            }
+            return expression;
+        }
+
+        let mut expression = Self::join_sequence(a, b, ctx);
+        if !ctx.is_tree_shake_only()
+            && let Expression::SequenceExpression(sequence) = &mut expression
+            && Self::conflate_assignments(sequence, ctx)
+        {
+            Self::remove_sequence_expression(&mut expression, ctx);
+        }
+        expression
     }
 
     fn jump_stmts_look_the_same(left: &Statement<'a>, right: &Statement<'a>) -> bool {
@@ -494,7 +547,7 @@ impl<'a> PeepholeOptimizations {
         {
             let a = &mut prev_expr_stmt.expression;
             let b = &mut switch_stmt.discriminant;
-            switch_stmt.discriminant = Self::join_sequence(a, b, ctx);
+            switch_stmt.discriminant = Self::join_sequence_and_conflate(a, b, ctx);
             let dropped = result.pop().unwrap();
             ctx.drop_statement(&dropped);
         }
@@ -579,7 +632,7 @@ impl<'a> PeepholeOptimizations {
             if let Some(Statement::ExpressionStatement(prev_expr_stmt)) = result.last_mut() {
                 let a = &mut prev_expr_stmt.expression;
                 let b = &mut if_stmt.test;
-                if_stmt.test = Self::join_sequence(a, b, ctx);
+                if_stmt.test = Self::join_sequence_and_conflate(a, b, ctx);
                 let dropped = result.pop().unwrap();
                 ctx.drop_statement(&dropped);
             }
@@ -702,7 +755,7 @@ impl<'a> PeepholeOptimizations {
                     && let Some(Statement::ExpressionStatement(prev_expr_stmt)) = result.last_mut()
                 {
                     let a = &mut prev_expr_stmt.expression;
-                    prev_expr_stmt.expression = Self::join_sequence(a, argument, ctx);
+                    prev_expr_stmt.expression = Self::join_sequence_and_conflate(a, argument, ctx);
                 } else {
                     let span = argument.span();
                     let argument = ret_stmt.argument.take().unwrap();
@@ -718,7 +771,7 @@ impl<'a> PeepholeOptimizations {
             && let Some(Statement::ExpressionStatement(prev_expr_stmt)) = result.last_mut()
         {
             let a = &mut prev_expr_stmt.expression;
-            let new_arg = Self::join_sequence(a, argument, ctx);
+            let new_arg = Self::join_sequence_and_conflate(a, argument, ctx);
             ctx.replace_expression(argument, new_arg);
             result.pop();
         }
@@ -827,7 +880,7 @@ impl<'a> PeepholeOptimizations {
         {
             let a = &mut prev_expr_stmt.expression;
             let b = &mut throw_stmt.argument;
-            throw_stmt.argument = Self::join_sequence(a, b, ctx);
+            throw_stmt.argument = Self::join_sequence_and_conflate(a, b, ctx);
             let dropped = result.pop().unwrap();
             ctx.drop_statement(&dropped);
         }
@@ -946,7 +999,7 @@ impl<'a> PeepholeOptimizations {
                     if let Some(init) = &mut for_stmt.init {
                         if let Some(init) = init.as_expression_mut() {
                             let a = &mut prev_expr_stmt.expression;
-                            let new_init = Self::join_sequence(a, init, ctx);
+                            let new_init = Self::join_sequence_and_conflate(a, init, ctx);
                             ctx.replace_expression(init, new_init);
                             let dropped = result.pop().unwrap();
                             ctx.drop_statement(&dropped);
@@ -1047,7 +1100,8 @@ impl<'a> PeepholeOptimizations {
                     };
                     if can_inline {
                         let a = &mut prev_expr_stmt.expression;
-                        for_in_stmt.right = Self::join_sequence(a, &mut for_in_stmt.right, ctx);
+                        for_in_stmt.right =
+                            Self::join_sequence_and_conflate(a, &mut for_in_stmt.right, ctx);
                         let dropped = result.pop().unwrap();
                         ctx.drop_statement(&dropped);
                     }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -1,3 +1,4 @@
+mod conflate_assignments;
 mod convert_to_dotted_properties;
 mod fold_constants;
 mod inline;
@@ -634,7 +635,10 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                     Self::minimize_assignment_to_update_expression(expr, ctx);
                     Self::remove_unused_assignment_expr(expr, ctx);
                 }
-                Expression::SequenceExpression(_) => Self::remove_sequence_expression(expr, ctx),
+                Expression::SequenceExpression(sequence) => {
+                    Self::conflate_assignments(sequence, ctx);
+                    Self::remove_sequence_expression(expr, ctx);
+                }
                 Expression::ArrowFunctionExpression(e) => Self::substitute_arrow_expression(e, ctx),
                 Expression::FunctionExpression(e) => Self::try_remove_name_from_functions(e, ctx),
                 Expression::ClassExpression(e) => Self::try_remove_name_from_classes(e, ctx),

--- a/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
@@ -1,0 +1,157 @@
+use oxc_ecmascript::side_effects::PropertyReadSideEffects;
+use oxc_span::SourceType;
+
+use crate::{
+    CompressOptions, TreeShakeOptions, default_options, test, test_options_source_type,
+    test_options_with_iterations, test_same, test_same_options, test_same_options_source_type,
+};
+
+#[test]
+fn conflate_identifier_assignments() {
+    test(
+        "export let x, y; export function setVars(value) { x = value; y = value; }",
+        "export let x, y; export function setVars(value) { y = x = value; }",
+    );
+    test(
+        "export let x, y, z; export function setVars(value) { x = value, y = value, z = value; }",
+        "export let x, y, z; export function setVars(value) { z = y = x = value; }",
+    );
+    test(
+        "export let x, y, z; export function setVars(value) { y = x = value, z = value; }",
+        "export let x, y, z; export function setVars(value) { z = y = x = value; }",
+    );
+    test(
+        "export let x, y, z, w; export function setVars(value) { y = x = value, w = z = value; }",
+        "export let x, y, z, w; export function setVars(value) { w = z = y = x = value; }",
+    );
+    test(
+        "export let x, y; export function setVars(value) { return (x = value, y = value); }",
+        "export let x, y; export function setVars(value) { return y = x = value; }",
+    );
+    test(
+        "export let x, y; export function setVars() { x = 1 + 2, y = 1 + 2; }",
+        "export let x, y; export function setVars() { y = x = 3; }",
+    );
+    test(
+        "export let x, y, z, w; export function f(value) { x = value, y = value, sideEffect(), z = value, w = value; }",
+        "export let x, y, z, w; export function f(value) { y = x = value, sideEffect(), w = z = value; }",
+    );
+    test(
+        "export let x, y; export function f(value) { x = typeof value, y = typeof value; }",
+        "export let x, y; export function f(value) { y = x = typeof value; }",
+    );
+    test(
+        "export let x, y; export function f(value) { x = typeof value == 'string', y = typeof value == 'string'; }",
+        "export let x, y; export function f(value) { y = x = typeof value == 'string'; }",
+    );
+    test(
+        "export let x, y; export const value = {}; export function f() { x = value === null, y = value === null; }",
+        "export let x, y; export const value = {}; export function f() { y = x = value === null; }",
+    );
+}
+
+#[test]
+fn statement_fusion_does_not_add_an_iteration() {
+    test_options_with_iterations(
+        "export let x, y; export function setVars(value) { x = value; y = value; }",
+        "export let x, y; export function setVars(value) { y = x = value; }",
+        1,
+        &CompressOptions::smallest(),
+    );
+}
+
+#[test]
+fn late_statement_fusion_is_idempotent() {
+    test(
+        "export let a, b, c, d; export function f() { a = 0; b = 0; for (c = 0, d = 1; c < d; c++); }",
+        "export let a, b, c, d; export function f() { for (c = b = a = 0, d = 1; c < d; c++); }",
+    );
+}
+
+#[test]
+fn conflate_static_member_assignments() {
+    test(
+        "export const obj = {}; export function setProps(value) { obj.x = value; obj.y = value; }",
+        "export const obj = {}; export function setProps(value) { obj.y = obj.x = value; }",
+    );
+    test(
+        "export const obj = {}; export function setProps(value) { obj.x = value, obj.y = value, obj.z = value; }",
+        "export const obj = {}; export function setProps(value) { obj.z = obj.y = obj.x = value; }",
+    );
+    test(
+        "export function setProps(value) { this.x = value, this.y = value; }",
+        "export function setProps(value) { this.y = this.x = value; }",
+    );
+}
+
+#[test]
+fn do_not_conflate_unsafe_assignments() {
+    // The assignment targets must be resolved bindings.
+    test_same("function setVars(value) { x = value, y = value; }");
+
+    // Only plain assignments with structurally equal right-hand sides qualify.
+    test_same("export let x, y; export function f(value) { x += value, y = value; }");
+    test_same("export let x, y; export function f(a, b) { x = a, y = b; }");
+
+    // Re-evaluation must not allocate a distinct value or run user code.
+    test_same("export let x, y; export function f() { x = {}, y = {}; }");
+    test_same("export let x, y; export function f() { x = value(), y = value(); }");
+    test_same(
+        "export let x, y; export const value = { n: 0, valueOf() { return ++this.n; } }; export function f() { x = value == 1, y = value == 1; }",
+    );
+
+    // A mutable RHS binding could change between the original evaluations.
+    test_same(
+        "export let x, y, value; export function setValue(v) { value = v; } export function f() { x = value, y = value; }",
+    );
+
+    // Static member targets must use the same stable object binding.
+    test_same(
+        "export let obj = {}, other = {}; export function f(value) { obj.x = value, other.y = value; }",
+    );
+    test_same(
+        "export let obj = {}; export function replace(value) { obj = value; } export function f(value) { obj.x = value, obj.y = value; }",
+    );
+    test_same(
+        "export const obj = {}; export let x, y; export function f(value) { x = obj.a = value, y = value; }",
+    );
+}
+
+#[test]
+fn setter_cannot_change_repeated_rhs() {
+    test_same(
+        "export const obj = { set x(_) { value = 2; } }; export let value = 1; export function f() { obj.x = value, obj.y = value; }",
+    );
+    test_same(
+        "export const obj = { set x(_) { eval('value = 2'); } }; export let value = 1; export function f() { obj.x = value, obj.y = value; }",
+    );
+
+    // Sloppy-mode parameters can be rebound through the mapped `arguments` object.
+    let options = default_options();
+    test_options_source_type(
+        "function f(value) { const args = arguments, obj = { set x(_) { args[0] = 2; } }; obj.x = value, obj.y = value; }",
+        "function f(value) { let args = arguments, obj = { set x(_) { args[0] = 2; } }; obj.x = value, obj.y = value; }",
+        SourceType::script(),
+        &options,
+    );
+    test_same_options_source_type(
+        "function f(obj) { obj.x = 1, obj.y = 1; }",
+        SourceType::script(),
+        &options,
+    );
+}
+
+#[test]
+fn property_reads_are_not_repeatable() {
+    let options = CompressOptions {
+        treeshake: TreeShakeOptions {
+            property_read_side_effects: PropertyReadSideEffects::None,
+            ..TreeShakeOptions::default()
+        },
+        ..default_options()
+    };
+    test_same_options(
+        "export const box = {}, obj = {}; export function f() { obj.x = box.value === 1, obj.y = box.value === 1; }",
+        &options,
+    );
+}

--- a/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
@@ -157,6 +157,14 @@ fn redeclaration_initializers_are_not_stable() {
 }
 
 #[test]
+fn delayed_var_initializer_is_not_stable() {
+    test(
+        "export let iter; export function* gen() { let obj = { set a(x) { console.log(x); iter.next(); }, set b(x) { console.log(x); } }; yield () => { obj.a = value; obj.b = value; }; var value = 2; }",
+        "export let iter; export function* gen() { let obj = { set a(x) { console.log(x), iter.next(); }, set b(x) { console.log(x); } }; yield () => { obj.a = value, obj.b = value; }; var value = 2; }",
+    );
+}
+
+#[test]
 fn property_reads_are_not_repeatable() {
     let options = CompressOptions {
         treeshake: TreeShakeOptions {

--- a/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
@@ -61,6 +61,16 @@ fn statement_fusion_does_not_add_an_iteration() {
 }
 
 #[test]
+fn expression_statement_sequence_boundary_is_idempotent() {
+    test_options_with_iterations(
+        "export let x, y; export function f(value) { before(), x = value; y = value, after(); }",
+        "export let x, y; export function f(value) { before(), y = x = value, after(); }",
+        1,
+        &CompressOptions::smallest(),
+    );
+}
+
+#[test]
 fn late_statement_fusion_is_idempotent() {
     test(
         "export let a, b, c, d; export function f() { a = 0; b = 0; for (c = 0, d = 1; c < d; c++); }",

--- a/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
+++ b/crates/oxc_minifier/tests/peephole/conflate_assignments.rs
@@ -142,6 +142,21 @@ fn setter_cannot_change_repeated_rhs() {
 }
 
 #[test]
+fn redeclaration_initializers_are_not_stable() {
+    // A setter can resume the generator and execute a later initializer, which
+    // is not represented as a write reference to the binding.
+    test(
+        "export let iter; export function* gen() { var value = 1; let obj = { set a(x) { console.log(x); iter.next(); }, set b(x) { console.log(x); } }; yield () => { obj.a = value; obj.b = value; }; var value = 2; }",
+        "export let iter; export function* gen() { var value = 1; let obj = { set a(x) { console.log(x), iter.next(); }, set b(x) { console.log(x); } }; yield () => { obj.a = value, obj.b = value; }; var value = 2; }",
+    );
+    // The same restriction applies to the object of a member assignment.
+    test(
+        "export let iter; export function* gen() { var obj = { set a(x) { iter.next(); } }; yield () => { obj.a = 1; obj.b = 1; }; var obj = {}; console.log(obj); }",
+        "export let iter; export function* gen() { var obj = { set a(x) { iter.next(); } }; yield () => { obj.a = 1, obj.b = 1; }; var obj = {}; console.log(obj); }",
+    );
+}
+
+#[test]
 fn property_reads_are_not_repeatable() {
     let options = CompressOptions {
         treeshake: TreeShakeOptions {

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -207,6 +207,11 @@ fn dce_if_statement() {
 }
 
 #[test]
+fn dce_does_not_conflate_assignments() {
+    test_same("export let x, y; export function f(value) { x = value, y = value; }");
+}
+
+#[test]
 fn dce_while_statement() {
     test_same("while (true);");
     test_same("while (false);");

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -1,5 +1,6 @@
 mod collapse_variable_declarations;
 mod compression_pass;
+mod conflate_assignments;
 mod convert_to_dotted_properties;
 mod dead_code_elimination;
 mod esbuild;

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,27 +1,27 @@
            | Oxc props  | ESBuild    | Oxc props  | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File
 -------------------------------------------------------------------------------------
-72.14 kB   | 22.48 kB   | 23.70 kB   | 8.19 kB    | 8.54 kB    |          2 | react.development.js
+72.14 kB   | 22.47 kB   | 23.70 kB   | 8.19 kB    | 8.54 kB    |          2 | react.development.js
 
-173.90 kB  | 55.50 kB   | 59.82 kB   | 18.77 kB   | 19.33 kB   |          2 | moment.js
+173.90 kB  | 55.48 kB   | 59.82 kB   | 18.77 kB   | 19.33 kB   |          2 | moment.js
 
 287.63 kB  | 89.01 kB   | 90.07 kB   | 30.85 kB   | 31.95 kB   |          2 | jquery.js
 
-342.15 kB  | 114.80 kB  | 118.14 kB  | 42.71 kB   | 44.37 kB   |          2 | vue.js
+342.15 kB  | 114.75 kB  | 118.14 kB  | 42.70 kB   | 44.37 kB   |          2 | vue.js
 
 544.10 kB  | 69.88 kB   | 72.48 kB   | 25.58 kB   | 26.20 kB   |          2 | lodash.js
 
-555.77 kB  | 262.75 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
+555.77 kB  | 262.72 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
-1.01 MB    | 435.99 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
+1.01 MB    | 435.93 kB  | 458.89 kB  | 121.79 kB  | 126.71 kB  |          2 | bundle.min.js
 
-1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
+1.25 MB    | 633.61 kB  | 646.76 kB  | 158.50 kB  | 163.73 kB  |          2 | three.js
 
-2.14 MB    | 707.63 kB  | 724.14 kB  | 160.08 kB  | 181.07 kB  |          2 | victory.js
+2.14 MB    | 707.61 kB  | 724.14 kB  | 160.07 kB  | 181.07 kB  |          2 | victory.js
 
-3.20 MB    | 958.89 kB  | 1.01 MB    | 317.07 kB  | 331.56 kB  |          2 | echarts.js
+3.20 MB    | 958.45 kB  | 1.01 MB    | 317.05 kB  | 331.56 kB  |          2 | echarts.js
 
-6.69 MB    | 2.12 MB    | 2.31 MB    | 453.44 kB  | 488.28 kB  |          5 | antd.js
+6.69 MB    | 2.12 MB    | 2.31 MB    | 453.40 kB  | 488.28 kB  |          5 | antd.js
 
-10.95 MB   | 3.31 MB    | 3.49 MB    | 849.97 kB  | 915.50 kB  |          4 | typescript.js
+10.95 MB   | 3.31 MB    | 3.49 MB    | 849.86 kB  | 915.50 kB  |          4 | typescript.js
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -3,22 +3,22 @@ checker.ts:
   sys allocs: 150
   sys reallocs: 5
   sys deallocs: 150
-  sys alloc bytes: 14996600 # 15.00 MB
+  sys alloc bytes: 14996568 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
   arena allocs: 143446
   arena reallocs: 28269
-  arena size: 19097584 # 19.10 MB
+  arena size: 19097528 # 19.10 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 61
   sys reallocs: 8
   sys deallocs: 61
-  sys alloc bytes: 2128555 # 2.13 MB
+  sys alloc bytes: 2128539 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
   arena allocs: 15643
   arena reallocs: 2709
-  arena size: 2879680 # 2.88 MB
+  arena size: 2879408 # 2.88 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,18 +29,18 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 11628 # 11.63 kB
   arena allocs: 29
   arena reallocs: 6
-  arena size: 35632 # 35.63 kB
+  arena size: 35616 # 35.62 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 2427
   sys reallocs: 205
   sys deallocs: 2427
-  sys alloc bytes: 5334247 # 5.33 MB
+  sys alloc bytes: 5313795 # 5.31 MB
   sys peak growth: 3693355 # 3.69 MB
   arena allocs: 44749
   arena reallocs: 7699
-  arena size: 6304256 # 6.30 MB
+  arena size: 6304096 # 6.30 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 351149
-  arena reallocs: 75941
-  arena size: 48738712 # 48.74 MB
+  arena allocs: 351123
+  arena reallocs: 75927
+  arena size: 48736496 # 48.74 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,15 +62,15 @@ binder.ts:
   sys peak growth: 657404 # 657.40 kB
   arena allocs: 6784
   arena reallocs: 834
-  arena size: 1162400 # 1.16 MB
+  arena size: 1162224 # 1.16 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 1854
   sys reallocs: 174
   sys deallocs: 1854
-  sys alloc bytes: 5307512 # 5.31 MB
+  sys alloc bytes: 5304252 # 5.30 MB
   sys peak growth: 3707425 # 3.71 MB
   arena allocs: 64833
   arena reallocs: 12187
-  arena size: 9385624 # 9.39 MB
+  arena size: 9385344 # 9.39 MB


### PR DESCRIPTION
Conflate consecutive assignments with equal, repeatable values into assignment chains:

```js
// Before
obj.x = value;
obj.y = value;
obj.z = value;

// After
obj.z = obj.y = obj.x = value;
```

The pass finds adjacent assignments with structurally equal RHS expressions, including existing assignment chains. Targets must be bound identifiers or static properties on the same stable object.

Because chaining moves target evaluation earlier and removes repeated RHS evaluations, the pass checks object stability and RHS repeatability. It rejects expressions that allocate distinct objects or may run user code, and bindings that can change through writes, direct `eval`, mapped arguments, or multiple declaration initializers.

Eligible runs are merged by swapping AST nodes into the following assignment’s RHS, then compacting the sequence in one pass. Short run lists stay on the stack, and symbol-stability queries use a small cache to avoid repeated reference scans.

The pass runs during expression traversal and after statement fusion, including across sequence boundaries. This handles newly formed sequences without requiring another whole-program compression iteration.

Implements #14340.