### PR TITLE
fix(formatter_css): hide raw comment printing API, use strcut instead

### DIFF
--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -624,6 +624,47 @@ Consecutive `//` comments in a comment-only map indent uniformly;
 Prettier misaligns the second with a stray extra leading space, an artifact of its `join(line)` separator printing before the deferred `lineSuffix` flushes.
 A meaningless glitch.
 
+## supports-selector-inline-comment-list
+
+- Why: uniform-rule (same construct, same output: `selector(a // c\n)`)
+- Pin: `tests/fixtures/format/scss/supports-selector-inline-comments.scss`
+
+```scss
+/* input */
+@supports selector(a, // c
+ b) {}
+@supports selector(a // c
+ // d
+) {}
+
+/* ours */
+@supports selector(
+  a, // c
+  b
+) {
+}
+@supports selector(
+  a // c
+  // d
+) {
+}
+
+/* prettier */
+@supports selector(a, // c
+ b) {
+}
+@supports selector(
+  a // c
+ // d
+) {
+}
+```
+
+A `//` inside `selector()` opens the parens and ends its line, the shape Prettier itself prints for a single selector (`selector(a // c\n)`);
+a comma list holding a `//` it keeps verbatim instead, source whitespace included.
+A second `//` indents like the first; Prettier prints it with a stray leading space and no indent,
+the same `join(line)` + deferred `lineSuffix` artifact as "comment-only-map-indent".
+
 ## semiless-custom-property-block
 
 - Why: cost

--- a/crates/oxc_formatter_css/src/comments.rs
+++ b/crates/oxc_formatter_css/src/comments.rs
@@ -1,12 +1,15 @@
 use oxc_formatter_core::{
-    Buffer, SourceText, SpanCursor,
-    builders::{empty_line, expand_parent, hard_line_break, line_suffix, space, text},
+    Buffer, Format, SourceText, SpanCursor,
+    builders::{empty_line, expand_parent, hard_line_break, line_suffix, maybe_space, space, text},
     spec::is_suppression_marker,
     write,
 };
 use oxc_span::{GetSpan, Span};
 
-use crate::print::{CssFormatter, format_with};
+use crate::{
+    context::CssFormatContext,
+    print::{CssFormatter, format_with},
+};
 
 /// A source comment.
 ///
@@ -30,15 +33,99 @@ pub type Comments<'a> = SpanCursor<'a, CssComment>;
 
 pub use oxc_formatter_core::spec::{Gap, classify_gap};
 
