### PR TITLE
refactor(formatter_json): hide raw comment printing API, use struct instead

### DIFF
--- a/crates/oxc_formatter_json/src/comments.rs
+++ b/crates/oxc_formatter_json/src/comments.rs
@@ -2,7 +2,7 @@ use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::Comment;
 use oxc_formatter_core::{
     Buffer, Format, LINE_TERMINATORS, SourceText, SpanCursor, arena_cow_str,
-    builders::{empty_line, expand_parent, hard_line_break, line_suffix, space, text},
+    builders::{empty_line, expand_parent, hard_line_break, line_suffix, maybe_space, space, text},
     normalize_newlines,
     spec::is_suppression_marker,
     write,
@@ -21,18 +21,18 @@ use crate::{
 /// Cursor over the sorted comment list.
 pub type Comments<'a> = SpanCursor<'a, Comment>;
 
-/// Emit a single comment, re-aligning interior `*`-prefixed lines
-/// so the stars line up with the opening `/*` regardless of the source's original indentation.
+/// Emit comment content without its surrounding placement.
+/// Re-aligns interior `*`-prefixed lines with the opening `/*`.
 ///
-/// Mirrors `oxc_formatter`'s `impl Format for Comment` (`formatter/trivia.rs`):
+/// Mirrors `oxc_formatter`'s `FormatCommentText` (`formatter/trivia.rs`):
 /// - Single-line comments (line and one-line block) emit as-is (trim trailing whitespace).
-/// - Multi-line block comments whose interior lines all start with `*` (an
-///   "indentable" / JSDoc-shaped comment) split into lines; the first is emitted
-///   trimmed, and each subsequent line as `[hard_line_break, " ", trimmed]` so
-///   the surrounding indent context re-indents the stars.
-/// - Other multi-line block comments normalize `\r\n` → `\n` but otherwise stay
-///   verbatim; their first line still gets its trailing whitespace trimmed.
-pub fn write_single_comment(comment: &Comment, f: &mut JsonFormatter<'_, '_>) {
+/// - Multi-line block comments whose interior lines all start with `*`
+///   (an "indentable" / JSDoc-shaped comment) split into lines;
+///   the first is emitted trimmed, and each subsequent line as `[hard_line_break, " ", trimmed]`
+///   so the surrounding indent context re-indents the stars.
+/// - Other multi-line block comments normalize `\r\n` → `\n` but otherwise stay verbatim;
+///   their first line still gets its trailing whitespace trimmed.
+fn write_comment_text(comment: &Comment, f: &mut JsonFormatter<'_, '_>) {
     let content = f.context().source_text().text_for(&comment.span);
 
     if !comment.is_multiline_block() {
@@ -61,6 +61,61 @@ pub fn write_single_comment(comment: &Comment, f: &mut JsonFormatter<'_, '_>) {
     }
 }
 
+/// A comment written in place:
+/// a line comment ends its line, a block comment gets nothing after.
+/// Callers today pass block comments only; the line branch keeps the contract uniform.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatCommentBeforeContent(Comment);
+
+impl FormatCommentBeforeContent {
+    pub const fn new(comment: Comment) -> Self {
+        Self(comment)
+    }
+}
+
+impl<'a> Format<'a, JsonFormatContext<'a>> for FormatCommentBeforeContent {
+    fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
+        write_comment_text(&self.0, f);
+        if self.0.is_line() {
+            write!(f, [expand_parent(), hard_line_break()]);
+        }
+    }
+}
+
+/// A line comment deferred through `line_suffix`:
+/// cannot swallow later tokens, not measured.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatLineCommentSuffix {
+    comment: Comment,
+    leading_space: bool,
+}
+
+impl FormatLineCommentSuffix {
+    pub const fn new(comment: Comment) -> Self {
+        Self { comment, leading_space: false }
+    }
+
+    pub const fn with_leading_space(mut self) -> Self {
+        self.leading_space = true;
+        self
+    }
+}
+
+impl<'a> Format<'a, JsonFormatContext<'a>> for FormatLineCommentSuffix {
+    fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
+        debug_assert!(self.comment.is_line(), "expected a line comment");
+        let comment = self.comment;
+        let leading_space = self.leading_space;
+        let suffix = format_with(move |f: &mut JsonFormatter<'_, 'a>| {
+            write!(f, maybe_space(leading_space));
+            write_comment_text(&comment, f);
+        });
+        write!(f, line_suffix(&suffix));
+    }
+}
+
 /// Returns `true` if every line after the first starts with `*`.
 /// (after stripping leading whitespace)
 /// These comments are "alignable":
