### PR TITLE
fix(formatter_css): keep a line comment on its comma's line

### DIFF
--- a/crates/oxc_formatter_core/src/source/cursor.rs
+++ b/crates/oxc_formatter_core/src/source/cursor.rs
@@ -65,6 +65,11 @@ impl<T: GetSpan + Copy> SpanCursor<'_, T> {
         self.inner[start..].iter().copied().take_while(move |item| item.span().end <= upper_bound)
     }
 
+    /// Iterator over every unprinted item ([`Self::take_remaining`] without advancing the cursor).
+    pub fn iter_remaining(&self) -> impl Iterator<Item = T> {
+        self.inner[self.cursor.get()..].iter().copied()
+    }
+
     /// Returns the most recently consumed item, if any.
     /// ([`Self::peek`]'s mirror on the consumed side)
     /// Lets consumers re-anchor position measurements after a drain consumed items past their own anchor.

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -63,7 +63,7 @@ Ownership is a claim discipline, not attachment: each printer claims the comment
 The shared invariants (FORMATTER_POLICY.md "Comment placement invariants") apply; this section records their CSS translation:
 
 - `,` is a list SEPARATOR: a comment between an element and its comma stays BEFORE the comma
-  - `a /* c */, b`; comments after it lead the next element
+  - `a /* c */, b`; comments after it lead the next element, except a `//` on the comma's line (line-boundary rule below)
   - Declaration value lists (`write_value_groups`) and function arguments (`write_function`) route every comma through `write_group_comma` with the comma offset paired to its group
   - `split_comma_groups` returns `(group, Option<comma_start>)`; SCSS/Less lists pair `comma_spans`
   - A new comma site must take the pair, the shape makes taking the groups without the commas a visible choice, not an accident
@@ -77,8 +77,8 @@ The shared invariants (FORMATTER_POLICY.md "Comment placement invariants") apply
   - a flush's upper bound must never extend past the next piece of user content,
   - and a declaration's `tail_bound` may only be consumed by the LAST comma group (`write_value_groups` clears it for every other group)
 - Line-boundary rule in CSS terms: `//` comments force a hardline after;