-/// Emit a single comment verbatim.
-/// Mirrors Prettier's `css-comment` case: the original text slice,
-/// with trailing whitespace trimmed for inline (`//`) comments.
-pub fn write_single_comment(comment: CssComment, f: &mut CssFormatter<'_, '_>) {
+/// Emit raw comment text, trimming trailing whitespace from `//`.
+/// Private because it does not emit the line boundary `//` requires.
+fn write_comment_text(comment: CssComment, f: &mut CssFormatter<'_, '_>) {
     let content = f.context().source_text().text_for(&comment.span);
     if comment.inline {
         write!(f, text(content.trim_end()));
     } else {
         write!(f, text(content));
+    }
+}
+
+/// Spacing after a block comment. A `//` comment always hard-breaks instead.
+#[derive(Clone, Copy, Debug)]
+pub enum BlockCommentAfter {
+    None,
+    Space,
+    HardLine,
+}
+
+/// A comment written in place: a `//` ends its line, a block comment is followed by `block_after`.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatCommentBeforeContent {
+    comment: CssComment,
+    block_after: BlockCommentAfter,
+    expand_parent: bool,
+}
+
+impl FormatCommentBeforeContent {
+    pub const fn new(comment: CssComment, block_after: BlockCommentAfter) -> Self {
+        Self { comment, block_after, expand_parent: false }
+    }
+
+    /// Inside a `fill`, also break the separator BEFORE a `//` (the `//` takes its own line).
+    /// A fill measures `expand_parent` as not fitting but a hardline as fitting,
+    /// so the hardline alone only protects what FOLLOWS the comment.
+    pub const fn with_expand_parent(mut self) -> Self {
+        self.expand_parent = true;
+        self
+    }
+}
+
+impl<'a> Format<'a, CssFormatContext<'a>> for FormatCommentBeforeContent {
+    fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        write_comment_text(self.comment, f);
+        if self.comment.inline {
+            write!(f, [self.expand_parent.then_some(expand_parent()), hard_line_break()]);
+            return;
+        }
+        match self.block_after {
+            BlockCommentAfter::None => {}
+            BlockCommentAfter::Space => write!(f, space()),
+            BlockCommentAfter::HardLine => write!(f, hard_line_break()),
+        }
+    }
+}
+
+/// A `//` comment deferred through `line_suffix`: cannot swallow later tokens, not measured.
+#[must_use = "formatted comments must be written to the formatter"]
+#[derive(Clone, Copy, Debug)]
+pub struct FormatLineCommentSuffix {
+    comment: CssComment,
+    leading_space: bool,
+    expand_parent: bool,
+}
+
+impl FormatLineCommentSuffix {
+    pub const fn new(comment: CssComment) -> Self {
+        Self { comment, leading_space: false, expand_parent: false }
+    }
+
+    pub const fn with_leading_space(mut self) -> Self {
+        self.leading_space = true;
+        self
+    }
+
+    /// A `line_suffix` alone never breaks the enclosing group.
+    pub const fn with_expand_parent(mut self) -> Self {
+        self.expand_parent = true;
+        self
+    }
+}
+
+impl<'a> Format<'a, CssFormatContext<'a>> for FormatLineCommentSuffix {
+    fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        debug_assert!(self.comment.inline, "expected a line comment");
+        let comment = self.comment;
+        let leading_space = self.leading_space;
+        let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, maybe_space(leading_space));
+            write_comment_text(comment, f);
+        });
+        write!(f, [line_suffix(&content), self.expand_parent.then_some(expand_parent())]);
     }
 }
 
@@ -61,7 +148,7 @@ pub fn write_leading_comments(
 ) {
     let source = f.context().source_text();
     for (i, &comment) in comments.iter().enumerate() {
-        write_single_comment(comment, f);
+        write_comment_text(comment, f);
         match comments.get(i + 1) {
             // Comment followed by another comment: keep same-line pairs
             // (`*/ /*!`) together.
@@ -103,19 +190,18 @@ pub fn write_trailing_same_line_comments(
         }
 
         f.context().comments().take_before(comment.span.end);
-        let content = format_with(move |f: &mut CssFormatter<'_, '_>| {
-            write!(f, space());
-            write_single_comment(comment, f);
-        });
 
         // NOTE: Prettier does not distinguish between `// c` and `/* c */` at EOL only for CSS/SCSS/Less.
         // All other formatters treat EOL-line comments as line suffixes, so we are consistent with them.
         if comment.inline {
-            write!(f, [line_suffix(&content), expand_parent()]);
+            write!(
+                f,
+                FormatLineCommentSuffix::new(comment).with_leading_space().with_expand_parent()
+            );
             return;
         }
 
-        write!(f, [content]);
+        write!(f, [space(), FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)]);
         prev_end = comment.span.end;
     }
 }
@@ -133,7 +219,7 @@ pub fn write_trailing_inside_comments<'a>(
         let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             let gap = source.bytes_range(gap_start, comment.span.start);
             write_gap(gap, f);
