### PR TITLE
refactor(oxlint/lsp): remove `offset_to_position`

### DIFF
--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use oxc_span::Span;
 use tower_lsp_server::ls_types::{
     self, CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity,
-    NumberOrString, Position, Range, Uri,
+    NumberOrString, Range, Uri,
 };
 
 use oxc_diagnostics::{OxcCode, Severity};
@@ -101,8 +101,8 @@ pub fn message_to_lsp_diagnostic(
                 .iter()
                 .map(|span| {
                     let offset = span.offset();
-                    let start_position = offset_to_position(offset, source_text);
-                    let end_position = offset_to_position(offset + span.len(), source_text);
+                    let start_position = lsp_offset_to_position(source_text, offset);
+                    let end_position = lsp_offset_to_position(source_text, offset + span.len());
 
                     ls_types::DiagnosticRelatedInformation {
                         location: ls_types::Location {
@@ -118,8 +118,8 @@ pub fn message_to_lsp_diagnostic(
         )
     };
 
-    let start_position = offset_to_position(message.span.start, source_text);
-    let end_position = offset_to_position(message.span.end, source_text);
+    let start_position = lsp_offset_to_position(source_text, message.span.start);
+    let end_position = lsp_offset_to_position(source_text, message.span.end);
     let range = Range::new(start_position, end_position);
 
     let code = message.error.code.to_string();
@@ -192,8 +192,8 @@ pub fn message_to_lsp_diagnostic(
 }
 
 fn fix_to_fixed_content(fix: Fix, source_text: &str, fix_kind: FixedContentKind) -> FixedContent {
-    let start_position = offset_to_position(fix.span.start, source_text);
-    let end_position = offset_to_position(fix.span.end, source_text);
+    let start_position = lsp_offset_to_position(source_text, fix.span.start);
+    let end_position = lsp_offset_to_position(source_text, fix.span.end);
 
     let message = fix.message.unwrap_or_else(|| {
         let rule_name = match &fix_kind {
@@ -328,8 +328,8 @@ fn build_unused_disable_diagnostic_report(
     source_text: &str,
     fix: Option<Fix>,
 ) -> DiagnosticReport {
-    let start_position = offset_to_position(span.start, source_text);
-    let end_position = offset_to_position(span.end, source_text);
+    let start_position = lsp_offset_to_position(source_text, span.start);
+    let end_position = lsp_offset_to_position(source_text, span.end);
     let range = Range::new(start_position, end_position);
 
     DiagnosticReport {
@@ -352,64 +352,5 @@ fn build_unused_disable_diagnostic_report(
                 FixedContentKind::UnusedDirective,
             )],
         }),
-    }
-}
-
-pub fn offset_to_position(offset: u32, source_text: &str) -> Position {
-    lsp_offset_to_position(source_text, offset)
-}
-
-#[cfg(test)]
-#[expect(clippy::cast_possible_truncation)]
-mod test {
-    use super::offset_to_position;
-
-    #[test]
-    fn single_line() {
-        let source = "foo.bar!;";
-        assert_position(source, 0, (0, 0));
-        assert_position(source, 4, (0, 4));
-        assert_position(source, 9, (0, 9));
-    }
-
-    #[test]
-    fn multi_line() {
-        let source = "console.log(\n  foo.bar!\n);";
-        assert_position(source, 0, (0, 0));
-        assert_position(source, 12, (0, 12));
-        assert_position(source, 13, (1, 0));
-        assert_position(source, 23, (1, 10));
-        assert_position(source, 24, (2, 0));
-        assert_position(source, 26, (2, 2));
-    }
-
-    #[test]
-    fn multi_byte() {
-        let source = "let foo = \n  '👍';";
-        assert_position(source, 10, (0, 10));
-        assert_position(source, 11, (1, 0));
-        assert_position(source, 14, (1, 3));
-        assert_position(source, 18, (1, 5));
-        assert_position(source, 19, (1, 6));
-    }
-
-    #[test]
-    fn unicode_line_and_paragraph_separators_are_not_lsp_line_breaks() {
-        let source = "a\u{2028}b\nc\u{2029}d";
-        assert_position(source, source.find('b').unwrap() as u32, (0, 2));
-        assert_position(source, source.find('c').unwrap() as u32, (1, 0));
-        assert_position(source, source.find('d').unwrap() as u32, (1, 2));
-    }
-
-    #[test]
-    #[should_panic(expected = "out of bounds")]
-    fn out_of_bounds() {
-        offset_to_position(100, "foo");
-    }
-
-    fn assert_position(source: &str, offset: u32, expected: (u32, u32)) {
-        let position = offset_to_position(offset, source);
-        assert_eq!(position.line, expected.0);
-        assert_eq!(position.character, expected.1);
     }
 }

--- a/crates/oxc_language_server/src/position.rs
+++ b/crates/oxc_language_server/src/position.rs
@@ -143,6 +143,43 @@ mod tests {
         assert_position("🍄\nabc", 6, (1, 1));
     }
 
+    #[test]
+    fn single_line() {
+        let source = "foo.bar!;";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 4, (0, 4));
+        assert_position(source, 9, (0, 9));
+    }
+
+    #[test]
+    fn multi_line() {
+        let source = "console.log(\n  foo.bar!\n);";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 12, (0, 12));
+        assert_position(source, 13, (1, 0));
+        assert_position(source, 23, (1, 10));
+        assert_position(source, 24, (2, 0));
+        assert_position(source, 26, (2, 2));
+    }
+
+    #[test]
+    fn multi_byte() {
+        let source = "let foo = \n  '👍';";
+        assert_position(source, 10, (0, 10));
+        assert_position(source, 11, (1, 0));
+        assert_position(source, 14, (1, 3));
+        assert_position(source, 18, (1, 5));
+        assert_position(source, 19, (1, 6));
+    }
+
+    #[test]
+    fn unicode_line_and_paragraph_separators_are_not_lsp_line_breaks() {
+        let source = "a\u{2028}b\nc\u{2029}d";
+        assert_position(source, source.find('b').unwrap(), (0, 2));
+        assert_position(source, source.find('c').unwrap(), (1, 0));
+        assert_position(source, source.find('d').unwrap(), (1, 2));
+    }
+
     #[cfg(test)]
     fn utf16_len(s: &str) -> usize {
         s.encode_utf16().count()


### PR DESCRIPTION
With https://github.com/oxc-project/oxc/pull/23329 the conversion from offset to line/column position is now done by a helper function in `oxc_language_server`.
There was a helper function inside `oxlint` to call the function. Instead, call it directly now.
Moved the tests to the correct place, and removed duplicated ones.