### PR TITLE
test(formatter_tests): assert fingerprint survives formatting

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -10,8 +10,15 @@ use options::apply_js_options;
 
 struct JsHarness;
 
+/// What formatting must leave unchanged, see `FixtureFormatter::Fingerprint`.
+#[derive(Debug, PartialEq)]
+struct Fingerprint {
+    comments: usize,
+}
+
 impl FixtureFormatter for JsHarness {
     type Options = JsFormatOptions;
+    type Fingerprint = Fingerprint;
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = JsFormatOptions::default();
@@ -27,6 +34,23 @@ impl FixtureFormatter for JsHarness {
             .print()
             .unwrap()
             .into_code()
+    }
+
+    fn fingerprint(source: &str, path: &Path, options: &Self::Options) -> Fingerprint {
+        let source_type = SourceType::from_path(path).unwrap();
+        let allocator = Allocator::default();
+        let ret = oxc_formatter::parse_for_format(&allocator, source, source_type);
+        // The `jsdoc` option owns JSDoc blocks: it rewrites them and drops empty ones,
+        // so only the other comments are under the lossless contract there.
+        let jsdoc_rewritten = options.jsdoc.is_some();
+        Fingerprint {
+            comments: ret
+                .program
+                .comments
+                .iter()
+                .filter(|c| !(jsdoc_rewritten && c.is_jsdoc()))
+                .count(),
+        }
     }
 }
 

--- a/crates/oxc_formatter_core/FORMATTER_POLICY.md
+++ b/crates/oxc_formatter_core/FORMATTER_POLICY.md
@@ -145,6 +145,7 @@ node apps/oxfmt/node_modules/prettier/bin/prettier.cjs --parser <parser> --print
 NOTE: Prettier's default `printWidth` is `80`, but Oxfmt is `100`.
 
 Fixture tests and Prettier conformance re-format every output and record idempotency violations in their snapshots/reports.
+Fixture tests also assert the lossless contract through `FixtureFormatter::fingerprint` (`oxc_formatter_tests`): a loss fails the test instead of being pinned.
 
 ### Fixture tests
 

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -13,6 +13,7 @@ Prettier compatible CSS/SCSS/Less formatter (`oxfmt`'s Tier 1 backend), using th
   - `format()`: standalone files, on a service-less session
   - `format_with_session()`: standalone, on the caller's `FormatSession`
   - `format_to_ir()`: embedded use via the dispatcher (`template_placeholders` = the css-in-js parse mode)
+  - `parse_for_format()`: the parse `format()` runs, exposed for callers that inspect the AST (e.g. the fixture harness's fingerprint)
 
 ### Forked parser
 

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -6,7 +6,7 @@ use oxc_formatter_core::{
     Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, InputKind,
     VecBuffer,
     builders::{empty_line, hard_line_break, text},
-    spec::{FrontMatter, blank_front_matter, parse_front_matter},
+    spec::{FrontMatter, blank_front_matter, parse_front_matter, split_bom},
     write,
 };
 use oxc_span::Span;
@@ -62,15 +62,12 @@ pub fn format_with_session<'a>(
         session.input_kind() == InputKind::PhysicalFile,
         "format_with_session is the physical-root entry; embedded inputs go through format_to_ir"
     );
-    let allocator = session.allocator();
-    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
-
-    // A document root owns front matter;
-    // the session's dispatcher decides whether its body actually formats (`write_front_matter`).
-    let PreparedSource { source, parse_source, front_matter } =
-        prepare_source(allocator, source_text);
-    let (stylesheet, comments) =
-        parse_stylesheet(allocator, parse_source, options, /* tolerate_placeholders */ false)?;
+    let ParsedCss { stylesheet, comments, source, has_bom, front_matter } = parse_for_format(
+        session.allocator(),
+        source_text,
+        options,
+        /* template_placeholders */ false,
+    )?;
 
     let context =
         CssFormatContext::new(options, source, comments, /* template_placeholders */ false);
@@ -91,6 +88,44 @@ pub fn format_with_session<'a>(
     let ir = Document::new(elements, sorted_tailwind_classes);
 
     Ok(Formatted::new(ir, context))
+}
+
+/// [`parse_for_format`] output: the AST, plus the envelope [`format()`] prints around it.
+pub struct ParsedCss<'a> {
+    pub stylesheet: Stylesheet<'a>,
+    /// Sorted comments; oxc-css-parser keeps them out of the AST.
+    pub comments: &'a [CssComment],
+    /// Normalized arena source every span indexes into.
+    source: &'a str,
+    has_bom: bool,
+    front_matter: Option<FrontMatter<'a>>,
+}
+
+/// Parse `source_text` the way the formatter does, for callers that inspect the AST
+/// (e.g. a harness comparing what the source held against the formatted output).
+///
+/// [`format()`] goes through this too, so what a caller sees is exactly what gets formatted.
+/// Owns the envelope (BOM split, `\r` normalization, front matter blanking).
+/// `template_placeholders` is [`format_to_ir`]'s css-in-js parse mode.
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn parse_for_format<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+    options: CssFormatOptions,
+    template_placeholders: bool,
+) -> Result<ParsedCss<'a>, OxcDiagnostic> {
+    let (has_bom, source_text) = split_bom(source_text);
+
+    // A document root owns front matter;
+    // the session's dispatcher decides whether its body actually formats (`write_front_matter`).
+    let PreparedSource { source, parse_source, front_matter } =
+        prepare_source(allocator, source_text);
+    let (stylesheet, comments) =
+        parse_stylesheet(allocator, parse_source, options, template_placeholders)?;
+
+    Ok(ParsedCss { stylesheet, comments, source, has_bom, front_matter })
 }
 
 /// Parse `source_text` and build the formatter IR for embedding into another