-            write_single_comment(comment, f);
+            write_comment_text(comment, f);
         });
         write!(f, [line_suffix(&content), expand_parent()]);
         prev_end = comment.span.end;

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -27,7 +27,7 @@ use oxc_formatter_core::{
 };
 
 use crate::{
-    comments,
+    comments::{self, BlockCommentAfter, FormatCommentBeforeContent},
     format::to_span,
     print::{
         CssFormatter, format_with, normalize_whitespace, scss, selector, statement,
@@ -197,11 +197,10 @@ pub(super) fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, '
         let block_start = to_span(&block.span).start;
         let mut wrote_comment = false;
         if f.context().comments().peek().is_some_and(|c| c.inline && c.span.end <= block_start) {
-            for &comment in f.context().comments().take_before(block_start) {
-                write!(f, hard_line_break());
-                comments::write_single_comment(comment, f);
-            }
             write!(f, hard_line_break());
+            for &comment in f.context().comments().take_before(block_start) {
+                write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::HardLine));
+            }
             wrote_comment = true;
         }
         if !is_control_directive && !wrote_comment {
@@ -913,12 +912,7 @@ fn write_import_path_list<'a>(
                 }
                 for &comment in &leads[i] {
                     f.context().comments().take_before(comment.span.end);
-                    comments::write_single_comment(comment, f);
-                    if comment.inline {
-                        write!(f, hard_line_break());
-                    } else {
-                        write!(f, space());
-                    }
+                    write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
                 }
                 value::write_str_raw(path.1, f);
                 if i + 1 < n {
@@ -933,12 +927,7 @@ fn write_import_path_list<'a>(
         let lead: Vec<comments::CssComment> =
             f.context().comments().take_before(path_start).to_vec();
         for &comment in &lead {
-            comments::write_single_comment(comment, f);
-            if comment.inline {
-                write!(f, hard_line_break());
-            } else {
-                write!(f, space());
-            }
+            write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
         }
         value::write_str_raw(path.1, f);
     } else {
@@ -1863,7 +1852,10 @@ fn write_supports_in_parens<'a>(in_parens: &SupportsInParens<'a>, f: &mut CssFor
                     selector::write_selector_list(list, selector::SelectorListStyle::Line, f);
                     for &comment in f.context().comments().take_before(r_paren) {
                         write!(f, space());
-                        comments::write_single_comment(comment, f);
+                        write!(
+                            f,
+                            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        );
                     }
                 });
                 write!(f, [indent(&body), hard_line_break(), ")"]);

--- a/crates/oxc_formatter_css/src/print/less.rs
+++ b/crates/oxc_formatter_css/src/print/less.rs
@@ -15,7 +15,7 @@ use oxc_formatter_core::{
 };
 
 use crate::{
-    comments::write_single_comment,
+    comments::{BlockCommentAfter, FormatCommentBeforeContent},
     format::to_span,
     print::{
         CssFormatter, format_with,
@@ -79,8 +79,7 @@ pub(super) fn write_less_variable_declaration<'a>(
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         if inline_after_colon {
             for &comment in f.context().comments().take_before(value_start) {
-                write_single_comment(comment, f);
-                write!(f, hard_line_break());
+                write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::HardLine));
             }
         }
         write_top_level_list_element(&decl.value, value_ctx, f);