-  - besides the policy's opener exception, a same-line `//` after a list `,` also leads the next element on its own line
-    (Prettier's CSS; JS keeps `1, // c` trailing)
+  - a `//` on a list `,`'s line stays there (`1, // c`, like JS), together with the block comments glued before it on that line;
+    Prettier's CSS moves it below as the next element's leading comment (DIVERGENCES.md "line-comment-after-comma")
   - own-line comments stay own-line at statement and trailing level, but a value-level own-line BLOCK comment is a plain fill item (joins the line when it fits):
     - it carries no line-based semantics, and freezing it own-line would pin a wrapped layout (= not idempotent)
 
@@ -201,7 +201,9 @@ The harness snapshots both `--print-width 80` and `100`; verify fixtures at both
 At the current version (v3.9.6), these divergences have been confirmed and are intentional (see DIVERGENCES.md):
 
 - CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`, `css/stylefmt-repo/media-queries-ranges/media-queries-ranges.css`, `css/postcss-plugins/postcss-nesting.css`, `css/comments/declaration.css` (terminator-gap-normalized)
-- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`, `scss/trailing-comma/comments.scss`, `scss/trailing-comma/list.scss`, `scss/trailing-comma/variable.scss`, `scss/function/arbitrary-arguments-comment.scss`, `scss/map/15193.scss`, `scss/comments/variable-declaration.scss` (terminator-gap-normalized)
+- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`, `scss/trailing-comma/comments.scss`, `scss/trailing-comma/list.scss`, `scss/trailing-comma/variable.scss`, `scss/function/arbitrary-arguments-comment.scss`, `scss/map/15193.scss`, `scss/comments/variable-declaration.scss` (terminator-gap-normalized),
+  `scss/comments/4594.scss`, `scss/comments/lists.scss`, `scss/comments/maps.scss`, `scss/trailing-comma/issue-6920.scss` and one more hunk of `scss/trailing-comma/comments.scss` (line-comment-after-comma)
+- Less: `less/comments/value-lists.less` (line-comment-after-comma)
 
 Two more files fail with MIXED hunks; they can't pass as files (the intentional hunks alone keep them failing), so the remaining diffs are itemized here:
 

--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -665,6 +665,40 @@ a comma list holding a `//` it keeps verbatim instead, source whitespace include
 A second `//` indents like the first; Prettier prints it with a stray leading space and no indent,
 the same `join(line)` + deferred `lineSuffix` artifact as "comment-only-map-indent".
 
+## line-comment-after-comma
+
+- Why: invariant
+- Pin: `tests/fixtures/format/scss/line-comment-after-comma.scss`, `tests/fixtures/format/less/line-comment-after-comma.less`
+
+```scss
+/* input */
+$my-map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+
+/* ours */
+$my-map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+
+/* prettier */
+$my-map: (
+  "foo": 1,
+  // Comment
+  "bar": 2, // Comment
+);
+```
+
+A `//` on a comma's line stays on that line (the block comments glued before it come along);
+Prettier moves it below as the next element's leading comment, across the line boundary (`a, // stylelint-disable-line` loses its target).
+Prettier keeps the same comment after the LAST comma (`"bar": 2, // Comment`) and its JS printer keeps `1, // c` everywhere:
+the move is where postcss-value-parser hands the comment to the next comma group, not a rule.
+Applies at every comma site: values, function and `@include` arguments, maps, paren lists, `@use ... with`, `@forward` members, `@each`, `@import` paths,
+`@media` query lists and `selector()` lists.
+For `@media` Prettier's move also swallows the next query (`@media a, // c b {`), a semantics bug on its side.
+
 ## semiless-custom-property-block
 
 - Why: cost

--- a/crates/oxc_formatter_css/src/comments.rs
+++ b/crates/oxc_formatter_css/src/comments.rs
@@ -58,20 +58,11 @@ pub enum BlockCommentAfter {
 pub struct FormatCommentBeforeContent {
     comment: CssComment,
     block_after: BlockCommentAfter,
-    expand_parent: bool,
 }
 
 impl FormatCommentBeforeContent {
     pub const fn new(comment: CssComment, block_after: BlockCommentAfter) -> Self {
-        Self { comment, block_after, expand_parent: false }
-    }
-
-    /// Inside a `fill`, also break the separator BEFORE a `//` (the `//` takes its own line).
-    /// A fill measures `expand_parent` as not fitting but a hardline as fitting,
-    /// so the hardline alone only protects what FOLLOWS the comment.
-    pub const fn with_expand_parent(mut self) -> Self {
-        self.expand_parent = true;
-        self
+        Self { comment, block_after }
     }
 }
 
@@ -79,7 +70,7 @@ impl<'a> Format<'a, CssFormatContext<'a>> for FormatCommentBeforeContent {
     fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
         write_comment_text(self.comment, f);
         if self.comment.inline {
-            write!(f, [self.expand_parent.then_some(expand_parent()), hard_line_break()]);
+            write!(f, hard_line_break());
             return;
         }
         match self.block_after {
@@ -176,6 +167,7 @@ pub fn flush_leading_comments(value_start: u32, f: &mut CssFormatter<'_, '_>) {
 /// as `prev_end` as trailing comments (`red; /* x */ /* y */`); a `//` comment ends the run.
 /// Look-alike of `scss::write_same_line_trailing_comments`, which deliberately differs:
 /// no `expand_parent` there (its map/config bodies already hard-break).
+/// For the run on a list comma's line, see `value::flush_line_comment_after_comma`.
 pub fn write_trailing_same_line_comments(
     mut prev_end: u32,
     upper: u32,

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -813,8 +813,16 @@ fn write_at_rule_prelude<'a>(prelude: &AtRulePrelude<'a>, f: &mut CssFormatter<'
         AtRulePrelude::SassUse(sass_use) => scss::write_sass_use(sass_use, f),
         AtRulePrelude::SassForward(forward) => scss::write_sass_forward(forward, f),
         AtRulePrelude::SassImport(import) => {
-            let paths: Vec<(Span, &str)> =
-                import.paths.iter().map(|path| (path.span, path.raw)).collect();
+            let paths: Vec<ImportPath<'_>> = import
+                .paths
+                .iter()
+                .enumerate()
+                .map(|(i, path)| ImportPath {
+                    span: path.span,
+                    raw: path.raw,
+                    comma_start: import.comma_spans.get(i).map(|sp| to_span(sp).start),
+                })
+                .collect();
             write_import_path_list(&paths, to_span(import.span()).end, f);
         }
         // Only reached for SCSS-family names parsed AS CSS (see `is_value_parsed_at_rule`);
@@ -848,8 +856,15 @@ fn write_at_rule_prelude<'a>(prelude: &AtRulePrelude<'a>, f: &mut CssFormatter<'
 /// Used by the SCSS `SassImportPrelude` AND by `ImportPrelude`
 /// when its non-standard tail is exactly a comma-separated string list (see `import_as_path_list`).
 /// Paths arrive as `(span, raw)` pairs so both callers can feed it without fabricating AST nodes.
+/// One `@import` path with the start of its trailing comma (see [`value::write_group_comma`]'s pairing).
+struct ImportPath<'a> {
+    span: Span,
+    raw: &'a str,
+    comma_start: Option<u32>,
+}
+
 fn write_import_path_list<'a>(
-    paths: &[(Span, &'a str)],
+    paths: &[ImportPath<'a>],
     last_end: u32,
     f: &mut CssFormatter<'_, 'a>,
 ) {
@@ -862,16 +877,29 @@ fn write_import_path_list<'a>(
         // So the separator breaks are simulated here with static widths.
         let all: Vec<comments::CssComment> = f.context().comments().iter_before(last_end).collect();
         let n = paths.len();
+        let source = f.context().source_text();
+        // A `//` on a path's comma line stays there (`"a", // c`, `value::flush_line_comment_after_comma`):
+        // `trailing[i]` is that comma, `leads[i + 1]` starts past the run.
+        let mut trailing: Vec<Option<u32>> = vec![None; n];
         let mut leads: Vec<Vec<comments::CssComment>> = Vec::with_capacity(n);
         for (i, path) in paths.iter().enumerate() {
-            let path_start = to_span(&path.0).start;
-            leads.push(
-                all.iter()
-                    .filter(|c| c.span.end <= path_start)
-                    .filter(|c| i == 0 || c.span.start >= to_span(&paths[i - 1].0).end)
-                    .copied()
-                    .collect(),
-            );
+            let path_start = to_span(&path.span).start;
+            let prev = (i > 0).then(|| &paths[i - 1]);
+            let prev_end = prev.map(|prev| to_span(&prev.span).end);
+            let mut lead: Vec<comments::CssComment> = all
+                .iter()
+                .filter(|c| c.span.end <= path_start)
+                .filter(|c| prev_end.is_none_or(|prev_end| c.span.start >= prev_end))
+                .copied()
+                .collect();
+            if let Some(comma) = prev.and_then(|prev| prev.comma_start)
+                && let Some(run_end) =
+                    value::line_comment_run_end(comma + 1, lead.iter().copied(), source)
+            {
+                lead.retain(|c| c.span.end > run_end);
+                trailing[i - 1] = Some(comma);
+            }
+            leads.push(lead);
         }
         // Prettier fill: separator stays flat only when
         // [chunk, ", ", next chunk] fits and neither chunk has a comment (hardline).
@@ -881,7 +909,7 @@ fn write_import_path_list<'a>(
             .iter()
             .enumerate()
             .map(|(i, p)| {
-                let span = to_span(&p.0);
+                let span = to_span(&p.span);
                 span.end - span.start + u32::from(i + 1 < n)
             })
             .collect();
@@ -891,7 +919,7 @@ fn write_import_path_list<'a>(
             if i + 1 == n {
                 break;
             }
-            let hard = leads[i].iter().any(|c| c.inline);
+            let hard = leads[i].iter().any(|c| c.inline) || trailing[i].is_some();
             let next_hard = leads[i + 1].iter().any(|c| c.inline);
             let fits2 = !hard && !next_hard && x + chunk_w[i] + 1 + chunk_w[i + 1] <= width;
             if fits2 {
@@ -914,22 +942,25 @@ fn write_import_path_list<'a>(
                     f.context().comments().take_before(comment.span.end);
                     write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
                 }
-                value::write_str_raw(path.1, f);
+                value::write_str_raw(path.raw, f);
                 if i + 1 < n {
                     write!(f, ",");
+                    if let Some(comma) = trailing[i] {
+                        value::flush_line_comment_after_comma(comma, f);
+                    }
                 }
             }
         });
         write!(f, indent(&body));
     } else if has_comments {
         let path = &paths[0];
-        let path_start = to_span(&path.0).start;
+        let path_start = to_span(&path.span).start;
         let lead: Vec<comments::CssComment> =
             f.context().comments().take_before(path_start).to_vec();
         for &comment in &lead {
             write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
         }
-        value::write_str_raw(path.1, f);
+        value::write_str_raw(path.raw, f);
     } else {
         // Comma-separated path list:
         // Prettier value-parses `@import` params (module rule) and fills them,
@@ -939,7 +970,7 @@ fn write_import_path_list<'a>(
             let n = paths.len();
             for (i, path) in paths.iter().enumerate() {
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                    value::write_str_raw(path.1, f);
+                    value::write_str_raw(path.raw, f);
                     if i + 1 < n {
                         write!(f, ",");
                     }
@@ -1346,12 +1377,12 @@ fn write_import_prelude<'a>(import: &ImportPrelude<'a>, f: &mut CssFormatter<'_,
     write!(f, group(&indent(&body)));
 }
 
-/// `Some(paths)` (as `(span, raw)` pairs) when the prelude is a plain multi-path import:
+/// `Some(paths)` when the prelude is a plain multi-path import:
 /// a string href whose whole tail is `, <string> (, <string>)*` held as raw tokens.
 fn import_as_path_list<'a>(
     import: &ImportPrelude<'a>,
     f: &CssFormatter<'_, 'a>,
-) -> Option<Vec<(Span, &'a str)>> {
+) -> Option<Vec<ImportPath<'a>>> {
     let modifiers = import.modifiers.as_ref()?;
     let ImportPreludeHref::Str(InterpolableStr::Literal(href)) = &import.href else {
         return None;
@@ -1365,16 +1396,25 @@ fn import_as_path_list<'a>(
     }
     let source = f.context().source_text();
     let mut paths = Vec::with_capacity(1 + modifiers.values.len() / 2);
-    paths.push((href.span, href.raw));
+    paths.push(ImportPath { span: href.span, raw: href.raw, comma_start: None });
     let mut expect_comma = true;
     for value in &modifiers.values {
         let ComponentValue::TokenWithSpan(tok) = value else {
             return None;
         };
         match &tok.token {
-            Token::Comma(_) if expect_comma => expect_comma = false,
+            Token::Comma(_) if expect_comma => {
+                expect_comma = false;
+                if let Some(last) = paths.last_mut() {
+                    last.comma_start = Some(to_span(&tok.span).start);
+                }
+            }
             Token::Str(_) if !expect_comma => {
-                paths.push((tok.span, source.text_for(&to_span(&tok.span))));
+                paths.push(ImportPath {
+                    span: tok.span,
+                    raw: source.text_for(&to_span(&tok.span)),
+                    comma_start: None,
+                });
                 expect_comma = true;
             }
             _ => return None,
@@ -1586,6 +1626,9 @@ fn write_media_query_list_inner<'a>(list: &MediaQueryList<'a>, f: &mut CssFormat
     for (i, query) in list.queries.iter().enumerate() {
         if i > 0 {
             write!(f, ",");
+            if let Some(comma) = list.comma_spans.get(i - 1) {
+                value::flush_line_comment_after_comma(to_span(comma).start, f);
+            }
             write!(f, soft_line_break_or_space());
         }
         write_media_query(query, f);

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -228,11 +228,7 @@ pub(super) fn write_sass_map<'a>(
                 if i > 0 && !tail[i - 1].inline {
                     write!(f, space());
                 }
-                write!(
-                    f,
-                    FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
-                        .with_expand_parent()
-                );
+                write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
             }
         });
         write!(
@@ -908,11 +904,10 @@ pub(super) fn write_sass_forward<'a>(forward: &SassForward<'a>, f: &mut CssForma
                 let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     value::write_text_with_leading_comments(to_span(member.span()), f);
                     if i + 1 < members.len() {
-                        write_same_line_trailing_comments(
-                            to_span(&visibility.comma_spans[i]).start,
-                            f,
-                        );
+                        let comma = to_span(&visibility.comma_spans[i]).start;
+                        write_same_line_trailing_comments(comma, f);
                         write!(f, ",");
+                        value::flush_line_comment_after_comma(comma, f);
                     }
                 });
                 filler.entry(&soft_line_break_or_space(), &entry);
@@ -997,8 +992,10 @@ fn write_sass_module_config<'a>(config: &SassModuleConfig<'a>, f: &mut CssFormat
             if i + 1 < config.items.len() {
                 // An own-line comment before the comma stays pending and
                 // leads the next item instead.
-                write_same_line_trailing_comments(to_span(&config.comma_spans[i]).start, f);
+                let comma = to_span(&config.comma_spans[i]).start;
+                write_same_line_trailing_comments(comma, f);
                 write!(f, ",");
+                value::flush_line_comment_after_comma(comma, f);
             } else {
                 // Comments before `)` (past a trailing comma, which is dropped):
                 // same-line ones glue to the last item, own-line ones keep their line.

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -4,6 +4,7 @@
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
+
 use oxc_css_parser::ast::{
     AttributeSelector, AttributeSelectorMatcherKind, AttributeSelectorValue, Combinator,
     CombinatorKind, ComplexSelector, ComplexSelectorChild, CompoundSelector, CompoundSelectorList,
@@ -11,7 +12,6 @@ use oxc_css_parser::ast::{
     PseudoClassSelector, PseudoClassSelectorArgKind, PseudoElementSelector,
     PseudoElementSelectorArgKind, SelectorList, SimpleSelector, TypeSelector, WqName,
 };
-
 use oxc_formatter_core::{
     Buffer, FormatElement, arena_cow_str,
     builders::{group, hard_line_break, indent, soft_line_break, soft_line_break_or_space, text},
@@ -84,9 +84,10 @@ pub(super) fn write_selector_list<'a>(
         for (i, complex) in list.selectors.iter().enumerate() {
             if i > 0 {
                 write!(f, ",");
-                // A comment trailing the comma stays on the same line
+                // A comment trailing the comma stays on the same line:
+                // a lone block comment (`a, /* b */ c`), or a run ending in a `//` (`a, /* b */ // c`).
+                // A `//` ends the line itself; the separator below then merges into its break.
                 let next_start = to_span(complex.span()).start;
-                let mut line_comment_broke = false;
                 if let Some(comment) = f.context().comments().peek()
                     && comment.span.end <= next_start
                 {
@@ -95,20 +96,18 @@ pub(super) fn write_selector_list<'a>(
                     if comments::classify_gap(source.bytes_range(prev_end, comment.span.start))
                         == comments::Gap::None
                     {
-                        f.context().comments().take_before(comment.span.end);
-                        write!(f, " ");
-                        line_comment_broke = comment.inline;
-                        write!(
-                            f,
-                            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
+                        let run_end = value::line_comment_run_end(
+                            comment.span.start,
+                            f.context().comments().iter_remaining(),
+                            source,
                         );
+                        let upper_bound = run_end.unwrap_or(comment.span.end);
+                        value::flush_same_line_comments(comment.span.start, upper_bound, f);
                     }
                 }
-                if !line_comment_broke {
-                    match style {
-                        SelectorListStyle::Hard => write!(f, hard_line_break()),
-                        SelectorListStyle::Line => write!(f, soft_line_break_or_space()),
-                    }
+                match style {
+                    SelectorListStyle::Hard => write!(f, hard_line_break()),
+                    SelectorListStyle::Line => write!(f, soft_line_break_or_space()),
                 }
             }
             // Comments on their own line between selectors

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -12,6 +12,7 @@
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
+
 use oxc_css_parser::{
     ast::{
         BracketBlock, Calc, CalcOperatorKind, ComponentValue, Delimiter, DelimiterKind, Dimension,
@@ -22,8 +23,6 @@ use oxc_css_parser::{
     },
     token::Token,
 };
-use oxc_span::Span;
-
 use oxc_formatter_core::{
     Buffer, SourceText, arena_cow_str,
     builders::{
@@ -34,6 +33,7 @@ use oxc_formatter_core::{
     spec::{format_trimmed_number, normalize_string},
     write,
 };
+use oxc_span::Span;
 
 use crate::{
     CssFormatOptions,
@@ -597,12 +597,52 @@ pub(super) fn comma_group_is_multi(group: &[ComponentValue<'_>], is_first: bool)
 
 /// A group's separator comma:
 /// comments between the group and its comma stay before the comma (`a /* c */, b`);
-/// only comments past it lead the next group.
+/// a same-line `//` right after it stays on its line (`a, // c`, the line-boundary invariant),
+/// only comments past those lead the next group.
 pub(super) fn write_group_comma(comma_start: Option<u32>, f: &mut CssFormatter<'_, '_>) {
-    if let Some(comma) = comma_start {
-        flush_trailing_value_comments(comma, f);
-    }
+    let Some(comma) = comma_start else {
+        write!(f, ",");
+        return;
+    };
+    flush_trailing_value_comments(comma, f);
     write!(f, ",");
+    flush_line_comment_after_comma(comma, f);
+}
+
+/// A `//` on the line of the comma just written (`a, // c`, `a, /* b */ // c`) stays on that line,
+/// the line-boundary invariant; the block comments glued before it on that line come along.
+/// Prettier's CSS moves them below as the next element's leading comments instead
+/// (its other printers keep them, and so do the other formatter crates), see DIVERGENCES.md "line-comment-after-comma".
+pub(super) fn flush_line_comment_after_comma(comma_start: u32, f: &mut CssFormatter<'_, '_>) {
+    let comma_end = comma_start + 1;
+    let source = f.context().source_text();
+    let run_end = line_comment_run_end(comma_end, f.context().comments().iter_remaining(), source);
+    if let Some(run_end) = run_end {
+        flush_same_line_comments(comma_end, run_end, f);
+    }
+}
+
+/// End of the comment run glued right after `prev_end` (only spaces/tabs between) that ends in a `//`;
+/// `None` when no `//` is glued there (a lone block comment leads the next element instead).
+/// `comments` are the pending comments in source order.
+pub(super) fn line_comment_run_end(
+    prev_end: u32,
+    comments: impl Iterator<Item = comments::CssComment>,
+    source: SourceText<'_>,
+) -> Option<u32> {
+    let mut prev_end = prev_end;
+    for comment in comments {
+        if comment.span.start < prev_end
+            || !source.all_bytes_match(prev_end, comment.span.start, |b| matches!(b, b' ' | b'\t'))
+        {
+            return None;
+        }
+        if comment.inline {
+            return Some(comment.span.end);
+        }
+        prev_end = comment.span.end;
+    }
+    None
 }
 
 /// Top-level comma-group list layout, shared between flat component streams and SCSS comma lists.
@@ -628,9 +668,9 @@ pub(super) fn write_value_groups<'a>(
                 let is_last = i + 1 == groups.len();
                 // The declaration tail belongs to the LAST group only
                 let gctx = if is_last { ctx } else { ValueContext { tail_bound: None, ..ctx } };
-                // Comments between groups (e.g. after the previous comma)
-                // fill together with the group they precede;
-                // `//` comments (and leading own-line comments) keep their own line.
+                // Comments between groups lead the group they precede
+                // (a `//` on the previous comma's line already went with the comma, see `write_group_comma`);
+                // own-line ones keep their line.
                 let lead: &'a [comments::CssComment] = group_values.first().map_or(&[], |first| {
                     f.context().comments().take_before(to_span(first.span()).start)
                 });
@@ -747,10 +787,7 @@ fn write_paren_tail_comments(
         } else if i > 0 || after_content {
             write!(f, space());
         }
-        write!(
-            f,
-            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
-        );
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
         after_inline = comment.inline;
     }
     after_inline
@@ -835,10 +872,7 @@ pub(super) fn write_text_with_leading_comments(span: Span, f: &mut CssFormatter<
 pub(super) fn flush_value_comments(upper_bound: u32, f: &mut CssFormatter<'_, '_>) -> bool {
     let mut last_inline = false;
     for &comment in f.context().comments().take_before(upper_bound) {
-        write!(
-            f,
-            FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space).with_expand_parent()
-        );
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::Space));
         last_inline = comment.inline;
     }
     last_inline
@@ -864,10 +898,7 @@ pub(super) fn flush_same_line_comments(
         }
         f.context().comments().take_before(comment.span.end);
         write!(f, " ");
-        write!(
-            f,
-            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
-        );
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
         if comment.inline {
             return;
         }
@@ -884,10 +915,7 @@ pub(super) fn flush_trailing_value_comments(
     let mut last_end = None;
     for &comment in f.context().comments().take_before(upper_bound) {
         write!(f, " ");
-        write!(
-            f,
-            FormatCommentBeforeContent::new(comment, BlockCommentAfter::None).with_expand_parent()
-        );
+        write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
         last_end = Some(comment.span.end);
     }
     last_end
@@ -1059,7 +1087,6 @@ pub(super) fn write_comma_group<'a>(
                         write!(
                             f,
                             FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
-                                .with_expand_parent()
                         );
                     }
                 }
@@ -1103,11 +1130,7 @@ pub(super) fn write_comma_group<'a>(
         for (k, &comment) in tail_comments.iter().enumerate() {
             let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                 f.context().comments().take_before(comment.span.end);
-                write!(
-                    f,
-                    FormatCommentBeforeContent::new(comment, BlockCommentAfter::None)
-                        .with_expand_parent()
-                );
+                write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
             });
             if k == 0 && ctx.tail_break {
                 filler.entry(&hard_line_break(), &entry);

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/line-comment-after-comma.less
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/line-comment-after-comma.less
@@ -1,0 +1,10 @@
+// A `//` on a comma's line stays on that line (DIVERGENCES.md "line-comment-after-comma").
+@list: #aaaaaa, // Start with A
+  #bbbbbb, // then some B
+  #cccccc; // and round it out with C
+a {
+  transition: a 1s, // c
+    b 2s;
+  b: f(a, // c
+    b);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/line-comment-after-comma.less.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/line-comment-after-comma.less.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A `//` on a comma's line stays on that line (DIVERGENCES.md "line-comment-after-comma").
+@list: #aaaaaa, // Start with A
+  #bbbbbb, // then some B
+  #cccccc; // and round it out with C
+a {
+  transition: a 1s, // c
+    b 2s;
+  b: f(a, // c
+    b);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A `//` on a comma's line stays on that line (DIVERGENCES.md "line-comment-after-comma").
+@list:
+  #aaaaaa, // Start with A
+  #bbbbbb, // then some B
+  #cccccc; // and round it out with C
+a {
+  transition:
+    a 1s, // c
+    b 2s;
+  b: f(
+    a, // c
+    b
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A `//` on a comma's line stays on that line (DIVERGENCES.md "line-comment-after-comma").
+@list:
+  #aaaaaa, // Start with A
+  #bbbbbb, // then some B
+  #cccccc; // and round it out with C
+a {
+  transition:
+    a 1s, // c
+    b 2s;
+  b: f(
+    a, // c
+    b
+  );
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/include-leading-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/include-leading-comment.scss
@@ -1,5 +1,6 @@
 // A comment before an `@include` argument leads that argument (`/* c */ 1`),
-// never crossing it or its comma; `//` keeps its own line.
+// never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`).
 // Same rule as function arguments (`fn( // c`) and paren list elements.
 @include m( // c
   1);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/include-leading-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/include-leading-comment.scss.snap
@@ -3,7 +3,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
 // A comment before an `@include` argument leads that argument (`/* c */ 1`),
-// never crossing it or its comma; `//` keeps its own line.
+// never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`).
 // Same rule as function arguments (`fn( // c`) and paren list elements.
 @include m( // c
   1);
@@ -22,7 +23,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 { printWidth: 80 }
 ------------------
 // A comment before an `@include` argument leads that argument (`/* c */ 1`),
-// never crossing it or its comma; `//` keeps its own line.
+// never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`).
 // Same rule as function arguments (`fn( // c`) and paren list elements.
 @include m(
   // c
@@ -30,8 +32,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 );
 @include m(/* c */ 1);
 @include m(
-  1,
-  // c
+  1, // c
   2
 );
 @include m(1, /* c */ 2);
@@ -50,7 +51,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 { printWidth: 100 }
 -------------------
 // A comment before an `@include` argument leads that argument (`/* c */ 1`),
-// never crossing it or its comma; `//` keeps its own line.
+// never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`).
 // Same rule as function arguments (`fn( // c`) and paren list elements.
 @include m(
   // c
@@ -58,8 +60,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 );
 @include m(/* c */ 1);
 @include m(
-  1,
-  // c
+  1, // c
   2
 );
 @include m(1, /* c */ 2);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss
@@ -11,7 +11,7 @@
 		transparent 100%
 	);
 }
-// Same-line `//` and block-comment variants keep their layout too
+// A `//` on the comma's line stays there; the block-comment variant keeps its layout too
 .a {
 	background: linear-gradient(
 		90deg, // same-line comment

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss.snap
@@ -15,7 +15,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 		transparent 100%
 	);
 }
-// Same-line `//` and block-comment variants keep their layout too
+// A `//` on the comma's line stays there; the block-comment variant keeps its layout too
 .a {
 	background: linear-gradient(
 		90deg, // same-line comment
@@ -49,11 +49,10 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
     transparent 100%
   );
 }
-// Same-line `//` and block-comment variants keep their layout too
+// A `//` on the comma's line stays there; the block-comment variant keeps its layout too
 .a {
   background: linear-gradient(
-    90deg,
-    // same-line comment
+    90deg, // same-line comment
     #e46c2c 20%,
     transparent 100%
   );
@@ -82,11 +81,10 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
     transparent 100%
   );
 }
-// Same-line `//` and block-comment variants keep their layout too
+// A `//` on the comma's line stays there; the block-comment variant keeps its layout too
 .a {
   background: linear-gradient(
-    90deg,
-    // same-line comment
+    90deg, // same-line comment
     #e46c2c 20%,
     transparent 100%
   );

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/line-comment-after-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/line-comment-after-comma.scss
@@ -1,0 +1,51 @@
+// A `//` on a comma's line stays on that line (`a, // c`), the line-boundary invariant;
+// Prettier's CSS moves it below as the next element's leading comment
+// (DIVERGENCES.md "line-comment-after-comma"). Every comma site:
+$map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+$list: a, // c
+  b;
+$paren: (a, // c
+  b);
+$glued: (
+  a: 1, /* c */ // d
+  b: 2,
+);
+a {
+  transition: a 1s, // c
+    b 2s;
+  b: f(a, // c
+    b);
+  @include m($a, // c
+    $b);
+  // A `//` glued to a run inside a space list stays with the run; the run is not pushed down.
+  margin: 1px 2px // c
+    3px 4px;
+}
+@mixin m($a, // c
+  $b) {
+}
+@each $k in a, // c
+  b {
+}
+@each $k, // c
+  $v in $m {
+}
+@use "a" with (
+  $a: 1, // c
+  $b: 2
+);
+@forward "b" show a, // c
+  b;
+@import "c", // c
+  "d";
+@media a, // c
+  b {
+}
+@supports selector(a, /* b */ // c
+  d) {
+}
+@import url(e) screen, // c
+  print;

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/line-comment-after-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/line-comment-after-comma.scss.snap
@@ -1,0 +1,198 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A `//` on a comma's line stays on that line (`a, // c`), the line-boundary invariant;
+// Prettier's CSS moves it below as the next element's leading comment
+// (DIVERGENCES.md "line-comment-after-comma"). Every comma site:
+$map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+$list: a, // c
+  b;
+$paren: (a, // c
+  b);
+$glued: (
+  a: 1, /* c */ // d
+  b: 2,
+);
+a {
+  transition: a 1s, // c
+    b 2s;
+  b: f(a, // c
+    b);
+  @include m($a, // c
+    $b);
+  // A `//` glued to a run inside a space list stays with the run; the run is not pushed down.
+  margin: 1px 2px // c
+    3px 4px;
+}
+@mixin m($a, // c
+  $b) {
+}
+@each $k in a, // c
+  b {
+}
+@each $k, // c
+  $v in $m {
+}
+@use "a" with (
+  $a: 1, // c
+  $b: 2
+);
+@forward "b" show a, // c
+  b;
+@import "c", // c
+  "d";
+@media a, // c
+  b {
+}
+@supports selector(a, /* b */ // c
+  d) {
+}
+@import url(e) screen, // c
+  print;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A `//` on a comma's line stays on that line (`a, // c`), the line-boundary invariant;
+// Prettier's CSS moves it below as the next element's leading comment
+// (DIVERGENCES.md "line-comment-after-comma"). Every comma site:
+$map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+$list:
+  a, // c
+  b;
+$paren: (
+  a, // c
+  b
+);
+$glued: (
+  a: 1, /* c */ // d
+  b: 2,
+);
+a {
+  transition:
+    a 1s, // c
+    b 2s;
+  b: f(
+    a, // c
+    b
+  );
+  @include m(
+    $a, // c
+    $b
+  );
+  // A `//` glued to a run inside a space list stays with the run; the run is not pushed down.
+  margin: 1px 2px // c
+    3px 4px;
+}
+@mixin m(
+  $a, // c
+  $b
+) {
+}
+@each $k in a, // c
+  b
+{
+}
+@each $k, // c
+  $v in $m
+{
+}
+@use "a" with (
+  $a: 1, // c
+  $b: 2
+);
+@forward "b" show a, // c
+  b;
+@import "c", // c
+  "d";
+@media a, // c
+  b {
+}
+@supports selector(
+  a, /* b */ // c
+  d
+) {
+}
+@import url(e)
+  screen, // c
+  print;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A `//` on a comma's line stays on that line (`a, // c`), the line-boundary invariant;
+// Prettier's CSS moves it below as the next element's leading comment
+// (DIVERGENCES.md "line-comment-after-comma"). Every comma site:
+$map: (
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+);
+$list:
+  a, // c
+  b;
+$paren: (
+  a, // c
+  b
+);
+$glued: (
+  a: 1, /* c */ // d
+  b: 2,
+);
+a {
+  transition:
+    a 1s, // c
+    b 2s;
+  b: f(
+    a, // c
+    b
+  );
+  @include m(
+    $a, // c
+    $b
+  );
+  // A `//` glued to a run inside a space list stays with the run; the run is not pushed down.
+  margin: 1px 2px // c
+    3px 4px;
+}
+@mixin m(
+  $a, // c
+  $b
+) {
+}
+@each $k in a, // c
+  b
+{
+}
+@each $k, // c
+  $v in $m
+{
+}
+@use "a" with (
+  $a: 1, // c
+  $b: 2
+);
+@forward "b" show a, // c
+  b;
+@import "c", // c
+  "d";
+@media a, // c
+  b {
+}
+@supports selector(
+  a, /* b */ // c
+  d
+) {
+}
+@import url(e)
+  screen, // c
+  print;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss
@@ -1,5 +1,6 @@
 // A comment before a bare scalar element of a comma list leads that element
-// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// (`/* c */ 1,`), never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`, see `line-comment-after-comma.scss`).
 // Where the source put a block comment (same line, own line) makes no difference.
 // Multi-token elements (`1 2`) already did this through their comma group.
 $first: (k: (/* c */ 1, 2));

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/list-leading-comment.scss.snap
@@ -3,7 +3,8 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
 // A comment before a bare scalar element of a comma list leads that element
-// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// (`/* c */ 1,`), never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`, see `line-comment-after-comma.scss`).
 // Where the source put a block comment (same line, own line) makes no difference.
 // Multi-token elements (`1 2`) already did this through their comma group.
 $first: (k: (/* c */ 1, 2));
@@ -29,7 +30,8 @@ $bare: 1, /* c */ 2;
 { printWidth: 80 }
 ------------------
 // A comment before a bare scalar element of a comma list leads that element
-// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// (`/* c */ 1,`), never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`, see `line-comment-after-comma.scss`).
 // Where the source put a block comment (same line, own line) makes no difference.
 // Multi-token elements (`1 2`) already did this through their comma group.
 $first: (
@@ -53,8 +55,7 @@ $line: (
 );
 $after-comma: (
   k: (
-    1,
-    // c
+    1, // c
     2,
   ),
 );
@@ -79,8 +80,7 @@ $bare:
 }
 @each $k in a, /* c */ b {
 }
-@each $k in a,
-  // c
+@each $k in a, // c
   b
 {
 }
@@ -89,7 +89,8 @@ $bare:
 { printWidth: 100 }
 -------------------
 // A comment before a bare scalar element of a comma list leads that element
-// (`/* c */ 1,`), never crossing it or its comma; `//` keeps its own line.
+// (`/* c */ 1,`), never crossing it or its comma; an own-line `//` keeps its own line,
+// a `//` on the comma's line stays there (`1, // c`, see `line-comment-after-comma.scss`).
 // Where the source put a block comment (same line, own line) makes no difference.
 // Multi-token elements (`1 2`) already did this through their comma group.
 $first: (
@@ -113,8 +114,7 @@ $line: (
 );
 $after-comma: (
   k: (
-    1,
-    // c
+    1, // c
     2,
   ),
 );
@@ -139,8 +139,7 @@ $bare:
 }
 @each $k in a, /* c */ b {
 }
-@each $k in a,
-  // c
+@each $k in a, // c
   b
 {
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss
@@ -14,7 +14,7 @@
   /* Spacing */
   $spacer: variables.$spacer
 );
-// A trailing `//` after a comma moves to its own line before the next item.
+// A trailing `//` after a comma stays on the comma's line (`line-comment-after-comma.scss`).
 // KNOWN DIVERGENCE (DIVERGENCES.md "own-line-trailing-comment-keeps-line"): the own-line `// before close` keeps its
 // own line, consistent with the map printer; Prettier pulls it up to the last
 // item's line (`$e: 5 // before close`).

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/module-config-comments.scss.snap
@@ -18,7 +18,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
   /* Spacing */
   $spacer: variables.$spacer
 );
-// A trailing `//` after a comma moves to its own line before the next item.
+// A trailing `//` after a comma stays on the comma's line (`line-comment-after-comma.scss`).
 // KNOWN DIVERGENCE (DIVERGENCES.md "own-line-trailing-comment-keeps-line"): the own-line `// before close` keeps its
 // own line, consistent with the map printer; Prettier pulls it up to the last
 // item's line (`$e: 5 // before close`).
@@ -61,13 +61,12 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 
   /* Spacing */ $spacer: variables.$spacer
 );
-// A trailing `//` after a comma moves to its own line before the next item.
+// A trailing `//` after a comma stays on the comma's line (`line-comment-after-comma.scss`).
 // KNOWN DIVERGENCE (DIVERGENCES.md "own-line-trailing-comment-keeps-line"): the own-line `// before close` keeps its
 // own line, consistent with the map printer; Prettier pulls it up to the last
 // item's line (`$e: 5 // before close`).
 @use "a" with (
-  $a: 1,
-  // trailing
+  $a: 1, // trailing
   $b: 2,
 
   $c: 3,
@@ -104,13 +103,12 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 
   /* Spacing */ $spacer: variables.$spacer
 );
-// A trailing `//` after a comma moves to its own line before the next item.
+// A trailing `//` after a comma stays on the comma's line (`line-comment-after-comma.scss`).
 // KNOWN DIVERGENCE (DIVERGENCES.md "own-line-trailing-comment-keeps-line"): the own-line `// before close` keeps its
 // own line, consistent with the map printer; Prettier pulls it up to the last
 // item's line (`$e: 5 // before close`).
 @use "a" with (
-  $a: 1,
-  // trailing
+  $a: 1, // trailing
   $b: 2,
 
   $c: 3,

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-less.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-less.snap
@@ -2,12 +2,13 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-less compatibility: 40/40 (100.00%), 7 files skipped
+less compatibility: 39/40 (97.50%), 7 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| less/comments/value-lists.less | 💥 | 76.92% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
@@ -2,13 +2,16 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-scss compatibility: 78/90 (86.67%), 6 files skipped
+scss compatibility: 74/90 (82.22%), 6 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| scss/comments/4594.scss | 💥 | 83.78% |
 | scss/comments/4878.scss | 💥 | 89.39% |
+| scss/comments/lists.scss | 💥 | 76.92% |
+| scss/comments/maps.scss | 💥 | 66.67% |
 | scss/comments/variable-declaration.scss | 💥 | 81.25% |
 | scss/function/arbitrary-arguments-comment.scss | 💥💥 | 72.73% |
 | scss/map/15193.scss | 💥✨ | 42.86% |
@@ -16,7 +19,8 @@ scss compatibility: 78/90 (86.67%), 6 files skipped
 | scss/map/function-argument/functional-argument.scss | 💥 | 96.00% |
 | scss/parens/2.scss | 💥 | 75.00% |
 | scss/parens/issue-16594.scss | 💥 | 71.43% |
-| scss/trailing-comma/comments.scss | 💥💥 | 95.00% |
+| scss/trailing-comma/comments.scss | 💥💥 | 87.18% |
+| scss/trailing-comma/issue-6920.scss | 💥💥 | 66.67% |
 | scss/trailing-comma/list.scss | 💥💥 | 95.56% |
 | scss/trailing-comma/variable.scss | 💥💥 | 50.00% |
 | scss/variables/apply-rule.scss | 💥 | 87.88% |


### PR DESCRIPTION
e.g.

```scss
$my-map: (
  "foo": 1, // Comment
  "bar": 2, // Comment
);
```

should not be formatted:

```scss
$my-map: (
  "foo": 1,
  // Comment
  "bar": 2, // Comment
);
```