@@ -118,32 +153,23 @@ pub fn format_to_ir<'a>(
     options: CssFormatOptions,
     template_placeholders: bool,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
-    let allocator = session.allocator();
-    let input_kind = session.input_kind();
-
-    let prepared = prepare_source(allocator, source_text);
-    if prepared.front_matter.is_some() && !input_kind.owns_front_matter() {
+    // `FormatSession::dispatch` never hands a BOM-headed input to an embedded part,
+    // so the BOM split inside `parse_for_format` is a no-op here.
+    let ParsedCss { stylesheet, comments, source, front_matter, .. } =
+        parse_for_format(session.allocator(), source_text, options, template_placeholders)?;
+    if front_matter.is_some() && !session.input_kind().owns_front_matter() {
         // A fragment (css-in-js, JSDoc fence) never acquires file envelope semantics:
         // refuse the whole child instead of partially treating its head as front matter.
         return Err(OxcDiagnostic::error(
             "Front matter in a CSS fragment; the part is preserved as-is",
         ));
     }
-    let (stylesheet, comments) = parse_stylesheet(
-        allocator,
-        prepared.parse_source,
-        options,
-        /* tolerate_placeholders */ template_placeholders,
-    )?;
 
-    let context = CssFormatContext::new(options, prepared.source, comments, template_placeholders);
+    let context = CssFormatContext::new(options, source, comments, template_placeholders);
     let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::new(&mut state);
 
-    write!(
-        &mut buffer,
-        FormatCssEmbedded { stylesheet: &stylesheet, front_matter: prepared.front_matter }
-    );
+    write!(&mut buffer, FormatCssEmbedded { stylesheet: &stylesheet, front_matter });
 
     let elements = buffer.into_vec();
     let tailwind_classes = state.context_mut().take_tailwind_classes();

--- a/crates/oxc_formatter_css/src/lib.rs
+++ b/crates/oxc_formatter_css/src/lib.rs
@@ -36,7 +36,8 @@ pub const TEMPLATE_PLACEHOLDER_PREFIX: &str = "`PLACEHOLDER-";
 pub const TEMPLATE_PLACEHOLDER_SUFFIX: &str = "`";
 
 pub use crate::{
+    comments::CssComment,
     context::CssFormatContext,
-    format::{format, format_to_ir, format_with_session},
+    format::{ParsedCss, format, format_to_ir, format_with_session, parse_for_format},
     options::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas},
 };

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 
 use oxc_allocator::{Allocator, ArenaVec};
