### PR TITLE
refactor(formatter_yaml): hide raw comment printing API, use struct instead

### DIFF
--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -1,12 +1,17 @@
 use oxc_formatter_core::{
-    Buffer, SourceText, SpanCursor,
-    builders::{align, empty_line, expand_parent, hard_line_break, line_suffix, space, text},
+    Buffer, Format, SourceText, SpanCursor,
+    builders::{
+        align, empty_line, expand_parent, hard_line_break, line_suffix, maybe_space, space, text,
+    },
     spec::is_suppression_marker,
     write,
 };
 use oxc_span::{GetSpan, Span};
 
-use crate::print::{YamlFormatter, format_with};
+use crate::{
+    context::YamlFormatContext,
+    print::{YamlFormatter, format_with},
+};
 
 /// A comment bridged from the parser: its span in the arena source,
 /// plus the parser-recorded layout fact print sites branch on.
@@ -69,11 +74,92 @@ pub fn write_blank_preserving_break(
     }
 }
 
-/// Emit a single comment verbatim (trailing whitespace trimmed).
-/// The spacing after `#` is kept as authored, never normalized.
-pub fn write_single_comment(span: Span, f: &mut YamlFormatter<'_, '_>) {
+/// Emit raw comment text without its required following line boundary.
+fn write_comment_text(span: Span, f: &mut YamlFormatter<'_, '_>) {
     let content = f.context().source_text().text_for(&span);
     write!(f, text(content.trim_end()));
+}
+
+/// A `#` comment written in place: it ends its line.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatCommentBeforeContent(Span);
+
+impl FormatCommentBeforeContent {
+    pub const fn new(span: Span) -> Self {
+        Self(span)
+    }
+}
+
+impl<'a> Format<'a, YamlFormatContext<'a>> for FormatCommentBeforeContent {
+    fn fmt(&self, f: &mut YamlFormatter<'_, 'a>) {
+        write_comment_text(self.0, f);
+        write!(f, hard_line_break());
+    }
+}
+
+/// A `#` comment deferred through `line_suffix`, excluding its width from `fits`.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatLineCommentSuffix {
+    span: Span,
+    leading_space: bool,
+    expand_parent: bool,
+}
+
+impl FormatLineCommentSuffix {
+    pub const fn new(span: Span) -> Self {
+        Self { span, leading_space: false, expand_parent: false }
+    }
+
+    pub const fn with_leading_space(mut self) -> Self {
+        self.leading_space = true;
+        self
+    }
+
+    /// A `line_suffix` alone never breaks the enclosing group.
+    pub const fn with_expand_parent(mut self) -> Self {
+        self.expand_parent = true;
+        self
+    }
+}
+
+impl<'a> Format<'a, YamlFormatContext<'a>> for FormatLineCommentSuffix {
+    fn fmt(&self, f: &mut YamlFormatter<'_, 'a>) {
+        let span = self.span;
+        let leading_space = self.leading_space;
+        let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
+            write!(f, maybe_space(leading_space));
+            write_comment_text(span, f);
+        });
+        write!(f, [line_suffix(&content), self.expand_parent.then_some(expand_parent())]);
+    }
+}
+
+/// Writes a document body's end comments, one per line, preserving the source's blank lines (normalized to one).
+/// In front of the first comment (measured from `anchor`) and between consecutive comments alike.
+/// The boundary AFTER the last comment is the document sequence's or the finalizer's
+/// (see `write_document_separator` in `print/document.rs` for the deliberate non-follow).
+pub fn write_end_comments(
+    anchor: Option<u32>,
+    comments: &[SourceComment],
+    f: &mut YamlFormatter<'_, '_>,
+) {
+    let source = f.context().source_text();
+    for (i, comment) in comments.iter().enumerate() {
+        let span = comment.span;
+        let prev_end = if i == 0 { anchor } else { Some(comments[i - 1].span.end) };
+        let blank = prev_end.is_some_and(|prev_end| {
+            prev_end < span.start
+                && classify_gap(source.bytes_range(prev_end, span.start)) == Gap::Blank
+        });
+        if blank {
+            write!(f, empty_line());
+        } else {
+            write!(f, hard_line_break());
+        }
+        write_comment_text(span, f);
+    }
 }
 
 /// Emits the formatter element that reproduces the vertical spacing implied by `gap`:
