### PR TITLE
perf(minifier): merge nested if stmt in place instead of creating dummies

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -87,18 +87,11 @@ impl<'a> PeepholeOptimizations {
             && if2_stmt.alternate.is_none()
         {
             // `if (a) if (b) x;` => `if (a && b) x;`
-            let a = if_stmt.test.take_in(ctx);
-            let b = if2_stmt.test.take_in(ctx);
-            let new_test = Self::join_with_left_associative_op(
-                if_stmt.test.span(),
-                LogicalOperator::And,
-                a,
-                b,
-                ctx,
-            );
-            let new_consequent = if2_stmt.consequent.take_in(ctx);
-            ctx.replace_expression(&mut if_stmt.test, new_test);
-            ctx.replace_statement(&mut if_stmt.consequent, new_consequent);
+            let IfStatement { test, consequent, .. } = if2_stmt.take_in(ctx);
+            ctx.replace_expression_with(&mut if_stmt.test, |a, ctx| {
+                Self::join_with_left_associative_op(test.span(), LogicalOperator::And, a, test, ctx)
+            });
+            ctx.replace_statement(&mut if_stmt.consequent, consequent);
         }
 
         Self::wrap_to_avoid_ambiguous_else(if_stmt, ctx);

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 143560
+  arena allocs: 143446
   arena reallocs: 28269
-  arena size: 19100024 # 19.10 MB
+  arena size: 19097584 # 19.10 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,7 +16,7 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15652
+  arena allocs: 15643
   arena reallocs: 2709
   arena size: 2879680 # 2.88 MB
 
@@ -38,7 +38,7 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 44756
+  arena allocs: 44749
   arena reallocs: 7699
   arena size: 6304256 # 6.30 MB
 
@@ -49,7 +49,7 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 351162
+  arena allocs: 351149
   arena reallocs: 75941
   arena size: 48738712 # 48.74 MB
 
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 6789
+  arena allocs: 6784
   arena reallocs: 834
   arena size: 1162400 # 1.16 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64844
+  arena allocs: 64833
   arena reallocs: 12187
   arena size: 9385624 # 9.39 MB


### PR DESCRIPTION
reduce allocations when converting `if (a) if (b) x;` to `if (a && b) x;`