@@ -244,11 +243,10 @@ fn write_less_detached_ruleset<'a>(
     ruleset: &LessDetachedRuleset<'a>,
     f: &mut CssFormatter<'_, 'a>,
 ) {
-    // Comments before `{` stay on the same line
+    // Block comments before `{` stay inline; `//` ends its line.
     let block_start = to_span(&ruleset.block.span).start;
     for &comment in f.context().comments().take_before(block_start) {
-        write_single_comment(comment, f);
-        write!(f, space());
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
     }
     let was = f.context().in_less_detached().replace(true);
     write_block(&ruleset.block, f);

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -10,15 +10,15 @@ use oxc_css_parser::ast::{
 use oxc_formatter_core::{
     Buffer,
     builders::{
-        dedent, empty_line, expand_parent, group, hard_line_break, if_group_breaks, indent,
-        line_suffix, soft_line_break, soft_line_break_or_space, space, text,
+        dedent, empty_line, group, hard_line_break, if_group_breaks, indent, soft_line_break,
+        soft_line_break_or_space, space, text,
     },
     write,
 };
 use oxc_span::Span;
 
 use crate::{
-    comments,
+    comments::{self, BlockCommentAfter, FormatCommentBeforeContent, FormatLineCommentSuffix},
     format::to_span,
     print::{
         CssFormatter, format_with, statement,
@@ -225,19 +225,14 @@ pub(super) fn write_sass_map<'a>(
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             write!(f, soft_line_break());
             for (i, &comment) in tail.iter().enumerate() {
-                if i > 0 {
-                    if tail[i - 1].inline {
-                        // Prettier leaves a stray leading space here
-                        // (`   // b`, the `join(line)` separator prints before the deferred `lineSuffix` flushes);
-                        write!(f, hard_line_break());
-                    } else {
-                        write!(f, space());
-                    }
+                if i > 0 && !tail[i - 1].inline {
+                    write!(f, space());
                 }
-                comments::write_single_comment(comment, f);
-                if comment.inline {
-                    write!(f, expand_parent());
-                }
+                write!(
+                    f,
+                    FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        .with_expand_parent()
+                );
             }
         });
         write!(
@@ -350,12 +345,9 @@ pub(super) fn write_sass_map<'a>(
                 let fits = !value_is_block
                     && u32::from(f.options().indent_width.value()) + comment_width + 2 + item_width
                         <= u32::from(f.options().line_width.value());
-                comments::write_single_comment(comment, f);
-                if comment.inline || !fits {
-                    write!(f, hard_line_break());
-                } else {
-                    write!(f, " ");
-                }
+                let block_after =
+                    if fits { BlockCommentAfter::Space } else { BlockCommentAfter::HardLine };
+                write!(f, FormatCommentBeforeContent::new(comment, block_after));
             }
             let key_is_block = is_paren_block(&item.key);
             if key_is_block && !value_is_block {
@@ -429,14 +421,17 @@ pub(super) fn write_sass_map<'a>(
         // Not `write_paren_tail_comments`:
         // a next-slot comment (above) is same-line in source but still starts a line here,
         // and consecutive own-line block comments glue.
-        let mut after_inline = true;
-        for &comment in f.context().comments().take_before(r_paren) {
-            if after_inline || comment.inline {
-                write!(f, hard_line_break());
-            } else {
-                write!(f, " ");
+        let mut after_inline = false;
+        for (i, &comment) in f.context().comments().take_before(r_paren).iter().enumerate() {
+            // A `//` already ended its line
+            if !after_inline {
+                if i == 0 || comment.inline {
+                    write!(f, hard_line_break());
+                } else {
+                    write!(f, " ");
+                }
             }
-            comments::write_single_comment(comment, f);
+            write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
             after_inline = comment.inline;
         }
     });
@@ -725,7 +720,7 @@ fn write_else_join(else_start: u32, f: &mut CssFormatter<'_, '_>) {
         } else {
             write!(f, space());
         }
-        comments::write_single_comment(comment, f);
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
     }
     if between.is_empty() {
         write!(f, [space(), "@else", space()]);
@@ -1012,7 +1007,7 @@ fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormat
                     write_same_line_trailing_comments(bound, f).unwrap_or(item_span.end);
                 for &comment in f.context().comments().take_before(bound) {
                     comments::write_gap(source.bytes_range(prev_end, comment.span.start), f);
-                    comments::write_single_comment(comment, f);
+                    write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
                     prev_end = comment.span.end;
                 }
             }
@@ -1029,9 +1024,9 @@ fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormat
 /// the map/config bodies this serves already hard-break,
 /// so propagating a break out of a still-flat head (`@use "a" /* c */ with (`) would be a behavior change.
 /// Returns the end offset of the last emitted comment.
-fn write_same_line_trailing_comments<'a>(
+fn write_same_line_trailing_comments(
     upper_bound: u32,
-    f: &mut CssFormatter<'_, 'a>,
+    f: &mut CssFormatter<'_, '_>,
 ) -> Option<u32> {
     let mut last_end = None;
     while let Some(comment) = f.context().comments().peek() {
@@ -1042,14 +1037,9 @@ fn write_same_line_trailing_comments<'a>(
         }
         f.context().comments().take_before(comment.span.end);
         if comment.inline {
-            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                write!(f, space());
-                comments::write_single_comment(comment, f);
-            });
-            write!(f, line_suffix(&content));
+            write!(f, FormatLineCommentSuffix::new(comment).with_leading_space());
         } else {
-            write!(f, space());
-            comments::write_single_comment(comment, f);
+            write!(f, [space(), FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)]);
         }
         last_end = Some(comment.span.end);
     }

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -19,7 +19,8 @@ use oxc_formatter_core::{
 };
 
 use crate::{
-    TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX, comments,
+    TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX,
+    comments::{self, BlockCommentAfter, FormatCommentBeforeContent},
     format::to_span,
     print::{CssFormatter, format_with, less, normalize_whitespace, value, write_maybe_lowercase},
 };