@@ -95,7 +181,7 @@ fn write_leading_comments(
 ) {
     let source = f.context().source_text();
     for (i, comment) in comments.iter().enumerate() {
-        write_single_comment(comment.span, f);
+        write_comment_text(comment.span, f);
         let next_pos = comments.get(i + 1).map_or(value_start, |c| c.span.start);
         write_gap(source.bytes_range(comment.span.end, next_pos), f);
     }
@@ -146,20 +232,7 @@ pub fn write_trailing_same_line_comment(
         return;
     };
     f.context().comments().take_before(comment.span.end);
-    write_comment_line_suffix(comment.span, f);
-    write!(f, expand_parent());
-}
-
-/// The ` # ...` emission of a same-line trailing comment: a `line_suffix`,
-/// so it never counts toward the `fits` measurement
-/// (known divergence: Prettier counts it for a block scalar header, and only there).
-/// Gating and consuming are the caller's.
-pub fn write_comment_line_suffix<'a>(span: Span, f: &mut YamlFormatter<'_, 'a>) {
-    let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
-        write!(f, space());
-        write_single_comment(span, f);
-    });
-    write!(f, line_suffix(&content));
+    write!(f, FormatLineCommentSuffix::new(comment.span).with_leading_space().with_expand_parent());
 }
 
 /// Returns `true` if `span` is an ignore marker (`# oxfmt-ignore` / `# prettier-ignore`).
@@ -263,7 +336,7 @@ pub fn flush_container_end_comments(
             } else {
                 write!(f, hard_line_break());
             }
-            write_single_comment(span, f);
+            write_comment_text(span, f);
         });
         write!(f, align(align_width, &inner));
         prev_end = span.end;

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -11,7 +11,7 @@ use oxc_formatter_core::{
 use oxc_yaml_parser::ast::{BlockScalar, Chomping, Content, MappingItem, Node, Root};
 
 use crate::{
-    comments::write_comment_line_suffix,
+    comments::FormatLineCommentSuffix,
     options::ProseWrap,
     print::{
         YamlFormatter, format_with,
@@ -91,7 +91,7 @@ pub fn write_block_scalar<'a>(
         && comment.own_line_column.is_none()
     {
         f.context().comments().take_before(comment.span.end);
-        write_comment_line_suffix(comment.span, f);
+        write!(f, FormatLineCommentSuffix::new(comment.span).with_leading_space());
     }
 
     let line_groups: Vec<Vec<&'a str>> =

--- a/crates/oxc_formatter_yaml/src/print/document.rs
+++ b/crates/oxc_formatter_yaml/src/print/document.rs
@@ -1,15 +1,15 @@
 use oxc_formatter_core::{
     Buffer,
-    builders::{empty_line, hard_line_break, space, text},
+    builders::{hard_line_break, space, text},
     write,
 };
 use oxc_yaml_parser::ast::{Directive, Document, Root};
 
 use crate::{
     comments::{
-        Gap, SourceComment, classify_gap, flush_leading_comments, gap_anchor_after_consumed,
-        gap_upper_bound, is_suppressed_last_before, write_blank_preserving_break,
-        write_single_comment, write_suppressed_node, write_trailing_same_line_comment,
+        flush_leading_comments, gap_anchor_after_consumed, gap_upper_bound,
+        is_suppressed_last_before, write_blank_preserving_break, write_end_comments,
+        write_suppressed_node, write_trailing_same_line_comment,
     },
     print::{
         YamlFormatter,
@@ -95,31 +95,6 @@ fn write_document_separator<'a>(
     let anchor = document_gap_anchor(prev, f);
     let upper_bound = gap_upper_bound(next.span.start, f);
     write_blank_preserving_break(anchor, upper_bound, f);
-}
-
-/// Writes a document body's end comments, one per line, preserving the source's blank lines (normalized to one).
-/// In front of the first comment (measured from `anchor`) and between consecutive comments alike.
-/// See [`write_document_separator`] for the deliberate non-follow.
-fn write_end_comments(
-    anchor: Option<u32>,
-    comments: &[SourceComment],
-    f: &mut YamlFormatter<'_, '_>,
-) {
-    let source = f.context().source_text();
-    for (i, comment) in comments.iter().enumerate() {
-        let span = comment.span;
-        let prev_end = if i == 0 { anchor } else { Some(comments[i - 1].span.end) };
-        let blank = prev_end.is_some_and(|prev_end| {
-            prev_end < span.start
-                && classify_gap(source.bytes_range(prev_end, span.start)) == Gap::Blank
-        });
-        if blank {
-            write!(f, empty_line());
-        } else {
-            write!(f, hard_line_break());
-        }
-        write_single_comment(span, f);
-    }
 }
 
 /// Prettier's `shouldPrintDocumentEndMarker`:

--- a/crates/oxc_formatter_yaml/src/print/flow.rs
+++ b/crates/oxc_formatter_yaml/src/print/flow.rs
@@ -11,8 +11,8 @@ use oxc_yaml_parser::ast::{FlowMapping, FlowSequence, FlowSequenceEntry};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, gap_upper_bound, is_suppressed_last_before,
-        write_single_comment, write_suppressed_node, write_trailing_same_line_comment,
+        FormatCommentBeforeContent, Gap, classify_gap, flush_leading_comments, gap_upper_bound,
+        is_suppressed_last_before, write_suppressed_node, write_trailing_same_line_comment,
     },
     print::{YamlFormatter, format_with, mapping_item, write_node},
 };
@@ -149,8 +149,10 @@ fn write_trailing_comma_and_end_comments(close_end: u32, f: &mut YamlFormatter<'
     // Comments inside the brackets after the last entry
     let close_start = close_end.saturating_sub(1);
     let comments = f.context().comments().take_before(close_start);
-    for comment in comments {
+    if !comments.is_empty() {
         write!(f, hard_line_break());
-        write_single_comment(comment.span, f);
+    }
+    for comment in comments {
+        write!(f, FormatCommentBeforeContent::new(comment.span));
     }
 }

--- a/crates/oxc_formatter_yaml/src/print/mapping_item.rs
+++ b/crates/oxc_formatter_yaml/src/print/mapping_item.rs
@@ -1,8 +1,7 @@
 use oxc_formatter_core::{
     Buffer, Format, GroupId, MemoizeFormat, best_fitting,
     builders::{
-        align, expand_parent, group, hard_line_break, if_group_breaks, if_group_fits_on_line,
-        line_suffix, space,
+        align, expand_parent, group, hard_line_break, if_group_breaks, if_group_fits_on_line, space,
     },
     format_args, write,
 };
@@ -10,8 +9,8 @@ use oxc_yaml_parser::ast::{Content, MappingItem, Node};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, pending_same_line_comment, write_single_comment,
-        write_trailing_same_line_comment,
+        FormatCommentBeforeContent, FormatLineCommentSuffix, Gap, classify_gap,
+        flush_leading_comments, pending_same_line_comment, write_trailing_same_line_comment,
     },
     context::YamlFormatContext,
     options::ProseWrap,
@@ -56,10 +55,7 @@ pub fn write_mapping_item<'a>(
         }
         if let Some(comment) = same_line_comment {
             f.context().comments().take_before(comment.span.end);
-            let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
-                write_single_comment(comment.span, f);
-            });
-            write!(f, [line_suffix(&content), expand_parent()]);
+            write!(f, FormatLineCommentSuffix::new(comment.span).with_expand_parent());
         }
         return;
     }
