### PR TITLE
fix(transformer): skip async generators in async-to-generator

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -144,6 +144,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for AsyncToGenerator<'a> {
 
     fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         if func.r#async
+            && !func.generator
             && !func.is_typescript_syntax()
             && AsyncGeneratorExecutor::is_class_method_like_ancestor(ctx.parent())
         {

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 273/401
+Passed: 274/402
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 1eac4481
 
 node: v26.5.0
 
-Passed: 17 of 19 (89.47%)
+Passed: 18 of 20 (90.00%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/exec.js
@@ -1,0 +1,16 @@
+const object = {
+  async *values() {
+    yield 1;
+  },
+};
+
+class Values {
+  async *values() {
+    yield 2;
+  }
+}
+
+return Promise.all([object.values().next(), new Values().values().next()]).then(function (results) {
+  expect(results[0]).toEqual({ value: 1, done: false });
+  expect(results[1]).toEqual({ value: 2, done: false });
+});

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/input.js
@@ -1,0 +1,11 @@
+const object = {
+  async *values() {
+    yield 1;
+  },
+};
+
+class Values {
+  async *values() {
+    yield 2;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-async-to-generator"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/oxc/ignore-async-generator-methods/output.js
@@ -1,0 +1,10 @@
+const object = {
+  async *values() {
+    yield 1;
+  }
+};
+class Values {
+  async *values() {
+    yield 2;
+  }
+}


### PR DESCRIPTION
## Summary

- keep async generator object and class methods out of the async-to-generator transform
- match the existing function-expression/function-declaration guard and Babel's plugin boundary
- add output and runtime coverage for both method forms

## Why

With only `transform-async-to-generator` enabled, this input:

```js
const object = {
  async *values() {
    yield 1;
  },
};
```

was rewritten through `asyncToGenerator`, so `object.values()` returned a Promise and `.next()` threw. Async generator methods must remain async iterators; this transform should leave them for the async-generator-functions transform when that transform is enabled.

This is stacked on #26227.

## Testing

- focused output and runtime conformance fixture
- full transformer conformance suite
- `cargo test -p oxc_transformer`
- formatting, lint, docs, and generated AST checks

AI assistance was used to diagnose the transform boundary, implement the guard, and add tests. I remain responsible for reviewing and understanding the changes before merge.