@@ -79,7 +134,7 @@ pub fn write_leading_comments(
 ) {
     let source = f.context().source_text();
     for (i, comment) in comments.iter().enumerate() {
-        write_single_comment(comment, f);
+        write_comment_text(comment, f);
         let next_pos = comments.get(i + 1).map_or(value_start, |c| c.span.start);
         write_gap(source.bytes_range(comment.span.end, next_pos), f);
     }
@@ -176,7 +231,7 @@ pub fn write_dangling_comments(comments: &[Comment], f: &mut JsonFormatter<'_, '
         if i > 0 {
             write!(f, hard_line_break());
         }
-        write_single_comment(comment, f);
+        write_comment_text(comment, f);
     }
 }
 
@@ -204,12 +259,12 @@ pub fn write_trailing_inside_comments(
             // so `[a, // comment -> ]` doesn't collapse.
             let content = format_with(move |f: &mut JsonFormatter<'_, '_>| {
                 write_gap(gap, f);
-                write_single_comment(comment, f);
+                write_comment_text(comment, f);
             });
             write!(f, [line_suffix(&content), expand_parent()]);
         } else {
             write_gap(gap, f);
-            write_single_comment(comment, f);
+            write_comment_text(comment, f);
         }
         prev_end = comment.span.end;
     }

--- a/crates/oxc_formatter_json/src/separated.rs
+++ b/crates/oxc_formatter_json/src/separated.rs
@@ -7,16 +7,14 @@
 
 use oxc_formatter_core::{
     Buffer,
-    builders::{
-        empty_line, hard_line_break, if_group_breaks, line_suffix, soft_line_break_or_space, space,
-    },
+    builders::{empty_line, hard_line_break, if_group_breaks, soft_line_break_or_space, space},
     write,
 };
 use oxc_span::Span;
 
 use crate::{
-    comments::{count_newlines, write_single_comment},
-    print::{JsonFormatter, format_with},
+    comments::{FormatCommentBeforeContent, FormatLineCommentSuffix, count_newlines},
+    print::JsonFormatter,
 };
 
 /// Whether a trailing `,` should follow the last entry.
@@ -97,8 +95,7 @@ fn write_trailing_separator(upper_bound: u32, f: &mut JsonFormatter<'_, '_>) {
 
     if let Some(block_end) = block_end {
         for c in f.context().comments().take_before(block_end) {
-            write!(f, space());
-            write_single_comment(c, f);
+            write!(f, [space(), FormatCommentBeforeContent::new(*c)]);
         }
     }
 
@@ -145,8 +142,7 @@ fn write_inter_entry_separator(prev: Span, curr: Span, f: &mut JsonFormatter<'_,
     };
 
     for c in block_comments {
-        write!(f, space());
-        write_single_comment(c, f);
+        write!(f, [space(), FormatCommentBeforeContent::new(*c)]);
     }
     write!(f, ",");
 
@@ -156,11 +152,7 @@ fn write_inter_entry_separator(prev: Span, curr: Span, f: &mut JsonFormatter<'_,
         // Without this, `"k": [a, b], // long...`
         // would force the array to expand even when it fits on its own.
         let lc = *lc;
-        let suffix = format_with(move |f: &mut JsonFormatter<'_, '_>| {
-            write!(f, space());
-            write_single_comment(&lc, f);
-        });
-        write!(f, line_suffix(&suffix));
+        write!(f, FormatLineCommentSuffix::new(lc).with_leading_space());
         // Promote to `empty_line` when the source preserves a blank line after the trailing comment;
         // otherwise a hard break (also flushes the line_suffix).
         if has_blank_line(lc.span.end, curr.start, f) {


### PR DESCRIPTION
#26313 for JSON formatter.