@@ -138,15 +134,14 @@ pub fn write_mapping_item<'a>(
                 }
                 f.context().comments().take_before(span.end);
                 write!(f, hard_line_break());
-                write_single_comment(span, f);
+                write!(f, FormatCommentBeforeContent::new(span));
             }
         });
         write!(f, align(2, &key_and_comments));
         write!(f, hard_line_break());
         let comments = f.context().comments().take_before(colon);
         for comment in comments {
-            write_single_comment(comment.span, f);
-            write!(f, hard_line_break());
+            write!(f, FormatCommentBeforeContent::new(comment.span));
         }
         write!(f, ": ");
         write!(f, align(2, &format_with(|f| write_value(item, f))));

--- a/crates/oxc_formatter_yaml/src/print/mod.rs
+++ b/crates/oxc_formatter_yaml/src/print/mod.rs
@@ -7,8 +7,8 @@ use oxc_yaml_parser::ast::{Content, Node, Props};
 
 use crate::{
     comments::{
-        flush_leading_comments, is_suppressed_last_before, suppression_flush_bound,
-        write_single_comment, write_suppressed_node,
+        FormatCommentBeforeContent, flush_leading_comments, is_suppressed_last_before,
+        suppression_flush_bound, write_suppressed_node,
     },
     context::YamlFormatContext,
 };
@@ -135,16 +135,11 @@ pub fn write_node<'a>(node: &'a Node<'a>, f: &mut YamlFormatter<'_, 'a>) {
     // it stays pending so the first item's check can claim it.
     let middles_bound = suppression_flush_bound(is_block_collection, content_start, f);
     let middles = f.context().comments().take_before(middles_bound);
-    // `i > 0` is subsumed: any later iteration implies more than one middle.
-    let multiple_middles = middles.len() > 1;
-    for comment in middles {
-        if multiple_middles {
-            write!(f, hard_line_break());
-        }
-        write_single_comment(comment.span, f);
-    }
-    if !middles.is_empty() {
+    if middles.len() > 1 {
         write!(f, hard_line_break());
+    }
+    for comment in middles {
+        write!(f, FormatCommentBeforeContent::new(comment.span));
     }
 
     match content {


### PR DESCRIPTION
#26313 for YAML formatter.