### PR TITLE
feat(linter): implement unicorn/prefer-string-repeat

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1655,6 +1655,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-single-call"?: RuleNoConfig | [AllowWarnDeny, PreferSingleCallConfig];
   "unicorn/prefer-spread"?: RuleNoConfig;
   "unicorn/prefer-string-raw"?: RuleNoConfig;
+  "unicorn/prefer-string-repeat"?: RuleNoConfig | [AllowWarnDeny, PreferStringRepeat];
   "unicorn/prefer-string-replace-all"?: RuleNoConfig;
   "unicorn/prefer-string-slice"?: RuleNoConfig;
   "unicorn/prefer-string-starts-ends-with"?: RuleNoConfig;
@@ -2112,6 +2113,7 @@ export interface DummyRuleMap {
     | [AllowWarnDeny, PreferNumberPropertiesConfig]
     | [AllowWarnDeny, PreferObjectFromEntriesConfig]
     | [AllowWarnDeny, PreferSingleCallConfig]
+    | [AllowWarnDeny, PreferStringRepeat]
     | [AllowWarnDeny, PreferStructuredCloneConfig]
     | [AllowWarnDeny, PreferTernaryOption]
     | [AllowWarnDeny, RelativeUrlStyleConfig]
@@ -6949,6 +6951,12 @@ export interface PreferSingleCallConfig {
    * Methods to ignore.
    */
   ignore?: string[];
+}
+export interface PreferStringRepeat {
+  /**
+   * The minimum number of repetitions required before reporting a string.
+   */
+  minimumRepetitions?: number;
 }
 export interface PreferStructuredCloneConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3909,6 +3909,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_string_raw::PreferStringRaw {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_string_repeat::PreferStringRepeat {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StringLiteral, AstType::TemplateLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::prefer_string_replace_all::PreferStringReplaceAll {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -743,6 +743,7 @@ pub use crate::rules::unicorn::prefer_set_size::PreferSetSize as UnicornPreferSe
 pub use crate::rules::unicorn::prefer_single_call::PreferSingleCall as UnicornPreferSingleCall;
 pub use crate::rules::unicorn::prefer_spread::PreferSpread as UnicornPreferSpread;
 pub use crate::rules::unicorn::prefer_string_raw::PreferStringRaw as UnicornPreferStringRaw;
+pub use crate::rules::unicorn::prefer_string_repeat::PreferStringRepeat as UnicornPreferStringRepeat;
 pub use crate::rules::unicorn::prefer_string_replace_all::PreferStringReplaceAll as UnicornPreferStringReplaceAll;
 pub use crate::rules::unicorn::prefer_string_slice::PreferStringSlice as UnicornPreferStringSlice;
 pub use crate::rules::unicorn::prefer_string_starts_ends_with::PreferStringStartsEndsWith as UnicornPreferStringStartsEndsWith;
@@ -1491,6 +1492,7 @@ pub enum RuleEnum {
     UnicornPreferSingleCall(UnicornPreferSingleCall),
     UnicornPreferSpread(UnicornPreferSpread),
     UnicornPreferStringRaw(UnicornPreferStringRaw),
+    UnicornPreferStringRepeat(UnicornPreferStringRepeat),
     UnicornPreferStringReplaceAll(UnicornPreferStringReplaceAll),
     UnicornPreferStringSlice(UnicornPreferStringSlice),
     UnicornPreferStringStartsEndsWith(UnicornPreferStringStartsEndsWith),
@@ -2442,7 +2444,8 @@ const UNICORN_PREFER_SET_SIZE_ID: usize = UNICORN_PREFER_SET_HAS_ID + 1usize;
 const UNICORN_PREFER_SINGLE_CALL_ID: usize = UNICORN_PREFER_SET_SIZE_ID + 1usize;
 const UNICORN_PREFER_SPREAD_ID: usize = UNICORN_PREFER_SINGLE_CALL_ID + 1usize;
 const UNICORN_PREFER_STRING_RAW_ID: usize = UNICORN_PREFER_SPREAD_ID + 1usize;
-const UNICORN_PREFER_STRING_REPLACE_ALL_ID: usize = UNICORN_PREFER_STRING_RAW_ID + 1usize;
+const UNICORN_PREFER_STRING_REPEAT_ID: usize = UNICORN_PREFER_STRING_RAW_ID + 1usize;
+const UNICORN_PREFER_STRING_REPLACE_ALL_ID: usize = UNICORN_PREFER_STRING_REPEAT_ID + 1usize;
 const UNICORN_PREFER_STRING_SLICE_ID: usize = UNICORN_PREFER_STRING_REPLACE_ALL_ID + 1usize;
 const UNICORN_PREFER_STRING_STARTS_ENDS_WITH_ID: usize = UNICORN_PREFER_STRING_SLICE_ID + 1usize;
 const UNICORN_PREFER_STRING_TRIM_START_END_ID: usize =
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3348,6 +3351,7 @@ static RULE_NAMES: [&str; 870usize] = [
     UnicornPreferSingleCall::NAME,
     UnicornPreferSpread::NAME,
     UnicornPreferStringRaw::NAME,
+    UnicornPreferStringRepeat::NAME,
     UnicornPreferStringReplaceAll::NAME,
     UnicornPreferStringSlice::NAME,
     UnicornPreferStringStartsEndsWith::NAME,
@@ -4324,6 +4328,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UNICORN_PREFER_SINGLE_CALL_ID,
             Self::UnicornPreferSpread(_) => UNICORN_PREFER_SPREAD_ID,
             Self::UnicornPreferStringRaw(_) => UNICORN_PREFER_STRING_RAW_ID,
+            Self::UnicornPreferStringRepeat(_) => UNICORN_PREFER_STRING_REPEAT_ID,
             Self::UnicornPreferStringReplaceAll(_) => UNICORN_PREFER_STRING_REPLACE_ALL_ID,
             Self::UnicornPreferStringSlice(_) => UNICORN_PREFER_STRING_SLICE_ID,
             Self::UnicornPreferStringStartsEndsWith(_) => UNICORN_PREFER_STRING_STARTS_ENDS_WITH_ID,
@@ -5361,6 +5366,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::CATEGORY,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::CATEGORY,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::CATEGORY,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::CATEGORY,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::CATEGORY,
             Self::UnicornPreferStringSlice(_) => UnicornPreferStringSlice::CATEGORY,
             Self::UnicornPreferStringStartsEndsWith(_) => {
@@ -6370,6 +6376,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::FIX,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::FIX,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::FIX,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::FIX,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::FIX,
             Self::UnicornPreferStringSlice(_) => UnicornPreferStringSlice::FIX,
             Self::UnicornPreferStringStartsEndsWith(_) => UnicornPreferStringStartsEndsWith::FIX,
@@ -7537,6 +7544,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::documentation(),
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::documentation(),
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::documentation(),
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::documentation(),
             Self::UnicornPreferStringReplaceAll(_) => {
                 UnicornPreferStringReplaceAll::documentation()
             }
@@ -9659,6 +9667,10 @@ impl RuleEnum {
                 .or_else(|| UnicornPreferSpread::schema(generator)),
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::config_schema(generator)
                 .or_else(|| UnicornPreferStringRaw::schema(generator)),
+            Self::UnicornPreferStringRepeat(_) => {
+                UnicornPreferStringRepeat::config_schema(generator)
+                    .or_else(|| UnicornPreferStringRepeat::schema(generator))
+            }
             Self::UnicornPreferStringReplaceAll(_) => {
                 UnicornPreferStringReplaceAll::config_schema(generator)
                     .or_else(|| UnicornPreferStringReplaceAll::schema(generator))
@@ -11028,6 +11040,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => "unicorn",
             Self::UnicornPreferSpread(_) => "unicorn",
             Self::UnicornPreferStringRaw(_) => "unicorn",
+            Self::UnicornPreferStringRepeat(_) => "unicorn",
             Self::UnicornPreferStringReplaceAll(_) => "unicorn",
             Self::UnicornPreferStringSlice(_) => "unicorn",
             Self::UnicornPreferStringStartsEndsWith(_) => "unicorn",
@@ -12108,6 +12121,9 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => Ok(Self::UnicornPreferSingleCall(
                 UnicornPreferSingleCall::from_configuration(value)?,
             )),
+            Self::UnicornPreferStringRepeat(_) => Ok(Self::UnicornPreferStringRepeat(
+                UnicornPreferStringRepeat::from_configuration(value)?,
+            )),
             Self::UnicornPreferStructuredClone(_) => Ok(Self::UnicornPreferStructuredClone(
                 UnicornPreferStructuredClone::from_configuration(value)?,
             )),
@@ -13036,6 +13052,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.run(node, ctx),
             Self::UnicornPreferSpread(rule) => rule.run(node, ctx),
             Self::UnicornPreferStringRaw(rule) => rule.run(node, ctx),
+            Self::UnicornPreferStringRepeat(rule) => rule.run(node, ctx),
             Self::UnicornPreferStringReplaceAll(rule) => rule.run(node, ctx),
             Self::UnicornPreferStringSlice(rule) => rule.run(node, ctx),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.run(node, ctx),
@@ -13923,6 +13940,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.run_once(ctx),
             Self::UnicornPreferSpread(rule) => rule.run_once(ctx),
             Self::UnicornPreferStringRaw(rule) => rule.run_once(ctx),
+            Self::UnicornPreferStringRepeat(rule) => rule.run_once(ctx),
             Self::UnicornPreferStringReplaceAll(rule) => rule.run_once(ctx),
             Self::UnicornPreferStringSlice(rule) => rule.run_once(ctx),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.run_once(ctx),
@@ -14905,6 +14923,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferStringRaw(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornPreferStringRepeat(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferStringReplaceAll(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferStringSlice(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15815,6 +15834,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.should_run(ctx),
             Self::UnicornPreferSpread(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringRaw(rule) => rule.should_run(ctx),
+            Self::UnicornPreferStringRepeat(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringReplaceAll(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringSlice(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.should_run(ctx),
@@ -16959,6 +16979,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::IS_TSGOLINT_RULE,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::IS_TSGOLINT_RULE,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::IS_TSGOLINT_RULE,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::IS_TSGOLINT_RULE,
             Self::UnicornPreferStringReplaceAll(_) => {
                 UnicornPreferStringReplaceAll::IS_TSGOLINT_RULE
             }
@@ -18085,6 +18106,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::VERSION,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::VERSION,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::VERSION,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::VERSION,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::VERSION,
             Self::UnicornPreferStringSlice(_) => UnicornPreferStringSlice::VERSION,
             Self::UnicornPreferStringStartsEndsWith(_) => {
@@ -19160,6 +19182,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::HAS_CONFIG,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::HAS_CONFIG,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::HAS_CONFIG,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::HAS_CONFIG,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::HAS_CONFIG,
             Self::UnicornPreferStringSlice(_) => UnicornPreferStringSlice::HAS_CONFIG,
             Self::UnicornPreferStringStartsEndsWith(_) => {
@@ -20184,6 +20207,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::INFO,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::INFO,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::INFO,
+            Self::UnicornPreferStringRepeat(_) => UnicornPreferStringRepeat::INFO,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::INFO,
             Self::UnicornPreferStringSlice(_) => UnicornPreferStringSlice::INFO,
             Self::UnicornPreferStringStartsEndsWith(_) => UnicornPreferStringStartsEndsWith::INFO,
@@ -21085,6 +21109,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.types_info(),
             Self::UnicornPreferSpread(rule) => rule.types_info(),
             Self::UnicornPreferStringRaw(rule) => rule.types_info(),
+            Self::UnicornPreferStringRepeat(rule) => rule.types_info(),
             Self::UnicornPreferStringReplaceAll(rule) => rule.types_info(),
             Self::UnicornPreferStringSlice(rule) => rule.types_info(),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.types_info(),
@@ -21959,6 +21984,7 @@ impl RuleEnum {
             Self::UnicornPreferSingleCall(rule) => rule.run_info(),
             Self::UnicornPreferSpread(rule) => rule.run_info(),
             Self::UnicornPreferStringRaw(rule) => rule.run_info(),
+            Self::UnicornPreferStringRepeat(rule) => rule.run_info(),
             Self::UnicornPreferStringReplaceAll(rule) => rule.run_info(),
             Self::UnicornPreferStringSlice(rule) => rule.run_info(),
             Self::UnicornPreferStringStartsEndsWith(rule) => rule.run_info(),
@@ -22947,6 +22973,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornPreferSingleCall(UnicornPreferSingleCall::default()),
         RuleEnum::UnicornPreferSpread(UnicornPreferSpread::default()),
         RuleEnum::UnicornPreferStringRaw(UnicornPreferStringRaw::default()),
+        RuleEnum::UnicornPreferStringRepeat(UnicornPreferStringRepeat::default()),
         RuleEnum::UnicornPreferStringReplaceAll(UnicornPreferStringReplaceAll::default()),
         RuleEnum::UnicornPreferStringSlice(UnicornPreferStringSlice::default()),
         RuleEnum::UnicornPreferStringStartsEndsWith(UnicornPreferStringStartsEndsWith::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -679,6 +679,7 @@ pub(crate) mod unicorn {
     pub mod prefer_single_call;
     pub mod prefer_spread;
     pub mod prefer_string_raw;
+    pub mod prefer_string_repeat;
     pub mod prefer_string_replace_all;
     pub mod prefer_string_slice;
     pub mod prefer_string_starts_ends_with;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_repeat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_repeat.rs
@@ -1,0 +1,419 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AccessorPropertyType, MethodDefinitionType, ModuleExportName, PropertyDefinitionType,
+        TSLiteral,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::keyword::RESERVED_KEYWORDS;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn prefer_string_repeat_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `String#repeat()` for repeated whitespace.")
+        .with_help("Replace the repeated whitespace with a call to `String#repeat()`.")
+        .with_label(span)
+}
+
+const DEFAULT_MINIMUM_REPETITIONS: usize = 3;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PreferStringRepeat {
+    /// The minimum number of repetitions required before reporting a string.
+    #[serde(deserialize_with = "deserialize_minimum_repetitions")]
+    #[schemars(range(min = 2))]
+    minimum_repetitions: usize,
+}
+
+fn deserialize_minimum_repetitions<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let minimum_repetitions = usize::deserialize(deserializer)?;
+    if minimum_repetitions < 2 {
+        return Err(serde::de::Error::custom("minimumRepetitions must be at least 2"));
+    }
+    Ok(minimum_repetitions)
+}
+
+impl Default for PreferStringRepeat {
+    fn default() -> Self {
+        Self { minimum_repetitions: DEFAULT_MINIMUM_REPETITIONS }
+    }
+}
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prefers `String#repeat()` over literal strings containing repeated whitespace.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `String#repeat()` makes the intended number and kind of repeated whitespace explicit,
+    /// instead of requiring readers to count visually indistinguishable characters.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const indentation = "    ";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const indentation = " ".repeat(4);
+    /// ```
+    PreferStringRepeat,
+    unicorn,
+    style,
+    fix,
+    config = PreferStringRepeat,
+    version = "next",
+    short_description = "Prefer `String#repeat()` over repeated whitespace.",
+);
+
+impl Rule for PreferStringRepeat {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        DefaultRuleConfig::<Self>::from_value(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let (span, value) = match node.kind() {
+            AstKind::StringLiteral(literal) => (literal.span, literal.value.as_str()),
+            AstKind::TemplateLiteral(literal) => {
+                if !literal.expressions.is_empty()
+                    || literal.quasis.len() != 1
+                    || matches!(
+                        ctx.nodes().parent_kind(node.id()),
+                        AstKind::TaggedTemplateExpression(_)
+                    )
+                {
+                    return;
+                }
+
+                let Some(value) = literal.quasis[0].value.cooked.as_ref() else {
+                    return;
+                };
+                (literal.span, value.as_str())
+            }
+            _ => return,
+        };
+
+        if is_restricted_context(node, span, ctx) {
+            return;
+        }
+
+        let mut chars = value.chars();
+        let Some(whitespace) = chars.next() else {
+            return;
+        };
+        if !is_ecmascript_whitespace(whitespace) {
+            return;
+        }
+
+        let repetitions = 1 + chars.take_while(|&ch| ch == whitespace).count();
+        if repetitions < self.minimum_repetitions || repetitions != value.chars().count() {
+            return;
+        }
+
+        let repeated = readable_whitespace(whitespace);
+        ctx.diagnostic_with_fix(prefer_string_repeat_diagnostic(span), |fixer| {
+            let source_text = ctx.source_text();
+            let leading_space = if needs_leading_space(span, source_text) { " " } else { "" };
+            let trailing_space = if needs_trailing_space(span, source_text) { " " } else { "" };
+            fixer.replace(
+                span,
+                format!("{leading_space}{repeated}.repeat({repetitions}){trailing_space}"),
+            )
+        });
+    }
+}
+
+/// Mirrors the contexts excluded by `eslint-plugin-unicorn` because replacing a literal with an
+/// expression would either be invalid syntax or change its meaning.
+///
+/// Reference: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-string-repeat.js>
+fn is_restricted_context(node: &AstNode<'_>, span: Span, ctx: &LintContext<'_>) -> bool {
+    match ctx.nodes().parent_kind(node.id()) {
+        AstKind::Directive(_)
+        | AstKind::TaggedTemplateExpression(_)
+        | AstKind::ExportAllDeclaration(_)
+        | AstKind::TSEnumMember(_)
+        | AstKind::JSXAttribute(_) => true,
+        AstKind::TSLiteralType(literal_type) => match &literal_type.literal {
+            TSLiteral::StringLiteral(literal) => literal.span == span,
+            TSLiteral::TemplateLiteral(literal) => literal.span == span,
+            _ => false,
+        },
+        AstKind::ImportDeclaration(declaration) => declaration.source.span == span,
+        AstKind::ExportFromDeclaration(declaration) => declaration.source.span == span,
+        AstKind::ImportSpecifier(specifier) => {
+            module_export_name_span(&specifier.imported) == Some(span)
+        }
+        AstKind::ExportSpecifier(specifier) => {
+            module_export_name_span(&specifier.local) == Some(span)
+                || module_export_name_span(&specifier.exported) == Some(span)
+        }
+        AstKind::ImportAttribute(attribute) => {
+            attribute.key.span() == span || attribute.value.span == span
+        }
+        AstKind::ObjectProperty(property) => !property.computed && property.key.span() == span,
+        AstKind::MethodDefinition(method) => {
+            method.key.span() == span
+                && (!method.computed
+                    || method.r#type == MethodDefinitionType::TSAbstractMethodDefinition)
+        }
+        AstKind::PropertyDefinition(property) => {
+            property.key.span() == span
+                && (!property.computed
+                    || property.r#type == PropertyDefinitionType::TSAbstractPropertyDefinition)
+        }
+        AstKind::AccessorProperty(property) => {
+            property.key.span() == span
+                && (!property.computed
+                    || property.r#type == AccessorPropertyType::TSAbstractAccessorProperty)
+        }
+        AstKind::TSPropertySignature(property) => property.key.span() == span,
+        AstKind::TSMethodSignature(method) => method.key.span() == span,
+        AstKind::TSExternalModuleDeclaration(declaration) => declaration.id.span == span,
+        AstKind::TSExternalModuleReference(reference) => reference.expression.span == span,
+        AstKind::TSImportType(import_type) => import_type.source.span == span,
+        AstKind::CallExpression(call) => is_jest_inline_snapshot(call, span),
+        _ => false,
+    }
+}
+
+fn is_jest_inline_snapshot(call: &oxc_ast::ast::CallExpression<'_>, span: Span) -> bool {
+    let Some(member) = call.callee.as_member_expression() else {
+        return false;
+    };
+    if call.optional
+        || member.optional()
+        || !matches!(
+            member.static_property_name(),
+            Some("toMatchInlineSnapshot" | "toThrowErrorMatchingInlineSnapshot")
+        )
+        || call.arguments.len() != 1
+        || call.arguments[0].span() != span
+    {
+        return false;
+    }
+
+    let oxc_ast::ast::Expression::CallExpression(expect_call) = member.object() else {
+        return false;
+    };
+    !expect_call.optional
+        && expect_call.arguments.len() == 1
+        && expect_call
+            .callee
+            .get_identifier_reference()
+            .is_some_and(|identifier| identifier.name == "expect")
+}
+
+fn module_export_name_span(name: &ModuleExportName<'_>) -> Option<Span> {
+    match name {
+        ModuleExportName::StringLiteral(literal) => Some(literal.span),
+        _ => None,
+    }
+}
+
+fn is_ecmascript_whitespace(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0009}'
+            | '\u{000A}'
+            | '\u{000B}'
+            | '\u{000C}'
+            | '\u{000D}'
+            | '\u{0020}'
+            | '\u{00A0}'
+            | '\u{1680}'
+            | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
+}
+
+fn readable_whitespace(ch: char) -> String {
+    match ch {
+        ' ' => "' '".to_string(),
+        '\t' => r"'\t'".to_string(),
+        '\n' => r"'\n'".to_string(),
+        '\r' => r"'\r'".to_string(),
+        '\u{000C}' => r"'\f'".to_string(),
+        _ => format!(r"'\u{{{:X}}}'", ch as u32),
+    }
+}
+
+fn needs_leading_space(span: Span, source_text: &str) -> bool {
+    let before = &source_text[..span.start as usize];
+    RESERVED_KEYWORDS.iter().any(|keyword| before.ends_with(keyword))
+        || before.ends_with("of")
+        || before.ends_with("await")
+}
+
+fn needs_trailing_space(span: Span, source_text: &str) -> bool {
+    let after = &source_text[span.end as usize..];
+    RESERVED_KEYWORDS.iter().any(|keyword| after.starts_with(keyword))
+        || after.starts_with("of")
+        || after.starts_with("await")
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"const string = " ";"#, None),
+        (r#"const string = "  ";"#, None),
+        (r#"const string = "a";"#, None),
+        (r#"const string = "aaa";"#, None),
+        (r#"const string = "unicorn unicorn unicorn";"#, None),
+        (r#"const string = " \t ";"#, None),
+        (r#"const string = " \n ";"#, None),
+        (r#"const string = "\r\n\r\n\r\n";"#, None),
+        (r#"const string = " ".repeat(3);"#, None),
+        ("const string = `  `;", None),
+        ("const string = tag`   `;", None),
+        (r"const string = `  ${value}`;", None),
+        (r#"const object = {"   ": value};"#, None),
+        (r#""   ";"#, None),
+        (r#"expect(foo).toMatchInlineSnapshot("   ");"#, None),
+        ("expect(foo).toMatchInlineSnapshot(`   `);", None),
+        (r#"expect(foo).toThrowErrorMatchingInlineSnapshot("   ");"#, None),
+        (
+            r#"const string = "   "; // minimumRepetitions: 4"#,
+            Some(serde_json::json!([{"minimumRepetitions": 4}])),
+        ),
+        (r#"import "   ";"#, None),
+        (r#"export {} from "   ";"#, None),
+        (r#"export * from "   ";"#, None),
+        (r#"import "module" with {"   ": "value"};"#, None),
+        (r#"export {} from "module" with {"   ": "value"};"#, None),
+        (r#"import "module" with {key: "   "};"#, None),
+        (r#"export {} from "module" with {key: "   "};"#, None),
+        (r#"import {"   " as string} from "module";"#, None),
+        (r#"export {"   " as string} from "module";"#, None),
+        (r#"export {string as "   "} from "module";"#, None),
+        (r#"export * as "   " from "module";"#, None),
+        (r#"enum Enum {"   " = 1}"#, None),
+        (r#"enum Enum {Key = "   "}"#, None),
+        (r#"declare module "   " {}"#, None),
+        (r#"import type Type = require("   ");"#, None),
+        (r#"type Type = "   ";"#, None),
+        ("type Type = `   `;", None),
+        (r#"type Type = import("   ");"#, None),
+        (r#"abstract class Class { abstract "   " }"#, None),
+        (r#"abstract class Class { abstract "   "() }"#, None),
+        ("abstract class Class { abstract [`   `](): void }", None),
+        (r#"abstract class Class { abstract accessor "   " }"#, None),
+        ("abstract class Class { abstract accessor [`   `]: string }", None),
+        (r#"interface Interface { "   " }"#, None),
+        (r#"interface Interface { "   "(): void }"#, None),
+        ("interface Interface { [`   `](): void }", None),
+        ("interface Interface { readonly [`   `]: string }", None),
+        (r#"type Type = { "   "(): void }"#, None),
+        ("type Type = { [`   `](): void }", None),
+        (r#"class Class { "   " = 1 }"#, None),
+        (r#"class Class { "   "() {} }"#, None),
+        (r#"class Class { accessor "   " = 1 }"#, None),
+        ("enum OtherEnum {Key = `   `}", None),
+        (r#"<Component attribute="   " />"#, None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, }
+    ];
+
+    let fail = vec![
+        (r#"const string = "   ";"#, None),
+        (r#"const string = "    ";"#, None),
+        (r#"const string = "\t\t\t";"#, None),
+        (r#"const string = "\n\n\n";"#, None),
+        (r#"const string = "\r\r\r";"#, None),
+        (r#"const string = "\v\v\v";"#, None),
+        (r#"const string = "\f\f\f";"#, None),
+        (r#"const string = "\u00A0\u00A0\u00A0";"#, None),
+        (r#"const string = "\u2003\u2003\u2003";"#, None),
+        (r#"const string = "\uFEFF\uFEFF\uFEFF";"#, None),
+        ("const string = `   `;", None),
+        (r"const string = `\t\t\t`;", None),
+        (r#"function foo() {return"   "}"#, None),
+        (r#"foo(); "   ";"#, None),
+        (r#"const object = {["   "]: value};"#, None),
+        (
+            r#"const string = "  "; // minimumRepetitions: 2"#,
+            Some(serde_json::json!([{"minimumRepetitions": 2}])),
+        ),
+        (
+            r#"const string = "    "; // minimumRepetitions: 4"#,
+            Some(serde_json::json!([{"minimumRepetitions": 4}])),
+        ),
+        (r#"class Class { ["   "] = 1 }"#, None),
+        (r#"class Class { ["   "]() {} }"#, None),
+        (r#"class Class { accessor ["   "] = 1 }"#, None),
+        (r#"formatter.toMatchInlineSnapshot("   ");"#, None),
+        (r#"custom.toThrowErrorMatchingInlineSnapshot("   ");"#, None),
+        (r#"expect(foo)?.toMatchInlineSnapshot("   ");"#, None),
+        (r#"expect(foo).toMatchInlineSnapshot?.("   ");"#, None),
+        (r#"expect?.(foo).toMatchInlineSnapshot("   ");"#, None),
+        (r#"<Component attribute={"   "} />"#, None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        (
+            "function foo() {
+                return'   ';
+            }",
+            None,
+        ),
+    ];
+
+    let fix = vec![
+        (r#"const string = "   ";"#, "const string = ' '.repeat(3);"),
+        (r#"const string = "\t\t\t";"#, r"const string = '\t'.repeat(3);"),
+        (r#"const string = "\u00A0\u00A0\u00A0";"#, r"const string = '\u{A0}'.repeat(3);"),
+        ("const string = `   `;", "const string = ' '.repeat(3);"),
+        (r#"const object = {["   "]: value};"#, "const object = {[' '.repeat(3)]: value};"),
+        (r#"const result = "   "in object;"#, "const result = ' '.repeat(3) in object;"),
+        (
+            "function foo() {
+                return'   ';
+            }",
+            "function foo() {
+                return ' '.repeat(3);
+            }",
+        ),
+    ];
+
+    Tester::new(PreferStringRepeat::NAME, PreferStringRepeat::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}
+
+#[test]
+fn configuration_minimum_repetitions() {
+    assert!(
+        PreferStringRepeat::from_configuration(serde_json::json!([{"minimumRepetitions": 0}]))
+            .is_err()
+    );
+    assert!(
+        PreferStringRepeat::from_configuration(serde_json::json!([{"minimumRepetitions": 1}]))
+            .is_err()
+    );
+    assert_eq!(
+        PreferStringRepeat::from_configuration(serde_json::json!([{"minimumRepetitions": 2}]))
+            .unwrap()
+            .minimum_repetitions,
+        2
+    );
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_string_repeat.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_string_repeat.snap
@@ -1,0 +1,194 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "   ";
+   ·                ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "    ";
+   ·                ──────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\t\t\t";
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\n\n\n";
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\r\r\r";
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\v\v\v";
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\f\f\f";
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\u00A0\u00A0\u00A0";
+   ·                ────────────────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\u2003\u2003\u2003";
+   ·                ────────────────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "\uFEFF\uFEFF\uFEFF";
+   ·                ────────────────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = `   `;
+   ·                ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = `\t\t\t`;
+   ·                ────────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:23]
+ 1 │ function foo() {return"   "}
+   ·                       ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:8]
+ 1 │ foo(); "   ";
+   ·        ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:18]
+ 1 │ const object = {["   "]: value};
+   ·                  ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "  "; // minimumRepetitions: 2
+   ·                ────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ const string = "    "; // minimumRepetitions: 4
+   ·                ──────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ class Class { ["   "] = 1 }
+   ·                ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:16]
+ 1 │ class Class { ["   "]() {} }
+   ·                ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:25]
+ 1 │ class Class { accessor ["   "] = 1 }
+   ·                         ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:33]
+ 1 │ formatter.toMatchInlineSnapshot("   ");
+   ·                                 ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:43]
+ 1 │ custom.toThrowErrorMatchingInlineSnapshot("   ");
+   ·                                           ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:36]
+ 1 │ expect(foo)?.toMatchInlineSnapshot("   ");
+   ·                                    ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:37]
+ 1 │ expect(foo).toMatchInlineSnapshot?.("   ");
+   ·                                     ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:37]
+ 1 │ expect?.(foo).toMatchInlineSnapshot("   ");
+   ·                                     ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:1:23]
+ 1 │ <Component attribute={"   "} />
+   ·                       ─────
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.
+
+  ⚠ unicorn(prefer-string-repeat): Use `String#repeat()` for repeated whitespace.
+   ╭─[prefer_string_repeat.tsx:2:23]
+ 1 │ function foo() {
+ 2 │                 return'   ';
+   ·                       ─────
+ 3 │             }
+   ╰────
+  help: Replace the repeated whitespace with a call to `String#repeat()`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9551,6 +9551,26 @@
         "unicorn/prefer-string-raw": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-string-repeat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PreferStringRepeat"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "unicorn/prefer-string-replace-all": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -18068,6 +18088,20 @@
             "type": "string"
           },
           "markdownDescription": "Methods to ignore."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferStringRepeat": {
+      "type": "object",
+      "properties": {
+        "minimumRepetitions": {
+          "description": "The minimum number of repetitions required before reporting a string.",
+          "default": 3,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 2.0,
+          "markdownDescription": "The minimum number of repetitions required before reporting a string."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- implement `unicorn/prefer-string-repeat` with an autofix for repeated ECMAScript whitespace
- support the upstream `minimumRepetitions` option with schema and runtime validation
- preserve syntax-sensitive literals and Jest/Vitest inline snapshots, including optional-call edge cases
- register the rule and regenerate the Rust/TypeScript configuration artifacts

Part of #684.

## Testing

- `cargo test -p oxc_linter --all-features`
- `cargo clippy -p oxc_linter --all-features --all-targets -- -D warnings`
- `cargo doc -p oxc_linter --no-deps --document-private-items --all-features` with `RUSTDOCFLAGS=-D warnings`
- `cargo shear --fix --check-test-targets`
- `typos`

`just ready` also ran through formatting and repository checks, but its full-workspace test phase stopped on an unrelated codegen snapshot that records Node v26.5.0 while the local environment uses Node v24.13.0.

## AI assistance disclosure

Codex assisted with implementation and adversarial review. I reviewed the complete diff, compared behavior with the upstream rule, addressed every review finding, and ran the checks listed above.
