### PR TITLE
refactor(parser): remove unused `Clone` derives from checkpoint types

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -11,7 +11,6 @@ use crate::{
     lexer::{Kind, LexerCheckpoint, Token, cold_branch},
 };
 
-#[derive(Clone)]
 pub struct ParserCheckpoint<'a> {
     lexer: LexerCheckpoint<'a>,
     cur_token: Token,

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -47,7 +47,7 @@ pub use token::Token;
 use source::{Source, SourcePosition};
 use trivia_builder::TriviaBuilder;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LexerCheckpoint<'a> {
     source_position: SourcePosition<'a>,
     token: Token,
@@ -57,7 +57,7 @@ pub struct LexerCheckpoint<'a> {
     no_side_effects_comments: Option<(usize, usize)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum ErrorSnapshot<'a> {
     Empty,
     Count(usize),


### PR DESCRIPTION
Pure refactor.

`ParserCheckpoint`, `LexerCheckpoint` and `ErrorSnapshot` are never cloned, so remove `#[derive(Clone)]` from them.