@@ -85,6 +86,7 @@ pub(super) fn write_selector_list<'a>(
                 write!(f, ",");
                 // A comment trailing the comma stays on the same line
                 let next_start = to_span(complex.span()).start;
+                let mut line_comment_broke = false;
                 if let Some(comment) = f.context().comments().peek()
                     && comment.span.end <= next_start
                 {
@@ -95,19 +97,24 @@ pub(super) fn write_selector_list<'a>(
                     {
                         f.context().comments().take_before(comment.span.end);
                         write!(f, " ");
-                        comments::write_single_comment(comment, f);
+                        line_comment_broke = comment.inline;
+                        write!(
+                            f,
+                            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        );
                     }
                 }
-                match style {
-                    SelectorListStyle::Hard => write!(f, hard_line_break()),
-                    SelectorListStyle::Line => write!(f, soft_line_break_or_space()),
+                if !line_comment_broke {
+                    match style {
+                        SelectorListStyle::Hard => write!(f, hard_line_break()),
+                        SelectorListStyle::Line => write!(f, soft_line_break_or_space()),
+                    }
                 }
             }
             // Comments on their own line between selectors
             let start = to_span(complex.span()).start;
             for &comment in f.context().comments().take_before(start) {
-                comments::write_single_comment(comment, f);
-                write!(f, hard_line_break());
+                write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::HardLine));
             }
             if placeholder_idx == Some(i) {
                 let source = f.context().source_text();

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -27,8 +27,8 @@ use oxc_span::Span;
 use oxc_formatter_core::{
     Buffer, SourceText, arena_cow_str,
     builders::{
-        empty_line, expand_parent, group, hard_line_break, if_group_breaks, indent,
-        soft_line_break, soft_line_break_or_space, space, text, token,
+        empty_line, group, hard_line_break, if_group_breaks, indent, soft_line_break,
+        soft_line_break_or_space, space, text, token,
     },
     format_args,
     spec::{format_trimmed_number, normalize_string},
@@ -36,7 +36,8 @@ use oxc_formatter_core::{
 };
 
 use crate::{
-    CssFormatOptions, comments,
+    CssFormatOptions,
+    comments::{self, BlockCommentAfter, FormatCommentBeforeContent},
     format::to_span,
     print::{CssFormatter, format_with, less, scss, statement},
 };
@@ -639,12 +640,12 @@ pub(super) fn write_value_groups<'a>(
                     let source = f.context().source_text();
                     for &comment in lead {
                         let own_line = comment_is_own_line(comment, source);
-                        comments::write_single_comment(comment, f);
-                        if comment.inline || own_line {
-                            write!(f, hard_line_break());
+                        let block_after = if own_line {
+                            BlockCommentAfter::HardLine
                         } else {
-                            write!(f, " ");
-                        }
+                            BlockCommentAfter::Space
+                        };
+                        write!(f, FormatCommentBeforeContent::new(comment, block_after));
                     }
                     write_comma_group(group_values, gctx, f);
                 } else {
@@ -658,19 +659,16 @@ pub(super) fn write_value_groups<'a>(
                         }) + u32::from(!is_last);
                     let mut x = 4u32; // hardline indent under the value
                     for (k, &comment) in lead.iter().enumerate() {
-                        comments::write_single_comment(comment, f);
                         x += comment.span.end - comment.span.start;
                         let next_w = lead.get(k + 1).map_or(group_w, |c| c.span.end - c.span.start);
-                        if comment.inline {
-                            write!(f, hard_line_break());
-                            x = 4;
-                        } else if x + 1 + next_w <= width {
-                            write!(f, space());
-                            x += 1;
+                        let fits = x + 1 + next_w <= width;
+                        let block_after = if fits {
+                            BlockCommentAfter::Space
                         } else {
-                            write!(f, hard_line_break());
-                            x = 4;
-                        }
+                            BlockCommentAfter::HardLine
+                        };
+                        write!(f, FormatCommentBeforeContent::new(comment, block_after));
+                        x = if !comment.inline && fits { x + 1 } else { 4 };
                     }
                     write_comma_group(group_values, gctx, f);
                 }
