### PR TITLE
chore(codeowners): attribute ownership of allocation tracking snapshots to the relevant crate owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,7 +100,16 @@ pnpm-lock.yaml
 /crates/oxc_estree_tokens @overlookmotel
 /npm/oxc-types @overlookmotel
 /tasks/ast_tools @overlookmotel
+
+# Memory allocation tracking (@overlookmotel)
+
 /tasks/track_memory_allocations @overlookmotel
+# The generated allocation snapshots belong to the crate whose code change regenerated them
+/tasks/track_memory_allocations/allocs_parser.yaml @Boshen
+/tasks/track_memory_allocations/allocs_formatter.yaml @leaysgur
+/tasks/track_memory_allocations/allocs_minifier.yaml @dunqing
+/tasks/track_memory_allocations/allocs_semantic.yaml @dunqing
+/tasks/track_memory_allocations/allocs_transformer.yaml @dunqing
 
 # Everything else falls through to the default owner @Boshen, including:
 #   parser (crates/oxc_parser, napi/parser), umbrella crates (crates/oxc,


### PR DESCRIPTION
I am the codeowner of memory allocation tracking infra. However, this has meant that I get added as a reviewer on every PR which alters the snapshot files (notably a torrent of PRs on minifier, which I know nothing about). This makes it harder to track what PRs I _should_ actually be looking at.

Attribute ownership of the snapshot files to the codeowners of the relevant crates. This seems more logical.