-use oxc_formatter_css::{CssFormatOptions, CssVariant, format};
+use oxc_formatter_css::{CssFormatOptions, CssVariant, format, parse_for_format};
 use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
 
 mod options;
@@ -16,8 +16,15 @@ use options::apply_css_options;
 
 struct CssHarness;
 
+/// What formatting must leave unchanged, see `FixtureFormatter::Fingerprint`.
+#[derive(Debug, PartialEq)]
+struct Fingerprint {
+    comments: usize,
+}
+
 impl FixtureFormatter for CssHarness {
     type Options = CssFormatOptions;
+    type Fingerprint = Fingerprint;
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = CssFormatOptions::default();
@@ -26,18 +33,9 @@ impl FixtureFormatter for CssHarness {
     }
 
     fn format(source: &str, path: &Path, options: &Self::Options) -> String {
-        // The dialect comes from the fixture extension, like oxfmt's classifier.
-        let variant = match path.extension().and_then(|e| e.to_str()) {
-            Some("scss") => CssVariant::Scss,
-            Some("less") => CssVariant::Less,
-            _ => CssVariant::Css,
-        };
-        let options = CssFormatOptions { variant, ..*options };
+        let options = CssFormatOptions { variant: variant_of(path), ..*options };
 
-        // Fixtures under `embedded/` exercise the dispatcher entry point
-        // (`format_to_ir`, css-in-js), which tolerates
-        // `` `PLACEHOLDER-N` `` markers in value/selector position.
-        if path.components().any(|c| c.as_os_str() == "embedded") {
+        if is_embedded(path) {
             return format_embedded(source, options);
         }
 
@@ -48,6 +46,35 @@ impl FixtureFormatter for CssHarness {
             .expect("print should succeed")
             .into_code()
     }
+
+    fn fingerprint(source: &str, path: &Path, options: &Self::Options) -> Fingerprint {
+        let options = CssFormatOptions { variant: variant_of(path), ..*options };
+        let allocator = Allocator::default();
+        let parsed = parse_for_format(
+            &allocator,
+            source,
+            options,
+            /* template_placeholders */ is_embedded(path),
+        )
+        .expect("source should parse");
+        Fingerprint { comments: parsed.comments.len() }
+    }
+}
+
+/// The dialect comes from the fixture extension, like oxfmt's classifier.
+fn variant_of(path: &Path) -> CssVariant {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("scss") => CssVariant::Scss,
+        Some("less") => CssVariant::Less,
+        _ => CssVariant::Css,
+    }
+}
+
+/// Fixtures under `embedded/` exercise the dispatcher entry point
+/// (`format_to_ir`, css-in-js), which tolerates
+/// `` `PLACEHOLDER-N` `` markers in value/selector position.
+fn is_embedded(path: &Path) -> bool {
+    path.components().any(|c| c.as_os_str() == "embedded")
 }
 
 /// Format through `format_to_ir` and print the raw IR, mirroring what the

--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -9,9 +9,10 @@ Prettier compatible GraphQL formatter (`oxfmt`'s Tier 1 backend), using the `oxc
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
-- Two entry points:
+- Entry points:
   - `format()`: standalone files (returns a printable `Formatted`)
   - `format_to_ir()`: embedded use via the dispatcher (e.g. graphql-in-js)
+  - `parse_for_format()`: the parse `format()` runs, exposed for callers that inspect the AST (e.g. the fixture harness's fingerprint)
 
 ### Forked parser
 

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -25,17 +25,16 @@ pub fn format<'a>(
     source_text: &str,
     options: GraphqlFormatOptions,
 ) -> Result<Formatted<'a, GraphqlFormatContext<'a>>, OxcDiagnostic> {
-    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
-    let (document, source, comments) = parse_document(allocator, source_text)?;
+    let parsed = parse_for_format(allocator, source_text)?;
 
-    let context = GraphqlFormatContext::new(options, source, comments);
+    let context = GraphqlFormatContext::new(options, parsed.source, parsed.comments);
     let mut state = FormatState::new(context, allocator);
     // Pre-allocate: measured on 1,241 real-world files (gitlab operations, github/saleor schemas),
     // 0.4x source bytes plus a 1024-element floor for small operation documents avoided reallocation for the entire corpus.
-    let capacity = (source.len() * 2 / 5).max(1024);
+    let capacity = (parsed.source.len() * 2 / 5).max(1024);
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
-    write!(&mut buffer, FormatGraphqlRoot { document, has_bom });
+    write!(&mut buffer, FormatGraphqlRoot { document: parsed.document, has_bom: parsed.has_bom });
 
     let elements = buffer.into_vec();
     let context = state.into_context();
@@ -43,6 +42,33 @@ pub fn format<'a>(
     let ir = Document::new(elements, Vec::new());
 
     Ok(Formatted::new(ir, context))
+}
+
+/// [`parse_for_format`] output: the AST, plus the envelope [`format()`] prints around it.
+pub struct ParsedGraphql<'a> {
+    pub document: &'a GraphQLDocument<'a>,
+    /// Sorted comment spans; oxc-graphql-parser keeps them out of the AST.
+    pub comments: &'a [Span],
+    /// Arena source every span indexes into.
+    source: &'a str,
+    has_bom: bool,
+}
+
+/// Parse `source_text` the way the formatter does, for callers that inspect the AST
+/// (e.g. a harness comparing what the source held against the formatted output).
+///
+/// [`format()`] goes through this too, so what a caller sees is exactly what gets formatted.
+/// Owns the BOM split.
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn parse_for_format<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+) -> Result<ParsedGraphql<'a>, OxcDiagnostic> {
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
+    let (document, source, comments) = parse_document(allocator, source_text)?;
+    Ok(ParsedGraphql { document, comments, source, has_bom })
 }
 
 /// Parse `source_text` and build the formatter IR for embedding into another