@@ -728,7 +726,7 @@ pub(super) fn comment_is_own_line(comment: comments::CssComment, source: SourceT
 ///   - it carries no line semantics, and keeping it own-line would pin a wrapped layout
 ///   - With `body_hard_broken` it keeps its own line instead:
 ///     the body already prints one element per line, so there is no wrapped layout to pin.
-/// - After a `//`: always a new line, or the `//` would swallow the next comment.
+/// - After a `//`: always a new line (the `//` ends its own line).
 /// - `after_content == false` (`[ /* c */ ]`): the comments ARE the body, nothing to space them off.
 ///
 /// Returns true when the last comment was a `//`.
@@ -742,15 +740,17 @@ fn write_paren_tail_comments(
     let mut after_inline = false;
     for (i, &comment) in tail.iter().enumerate() {
         let keeps_line = comment.inline || body_hard_broken;
-        if after_inline || (keeps_line && comment_is_own_line(comment, source)) {
+        if after_inline {
+            // Already on a fresh line
+        } else if keeps_line && comment_is_own_line(comment, source) {
             write!(f, hard_line_break());
         } else if i > 0 || after_content {
             write!(f, space());
         }
-        comments::write_single_comment(comment, f);
-        if comment.inline {
-            write!(f, expand_parent());
-        }
+        write!(
+            f,
+            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
+        );
         after_inline = comment.inline;
     }
     after_inline
@@ -799,17 +799,13 @@ fn write_bracket_block<'a>(
             }
         }
         let tail: &'a [comments::CssComment] = f.context().comments().take_before(r_bracket);
-        let ends_with_line_comment = write_paren_tail_comments(
+        // A trailing `//` ends its own line, so `]` stays out of it even with no group to expand here.
+        write_paren_tail_comments(
             tail,
             /* body_hard_broken */ false,
             !bracket.value.is_empty(),
             f,
         );
-        if flat && ends_with_line_comment {
-            // No group to expand here: keep `]` out of the `//` comment
-            // (the `expand_parent` still reaches the declaration group).
-            write!(f, hard_line_break());
-        }
     });
     if flat {
         write!(f, ["[", body, "]"]);
@@ -839,12 +835,10 @@ pub(super) fn write_text_with_leading_comments(span: Span, f: &mut CssFormatter<
 pub(super) fn flush_value_comments(upper_bound: u32, f: &mut CssFormatter<'_, '_>) -> bool {
     let mut last_inline = false;
     for &comment in f.context().comments().take_before(upper_bound) {
-        comments::write_single_comment(comment, f);
-        if comment.inline {
-            write!(f, [expand_parent(), hard_line_break()]);
-        } else {
-            write!(f, " ");
-        }
+        write!(
+            f,
+            FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space).with_expand_parent()
+        );
         last_inline = comment.inline;
     }
     last_inline
@@ -870,9 +864,11 @@ pub(super) fn flush_same_line_comments(
         }
         f.context().comments().take_before(comment.span.end);
         write!(f, " ");
-        comments::write_single_comment(comment, f);
+        write!(
+            f,
+            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
+        );
         if comment.inline {
-            write!(f, [expand_parent()]);
             return;
         }
     }
@@ -888,10 +884,10 @@ pub(super) fn flush_trailing_value_comments(
     let mut last_end = None;
     for &comment in f.context().comments().take_before(upper_bound) {
         write!(f, " ");
-        comments::write_single_comment(comment, f);
-        if comment.inline {
-            write!(f, [expand_parent(), hard_line_break()]);
-        }
+        write!(
+            f,
+            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
+        );
         last_end = Some(comment.span.end);
     }
     last_end
@@ -1060,8 +1056,11 @@ pub(super) fn write_comma_group<'a>(
                         }
                         f.context().comments().take_before(comment.span.end);
                         write!(f, " ");
-                        comments::write_single_comment(comment, f);
-                        write!(f, expand_parent());
+                        write!(
+                            f,
+                            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                                .with_expand_parent()
+                        );
                     }
                 }
             });
@@ -1089,7 +1088,10 @@ pub(super) fn write_comma_group<'a>(
                     let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                         if f.context().comments().peek().is_some_and(|c| c.span == comment.span) {
                             f.context().comments().take_before(comment.span.end);
-                            comments::write_single_comment(comment, f);
+                            write!(
+                                f,
+                                FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                            );
                         }
                     });
                     filler.entry(&soft_line_break_or_space(), &entry);
