### PR TITLE
chore(codeowners): add @overlookmotel as codeowner of `oxc_lexer`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@ pnpm-lock.yaml
 /crates/oxc_ast @overlookmotel
 /crates/oxc_ast_macros @overlookmotel
 /crates/oxc_ast_visit @overlookmotel
+/crates/oxc_lexer @overlookmotel
 /crates/oxc_macros @overlookmotel
 /crates/oxc_span @overlookmotel
 /crates/oxc_str @overlookmotel


### PR DESCRIPTION
I'm not actually the primary owner of this code - @ShanonJackson is. But add me to codeowners file, so I get added as a reviewer on any PRs touching the crate, so I don't miss them.