--- a/crates/oxc_formatter_graphql/src/lib.rs
+++ b/crates/oxc_formatter_graphql/src/lib.rs
@@ -20,6 +20,6 @@ mod print;
 
 pub use crate::{
     context::GraphqlFormatContext,
-    format::{format, format_to_ir},
+    format::{ParsedGraphql, format, format_to_ir, parse_for_format},
     options::{BracketSpacing, GraphqlFormatOptions},
 };

--- a/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_graphql::{GraphqlFormatOptions, format};
+use oxc_formatter_graphql::{GraphqlFormatOptions, format, parse_for_format};
 use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
 
 mod options;
@@ -9,8 +9,15 @@ use options::apply_graphql_options;
 
 struct GraphqlHarness;
 
+/// What formatting must leave unchanged, see `FixtureFormatter::Fingerprint`.
+#[derive(Debug, PartialEq)]
+struct Fingerprint {
+    comments: usize,
+}
+
 impl FixtureFormatter for GraphqlHarness {
     type Options = GraphqlFormatOptions;
+    type Fingerprint = Fingerprint;
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = GraphqlFormatOptions::default();
@@ -25,6 +32,12 @@ impl FixtureFormatter for GraphqlHarness {
             .print()
             .expect("print should succeed")
             .into_code()
+    }
+
+    fn fingerprint(source: &str, _path: &Path, _options: &Self::Options) -> Fingerprint {
+        let allocator = Allocator::default();
+        let parsed = parse_for_format(&allocator, source).expect("source should parse");
+        Fingerprint { comments: parsed.comments.len() }
     }
 }
 