@@ -1101,10 +1103,11 @@ pub(super) fn write_comma_group<'a>(
         for (k, &comment) in tail_comments.iter().enumerate() {
             let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 f.context().comments().take_before(comment.span.end);
-                comments::write_single_comment(comment, f);
-                if comment.inline {
-                    write!(f, expand_parent());
-                }
+                write!(
+                    f,
+                    FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        .with_expand_parent()
+                );
             });
             if k == 0 && ctx.tail_break {
                 filler.entry(&hard_line_break(), &entry);
@@ -2328,7 +2331,10 @@ pub(super) fn write_function<'a>(
                 filler.entry(&soft_line_break_or_space(), &format_with(|_| {}));
                 for &comment in tail {
                     let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                        comments::write_single_comment(comment, f);
+                        write!(
+                            f,
+                            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        );
                     });
                     filler.entry(&soft_line_break_or_space(), &entry);
                 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/supports-selector-inline-comments.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/supports-selector-inline-comments.scss
@@ -1,0 +1,17 @@
+// A `//` inside `@supports selector(...)` opens the parens and ends its line,
+// so the next token or comment never rides it (`a, // c b` would swallow `b`).
+// Prettier prints the first three the same way;
+// the last two are DIVERGENCES.md "supports-selector-inline-comment-list".
+@supports selector(a // c
+) {}
+@supports selector(a /* c */ // d
+) {}
+@supports selector(a, /* c */ b // d
+) {}
+// Prettier keeps a comma list with a `//` verbatim: `selector(a, // c\n b)`.
+@supports selector(a, // c
+ b) {}
+// Prettier prints the second `//` with a stray leading space and no indent.
+@supports selector(a // c
+ // d
+) {}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/supports-selector-inline-comments.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/supports-selector-inline-comments.scss.snap
@@ -1,0 +1,88 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A `//` inside `@supports selector(...)` opens the parens and ends its line,
+// so the next token or comment never rides it (`a, // c b` would swallow `b`).
+// Prettier prints the first three the same way;
+// the last two are DIVERGENCES.md "supports-selector-inline-comment-list".
+@supports selector(a // c
+) {}
+@supports selector(a /* c */ // d
+) {}
+@supports selector(a, /* c */ b // d
+) {}
+// Prettier keeps a comma list with a `//` verbatim: `selector(a, // c\n b)`.
+@supports selector(a, // c
+ b) {}
+// Prettier prints the second `//` with a stray leading space and no indent.
+@supports selector(a // c
+ // d
+) {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A `//` inside `@supports selector(...)` opens the parens and ends its line,
+// so the next token or comment never rides it (`a, // c b` would swallow `b`).
+// Prettier prints the first three the same way;
+// the last two are DIVERGENCES.md "supports-selector-inline-comment-list".
+@supports selector(
+  a // c
+) {
+}
+@supports selector(
+  a /* c */ // d
+) {
+}
+@supports selector(
+  a, /* c */ b // d
+) {
+}
+// Prettier keeps a comma list with a `//` verbatim: `selector(a, // c\n b)`.
+@supports selector(
+  a, // c
+  b
+) {
+}
+// Prettier prints the second `//` with a stray leading space and no indent.
+@supports selector(
+  a // c
+  // d
+) {
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A `//` inside `@supports selector(...)` opens the parens and ends its line,
+// so the next token or comment never rides it (`a, // c b` would swallow `b`).
+// Prettier prints the first three the same way;
+// the last two are DIVERGENCES.md "supports-selector-inline-comment-list".
+@supports selector(
+  a // c
+) {
+}
+@supports selector(
+  a /* c */ // d
+) {
+}
+@supports selector(
+  a, /* c */ b // d
+) {
+}
+// Prettier keeps a comma list with a `//` verbatim: `selector(a, // c\n b)`.
+@supports selector(
+  a, // c
+  b
+) {
+}
+// Prettier prints the second `//` with a stray leading space and no indent.
+@supports selector(
+  a // c
+  // d
+) {
+}
+
+===================== End =====================


### PR DESCRIPTION
#26313 for CSS formatter. This also fixes some bugs.