### PR TITLE
perf(parser): remove fatal error guard from `parse_jsx_element_name`

### DIFF
--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -1,6 +1,6 @@
 //! [JSX](https://facebook.github.io/jsx)
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
@@ -160,16 +160,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             );
         }
 
-        if self.fatal_error.is_some() {
-            return JSXElementName::dummy(self.allocator());
-        }
-
         // Determine if this JSX element name is a reference (component) or an intrinsic element.
         // References (components) are:
         // - ASCII names that start with uppercase letter, `_` or `$`: `<Foo>`, `<_foo>`, `<$foo>`
         // - All non-ASCII names (e.g., Unicode identifiers like `<테스트>`)
         // - Names without hyphens (hyphenated names like `<my-element>` are custom elements)
         // https://babeljs.io/repl#?code_lz=DwMQ9mAED0B8DcAoYAzCMHIPpqnJwAJLhkkA&presets=react
+        //
+        // In case of a fatal error in `parse_jsx_identifier`, `name` is an empty string,
+        // so `!contains_dash` check must be first to avoid a panic in `name.as_bytes()[0]`.
         //
         // The identifier has already been validated by the parser, so for ASCII characters
         // we know it can only be `a-z`, `A-Z`, `_` or `$`.
@@ -503,12 +502,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
     ) -> (
         JSXIdentifier<'a>, // JSX identifier
-        bool,              // `true` if contains `-`
+        bool,              // `true` if contains `-`, or if parsing failed (see below)
     ) {
         let start = self.cur_start();
         let kind = self.cur_kind();
         if kind != Kind::Ident && !kind.is_any_keyword() {
-            return (self.unexpected(), false);
+            // Return `contains_dash = true`, so that `parse_jsx_element_name` does not read the first byte
+            // of the dummy identifier's empty name. `parse_jsx_member_expression` treats a dash as an error,
+            // but on this path its `fatal_error` call is a no-op, because a fatal error has already been recorded.
+            return (self.unexpected(), true);
         }
         // Currently at a valid normal Ident or Keyword, keep on lexing for `-` in `<component-name />`
         let contains_dash = self.continue_lex_jsx_identifier();


### PR DESCRIPTION
Small perf optimization to parser.

Remove the `if self.fatal_error.is_some()` branch from `parse_jsx_element_name`.

The guard existed so that code below it doesn't try to read the first byte of the dummy identifier's empty name after `parse_jsx_identifier` fails. Instead, make the error path return `contains_dash = true`, which skips reading the name in `parse_jsx_element_name`.

In `parse_jsx_member_expression`, a dash is already treated as an error, and its `fatal_error` call is a no-op because a fatal error has already been recorded. The other callers ignore the flag.

This removes a check, but main motivation is preparation for larger changes to how fatal errors are handled in further PRs to follow.