--- a/crates/oxc_formatter_json/AGENTS.md
+++ b/crates/oxc_formatter_json/AGENTS.md
@@ -8,9 +8,10 @@ Prettier compatible JSON/JSONC/JSON5/JSON.stringify formatter (`oxfmt`'s Tier 1 
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
-- Two entry points:
+- Entry points:
   - `format()`: standalone files (returns a printable `Formatted`)
   - `format_to_ir()`: embedded use via the dispatcher (e.g. a fenced block in JSDoc)
+  - `parse_for_format()`: the parse `format()` runs, exposed for callers that inspect the AST (e.g. the fixture harness's fingerprint)
 - This crate holds only the JSON-specific layer
 - Parses with `oxc_parser`, not `serde_json`
   - For Prettier, JSON is not spec compliant JSON

--- a/crates/oxc_formatter_json/src/format.rs
+++ b/crates/oxc_formatter_json/src/format.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Allocator;
-use oxc_ast::ast::Expression;
+use oxc_ast::{Comment, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
     Buffer, Document, EmbeddedIr, Format, FormatContext, FormatSession, FormatState, Formatted,
@@ -26,8 +26,7 @@ pub fn format<'a>(
     source_text: &str,
     options: JsonFormatOptions,
 ) -> Result<Formatted<'a, JsonFormatContext<'a>>, OxcDiagnostic> {
-    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
-    let parsed = parse_json(allocator, source_text, options.variant)?;
+    let parsed = parse_for_format(allocator, source_text, options)?;
 
     let context = JsonFormatContext::new(
         options,
@@ -39,10 +38,10 @@ pub fn format<'a>(
     // Pre-allocate: measured on 1,447 real-world files (vscode, saleor, bootstrap),
     // 0.3x source bytes plus a 1024-element floor for tiny-file spikes (`{}` is 3 elements)
     // avoids reallocation for 99.5% of the corpus.
-    let capacity = (source_text.len() * 3 / 10).max(1024);
+    let capacity = (parsed.wrapped_source.len() * 3 / 10).max(1024);
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
-    write!(&mut buffer, FormatJsonRoot { expression: parsed.expression, has_bom });
+    write!(&mut buffer, FormatJsonRoot { expression: parsed.expression, has_bom: parsed.has_bom });
 
     let elements = buffer.into_vec();
     let context = state.into_context();
@@ -54,6 +53,41 @@ pub fn format<'a>(
     let document = Document::new(elements, Vec::new());
 
     Ok(Formatted::new(document, context))
+}
+
+/// [`parse_for_format`] output: the AST, plus the envelope [`format()`] prints around it.
+pub struct ParsedJson<'a> {
+    /// `None` when the source contains only comments and whitespace.
+    pub expression: Option<&'a Expression<'a>>,
+    /// Sorted comments. Spans are in the wrapped-source coordinates the printer uses.
+    pub comments: &'a [Comment],
+    wrapped_source: &'a str,
+    source_offset: u32,
+    has_bom: bool,
+}
+
+/// Parse `source_text` the way the formatter does, for callers that inspect the AST
+/// (e.g. a harness comparing what the source held against the formatted output).
+///
+/// [`format()`] goes through this too, so what a caller sees is exactly what gets formatted.
+/// Owns the BOM split and the variant's comment rules.
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn parse_for_format<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+    options: JsonFormatOptions,
+) -> Result<ParsedJson<'a>, OxcDiagnostic> {
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
+    let parsed = parse_json(allocator, source_text, options.variant)?;
+    Ok(ParsedJson {
+        expression: parsed.expression,
+        comments: parsed.comments,
+        wrapped_source: parsed.wrapped_source,
+        source_offset: parsed.source_offset,
+        has_bom,
+    })
 }
 
 /// Parse `source_text` and build the formatter IR for embedding into another

--- a/crates/oxc_formatter_json/src/lib.rs
+++ b/crates/oxc_formatter_json/src/lib.rs
@@ -20,7 +20,7 @@ mod separated;
 
 pub use crate::{
     context::JsonFormatContext,
-    format::{format, format_to_ir},
+    format::{ParsedJson, format, format_to_ir, parse_for_format},
     options::{
         BracketSpacing, Expand, JsonFormatOptions, JsonVariant, QuoteProps, SingleQuote,
         TrailingCommas,

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -9,10 +9,11 @@ use oxc_span::SourceType;
 
 use crate::options::JsonVariant;
 
-/// Result of [`parse_json`].
+/// Result of [`parse_json`]: the root expression and comments in wrapped-source coordinates.
+/// `crate::ParsedJson` adds the file envelope on top.
 /// All borrows are arena-lifetime,
 /// so the parser's `Program` does not need to be kept alive by the caller.
-pub struct ParsedJson<'a> {
+pub struct ParsedExpression<'a> {
     /// `None` when `source` contains only comments and whitespace.
     pub expression: Option<&'a Expression<'a>>,
     /// Sorted comments. Spans are in [`Self::wrapped_source`] coordinates.
@@ -40,7 +41,7 @@ pub fn parse_json<'a>(
     allocator: &'a Allocator,
     source: &str,
     variant: JsonVariant,
-) -> Result<ParsedJson<'a>, OxcDiagnostic> {
+) -> Result<ParsedExpression<'a>, OxcDiagnostic> {
     // JSON object literals like `{"a":1}` are syntax errors when parsed as a JS program
     // (the leading `{` starts a `BlockStatement`),
     // so we wrap the source in `(...)` to force expression context.
@@ -102,7 +103,7 @@ pub fn parse_json<'a>(
         return Err(OxcDiagnostic::error("Expected a single expression at the top level"));
     };
 
-    Ok(ParsedJson {
+    Ok(ParsedExpression {
         expression: Some(&expr_stmt.expression),
         comments,
         wrapped_source,
@@ -139,7 +140,7 @@ fn try_parse_comments_only<'a>(
     allocator: &'a Allocator,
     source: &str,
     options: ParseOptions,
-) -> Option<ParsedJson<'a>> {
+) -> Option<ParsedExpression<'a>> {
     // `Parser::new` ties `source_text` to the arena lifetime;
     // Copy `source` into the arena so the resulting comment spans index into a string that outlives `ret`.
     let bare_source: &'a str = allocator.alloc_str(source);
@@ -154,7 +155,12 @@ fn try_parse_comments_only<'a>(
     let comments =
         std::mem::replace(&mut program.comments, ArenaVec::new_in(&allocator)).into_arena_slice();
 
-    Some(ParsedJson { expression: None, comments, wrapped_source: bare_source, source_offset: 0 })
+    Some(ParsedExpression {
+        expression: None,
+        comments,
+        wrapped_source: bare_source,
+        source_offset: 0,
+    })
 }
 
 /// Reject comments according to Prettier's per-variant rules.

--- a/crates/oxc_formatter_json/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_json/tests/fixtures/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_json::{JsonFormatOptions, format};
+use oxc_formatter_json::{JsonFormatOptions, format, parse_for_format};
 use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
 
 mod options;
@@ -9,8 +9,15 @@ use options::apply_json_options;
 
 struct JsonHarness;
 
+/// What formatting must leave unchanged, see `FixtureFormatter::Fingerprint`.
+#[derive(Debug, PartialEq)]
+struct Fingerprint {
+    comments: usize,
+}
+
 impl FixtureFormatter for JsonHarness {
     type Options = JsonFormatOptions;
+    type Fingerprint = Fingerprint;
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = JsonFormatOptions::default();
@@ -25,6 +32,12 @@ impl FixtureFormatter for JsonHarness {
             .print()
             .expect("print should succeed")
             .into_code()
+    }
+
+    fn fingerprint(source: &str, _path: &Path, options: &Self::Options) -> Fingerprint {
+        let allocator = Allocator::default();
+        let parsed = parse_for_format(&allocator, source, *options).expect("source should parse");
+        Fingerprint { comments: parsed.comments.len() }
     }
 }
 

--- a/crates/oxc_formatter_tests/AGENTS.md
+++ b/crates/oxc_formatter_tests/AGENTS.md
@@ -6,6 +6,7 @@ Test infrastructure shared by the formatter crates (e.g. `oxc_formatter`, `oxc_f
   - Consumers call `generate_tests` from `build.rs` via `[build-dependencies]` to emit one `#[test]` per fixture file
 - `harness`: fixture runtime
   - Consumers implement `FixtureFormatter` in `tests/fixtures/mod.rs` via `[dev-dependencies]`
+  - Asserts `FixtureFormatter::fingerprint` is the same for input and output; consumers take it from the crate's own parse (`parse_for_format`), what it captures is consumer-owned
 - `suite`: Prettier test-suite provisioning
   - `ensure_prettier_suite()` maintains the pinned suite at `prettier/` (gitignored), no separate clone step anywhere
 - `conformance` (feature `conformance`): Prettier-conformance machinery

--- a/crates/oxc_formatter_tests/src/harness.rs
+++ b/crates/oxc_formatter_tests/src/harness.rs
@@ -7,6 +7,7 @@
 //! - drives one format pass per option-set × per printWidth (80 + 100)
 //! - re-formats each output and pins any mismatch as a `Not idempotent` section
 //!   (idempotency violations are tracked in the snapshot, not asserted)
+//! - asserts the consumer's fingerprint of the input equals that of the output (lossless contract)
 //! - assembles the canonical `==== Input ==== ... ==== Output ==== ...` snapshot
 //! - returns the body for the consumer's `insta::assert_snapshot!`
 //!
@@ -88,12 +89,22 @@ pub trait FixtureFormatter {
     /// The typed format-option struct for this language.
     type Options: Clone;
 
+    /// Source-derived value that formatting must leave unchanged;
+    /// the harness compares the input's against the output's.
+    /// The harness knows nothing about what it captures, the consumer does
+    /// (comment counts, an AST fingerprint, ...).
+    type Fingerprint: PartialEq + std::fmt::Debug;
+
     /// Build typed options from a parsed `options.json` fragment.
     fn parse_options(json: &OptionSet) -> Self::Options;
 
     /// Format `source` (the contents of the fixture file at `path`) using `options`.
     /// `path` is passed for variant detection (e.g. `.json` vs `.jsonc`).
     fn format(source: &str, path: &Path, options: &Self::Options) -> String;
+
+    /// [`Self::Fingerprint`] of `source`.
+    /// Take it from the formatter's own parse (`parse_for_format`), so no test re-implements the parser setup.
+    fn fingerprint(source: &str, path: &Path, options: &Self::Options) -> Self::Fingerprint;
 }
 
 /// Resolves format options for `test_file` by walking up the directory tree
@@ -226,6 +237,15 @@ fn generate_snapshot<F: FixtureFormatter>(path: &Path, source_text: &str) -> Str
         let options = F::parse_options(&option_json);
         let formatted = F::format(source_text, path, &options);
         assert_line_ending_applied(&option_json, &formatted, path);
+        // Lossless contract (`FORMATTER_POLICY.md`, reason (2)): formatting drops nothing the user wrote.
+        // What is measured is the consumer's `Fingerprint`.
+        // Unlike idempotency this is asserted, not pinned: a loss is inadmissible whatever the snapshot says.
+        assert_eq!(
+            F::fingerprint(source_text, path, &options),
+            F::fingerprint(&formatted, path, &options),
+            "fingerprint changed by formatting {} with {options_line}\n  output:\n{formatted}",
+            path.display(),
+        );
 
         snapshot.push_str(&formatted);
         snapshot.push('\n');

--- a/crates/oxc_formatter_yaml/AGENTS.md
+++ b/crates/oxc_formatter_yaml/AGENTS.md
@@ -9,8 +9,9 @@ Prettier compatible YAML formatter (`oxfmt`'s Tier 1 backend), using the `oxc_fo
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
-- Two entry points (see their docs in `src/format.rs`):
+- Entry points (see their docs in `src/format.rs`):
   - `format()` for standalone files, `format_to_ir()` for embedded use via the dispatcher (e.g. CSS front matter, JSDoc fenced blocks)
+  - `parse_for_format()`: the parse `format()` runs, exposed for callers that inspect the AST (e.g. the fixture harness's fingerprint)
 
 ### Parser
 

--- a/crates/oxc_formatter_yaml/src/format.rs
+++ b/crates/oxc_formatter_yaml/src/format.rs
@@ -24,18 +24,21 @@ pub fn format<'a>(
     source_text: &str,
     options: YamlFormatOptions,
 ) -> Result<Formatted<'a, YamlFormatContext<'a>>, OxcDiagnostic> {
-    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
-    let (root, source, comments) = parse_root(allocator, source_text)?;
+    let parsed = parse_for_format(allocator, source_text)?;
 
-    let context =
-        YamlFormatContext::new(options, source, comments, print::last_descendant_end(root));
+    let context = YamlFormatContext::new(
+        options,
+        parsed.source,
+        parsed.comments,
+        print::last_descendant_end(parsed.root),
+    );
     let mut state = FormatState::new(context, allocator);
     // Pre-allocate: measured on 6,925 real-world files (kubernetes, vscode, saleor, bootstrap),
     // 0.3x source bytes plus a 1024-element floor for tiny-file spikes avoids reallocation for 99.9% of the corpus.
-    let capacity = (source.len() * 3 / 10).max(1024);
+    let capacity = (parsed.source.len() * 3 / 10).max(1024);
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
-    write!(&mut buffer, FormatYamlRoot { root, has_bom });
+    write!(&mut buffer, FormatYamlRoot { root: parsed.root, has_bom: parsed.has_bom });
 
     let elements = buffer.into_vec();
     let context = state.into_context();
@@ -43,6 +46,33 @@ pub fn format<'a>(
     let ir = Document::new(elements, Vec::new());
 
     Ok(Formatted::new(ir, context))
+}
+
+/// [`parse_for_format`] output: the AST, plus the envelope [`format()`] prints around it.
+pub struct ParsedYaml<'a> {
+    pub root: &'a Root<'a>,
+    /// Sorted comments bridged from the parser's trivia.
+    pub comments: &'a [SourceComment],
+    /// Normalized arena source every span indexes into.
+    source: &'a str,
+    has_bom: bool,
+}
+
+/// Parse `source_text` the way the formatter does, for callers that inspect the AST
+/// (e.g. a harness comparing what the source held against the formatted output).
+///
+/// [`format()`] goes through this too, so what a caller sees is exactly what gets formatted.
+/// Owns the BOM split and `\r` normalization.
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn parse_for_format<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+) -> Result<ParsedYaml<'a>, OxcDiagnostic> {
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
+    let (root, source, comments) = parse_root(allocator, source_text)?;
+    Ok(ParsedYaml { root, comments, source, has_bom })
 }
 
 /// Parse `source_text` and build the formatter IR for embedding into another

--- a/crates/oxc_formatter_yaml/src/lib.rs
+++ b/crates/oxc_formatter_yaml/src/lib.rs
@@ -21,7 +21,8 @@ mod options;
 mod print;
 
 pub use crate::{
+    comments::SourceComment,
     context::YamlFormatContext,
-    format::{format, format_to_ir},
+    format::{ParsedYaml, format, format_to_ir, parse_for_format},
     options::{BracketSpacing, ProseWrap, SingleQuote, TrailingCommas, YamlFormatOptions},
 };

--- a/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
@@ -2,15 +2,22 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
-use oxc_formatter_yaml::{YamlFormatOptions, format};
+use oxc_formatter_yaml::{YamlFormatOptions, format, parse_for_format};
 
 mod options;
 use options::apply_yaml_options;
 
 struct YamlHarness;
 
+/// What formatting must leave unchanged, see `FixtureFormatter::Fingerprint`.
+#[derive(Debug, PartialEq)]
+struct Fingerprint {
+    comments: usize,
+}
+
 impl FixtureFormatter for YamlHarness {
     type Options = YamlFormatOptions;
+    type Fingerprint = Fingerprint;
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = YamlFormatOptions::default();
@@ -25,6 +32,12 @@ impl FixtureFormatter for YamlHarness {
             .print()
             .expect("print should succeed")
             .into_code()
+    }
+
+    fn fingerprint(source: &str, _path: &Path, _options: &Self::Options) -> Fingerprint {
+        let allocator = Allocator::default();
+        let parsed = parse_for_format(&allocator, source).expect("source should parse");
+        Fingerprint { comments: parsed.comments.len() }
     }
 }
 


### PR DESCRIPTION
Historically, only JS formatter has had the `detect_code_removal` feature, which uses CI to check for missing nodes or comments.

While this would be useful in other languages (especially CSS), but setting up the mechanism is difficult. For now, just start with something simple that just guarantees the number of comments.

That said, even with a mechanism in place, it can't detect anything unless the cases are fully covered by fixtures, so this only tells us that the current state is problem-free.