### PR TITLE
fix(semantic): evaluate for-in/of targets on each iteration

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1423,11 +1423,15 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         // Annex B permits a var initializer here. It runs once, before the RHS.
-        let has_initializer = matches!(
-            &stmt.left,
-            ForStatementLeft::VariableDeclaration(declaration)
-                if declaration.declarations.iter().any(|declarator| declarator.init.is_some())
-        );
+        let has_initializer = !self.strict_mode()
+            && matches!(
+                &stmt.left,
+                ForStatementLeft::VariableDeclaration(declaration)
+                    if declaration.kind.is_var()
+                        && declaration.declarations.len() == 1
+                        && matches!(declaration.declarations[0].id, BindingPattern::BindingIdentifier(_))
+                        && declaration.declarations[0].init.is_some()
+            );
         if has_initializer {
             self.visit_for_statement_left(&stmt.left);
         }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1423,6 +1423,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         // Annex B permits a var initializer here. It runs once, before the RHS.
+        #[cfg(feature = "cfg")]
         let has_initializer = !self.strict_mode()
             && matches!(
                 &stmt.left,
@@ -1432,14 +1433,25 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
                         && matches!(declaration.declarations[0].id, BindingPattern::BindingIdentifier(_))
                         && declaration.declarations[0].init.is_some()
             );
-        if has_initializer {
-            self.visit_for_statement_left(&stmt.left);
-        }
+        #[cfg(feature = "cfg")]
+        let (before_for_stmt_graph_ix, target_graph_ix) = control_flow!(self, |cfg| {
+            let before_for_stmt_graph_ix = cfg.current_node_ix;
+            let target_graph_ix = (!has_initializer).then(|| cfg.new_basic_block_normal());
+            (before_for_stmt_graph_ix, target_graph_ix)
+        });
+
+        // Preserve source-order node visitation, but defer runtime targets to each iteration.
+        self.visit_for_statement_left(&stmt.left);
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let (before_for_stmt_graph_ix, start_prepare_cond_graph_ix) =
-            control_flow!(self, |cfg| (cfg.current_node_ix, cfg.new_basic_block_normal(),));
+        let (before_for_stmt_graph_ix, after_target_graph_ix, start_prepare_cond_graph_ix) =
+            control_flow!(self, |cfg| {
+                let after_target_graph_ix = cfg.current_node_ix;
+                let before_for_stmt_graph_ix =
+                    if has_initializer { after_target_graph_ix } else { before_for_stmt_graph_ix };
+                (before_for_stmt_graph_ix, after_target_graph_ix, cfg.new_basic_block_normal())
+            });
         /* cfg */
 
         #[cfg(feature = "cfg")]
@@ -1455,17 +1467,18 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
                 let end_of_prepare_cond_graph_ix = cfg.current_node_ix;
                 let iteration_graph_ix = cfg.new_basic_block_normal();
                 cfg.append_iteration(right_node_id, IterationInstructionKind::In);
-                let body_graph_ix = cfg.new_basic_block_normal();
+                let body_graph_ix = if let Some(target_graph_ix) = target_graph_ix {
+                    cfg.current_node_ix = after_target_graph_ix;
+                    target_graph_ix
+                } else {
+                    cfg.new_basic_block_normal()
+                };
 
                 cfg.ctx(None).default().allow_break().allow_continue();
                 (end_of_prepare_cond_graph_ix, iteration_graph_ix, body_graph_ix)
             });
         /* cfg */
 
-        // Evaluate assignment targets and destructuring only when an iteration succeeds.
-        if !has_initializer {
-            self.visit_for_statement_left(&stmt.left);
-        }
         self.visit_statement(&stmt.body);
 
         /* cfg */
@@ -1504,9 +1517,16 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let (before_for_stmt_graph_ix, start_prepare_cond_graph_ix) =
+        let (before_for_stmt_graph_ix, body_graph_ix) =
             control_flow!(self, |cfg| (cfg.current_node_ix, cfg.new_basic_block_normal()));
         /* cfg */
+
+        // Preserve source-order node visitation, but defer runtime targets to each iteration.
+        self.visit_for_statement_left(&stmt.left);
+
+        #[cfg(feature = "cfg")]
+        let (after_target_graph_ix, start_prepare_cond_graph_ix) =
+            control_flow!(self, |cfg| (cfg.current_node_ix, cfg.new_basic_block_normal()));
 
         #[cfg(feature = "cfg")]
         self.record_ast_nodes();
@@ -1516,19 +1536,16 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let (end_of_prepare_cond_graph_ix, iteration_graph_ix, body_graph_ix) =
-            control_flow!(self, |cfg| {
-                let end_of_prepare_cond_graph_ix = cfg.current_node_ix;
-                let iteration_graph_ix = cfg.new_basic_block_normal();
-                cfg.append_iteration(right_node_id, IterationInstructionKind::Of);
-                let body_graph_ix = cfg.new_basic_block_normal();
-                cfg.ctx(None).default().allow_break().allow_continue();
-                (end_of_prepare_cond_graph_ix, iteration_graph_ix, body_graph_ix)
-            });
+        let (end_of_prepare_cond_graph_ix, iteration_graph_ix) = control_flow!(self, |cfg| {
+            let end_of_prepare_cond_graph_ix = cfg.current_node_ix;
+            let iteration_graph_ix = cfg.new_basic_block_normal();
+            cfg.append_iteration(right_node_id, IterationInstructionKind::Of);
+            cfg.current_node_ix = after_target_graph_ix;
+            cfg.ctx(None).default().allow_break().allow_continue();
+            (end_of_prepare_cond_graph_ix, iteration_graph_ix)
+        });
         /* cfg */
 
-        // Evaluate assignment targets and destructuring only when an iteration succeeds.
-        self.visit_for_statement_left(&stmt.left);
         self.visit_statement(&stmt.body);
 
         /* cfg */

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1422,7 +1422,15 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
-        self.visit_for_statement_left(&stmt.left);
+        // Annex B permits a var initializer here. It runs once, before the RHS.
+        let has_initializer = matches!(
+            &stmt.left,
+            ForStatementLeft::VariableDeclaration(declaration)
+                if declaration.declarations.iter().any(|declarator| declarator.init.is_some())
+        );
+        if has_initializer {
+            self.visit_for_statement_left(&stmt.left);
+        }
 
         /* cfg */
         #[cfg(feature = "cfg")]
@@ -1450,6 +1458,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             });
         /* cfg */
 
+        // Evaluate assignment targets and destructuring only when an iteration succeeds.
+        if !has_initializer {
+            self.visit_for_statement_left(&stmt.left);
+        }
         self.visit_statement(&stmt.body);
 
         /* cfg */
@@ -1486,8 +1498,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
-        self.visit_for_statement_left(&stmt.left);
-
         /* cfg */
         #[cfg(feature = "cfg")]
         let (before_for_stmt_graph_ix, start_prepare_cond_graph_ix) =
@@ -1513,6 +1523,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             });
         /* cfg */
 
+        // Evaluate assignment targets and destructuring only when an iteration succeeds.
+        self.visit_for_statement_left(&stmt.left);
         self.visit_statement(&stmt.body);
 
         /* cfg */

--- a/crates/oxc_semantic/tests/integration/cfg.rs
+++ b/crates/oxc_semantic/tests/integration/cfg.rs
@@ -2,8 +2,6 @@
 
 use std::fs;
 
-use oxc_ast::AstKind;
-use oxc_cfg::{EdgeType, InstructionKind};
 use oxc_span::SourceType;
 
 use crate::util::SemanticTester;
@@ -20,95 +18,4 @@ fn test_cfg_files() {
             insta::assert_snapshot!(name, snapshot);
         });
     });
-}
-
-#[test]
-fn for_iteration_targets_run_on_success() {
-    for operator in ["in", "of"] {
-        for target in [
-            "getTarget().x",
-            "getTarget()[getKey()]",
-            "[getTarget().x = getDefault()]",
-            "const { [getKey()]: value = getDefault() }",
-        ] {
-            for next in ["", "continue;", "break;"] {
-                let code =
-                    format!("for ({target} {operator} getValues()) {{ body(); {next} }} after();");
-                let tester = SemanticTester::new(&code, SourceType::mjs()).with_cfg(true);
-                let semantic = tester.build();
-                let cfg = semantic.cfg().unwrap();
-                let nodes = semantic.nodes();
-                let call_block = |name: &str| {
-                    nodes
-                        .iter()
-                        .find_map(|node| {
-                            let AstKind::CallExpression(call) = node.kind() else { return None };
-                            (call.callee.get_identifier_reference()?.name == name)
-                                .then(|| nodes.cfg_id(node.id()))
-                        })
-                        .unwrap()
-                };
-                let body = call_block("body");
-                let values = call_block("getValues");
-                let after = call_block("after");
-                let iteration = cfg
-                    .graph
-                    .node_indices()
-                    .find(|&id| {
-                        cfg.basic_block(id).instructions.iter().any(|instruction| {
-                            matches!(instruction.kind, InstructionKind::Iteration(_))
-                        })
-                    })
-                    .unwrap();
-                let has_edge = |from, to, predicate: fn(&EdgeType) -> bool| {
-                    cfg.graph.edges_connecting(from, to).any(|edge| predicate(edge.weight()))
-                };
-                assert!(has_edge(values, iteration, |edge| matches!(edge, EdgeType::Normal)));
-                assert!(has_edge(iteration, body, |edge| matches!(edge, EdgeType::Jump)));
-                assert!(has_edge(iteration, after, |edge| matches!(edge, EdgeType::Normal)));
-                for name in ["getTarget", "getKey", "getDefault"] {
-                    if target.contains(name) {
-                        assert_eq!(call_block(name), body, "{code}: {name}");
-                    }
-                }
-                match next {
-                    "continue;" => {
-                        assert!(has_edge(body, iteration, |edge| matches!(edge, EdgeType::Jump)))
-                    }
-                    "break;" => {
-                        assert!(has_edge(body, after, |edge| matches!(edge, EdgeType::Jump)))
-                    }
-                    _ => assert!(has_edge(body, iteration, |edge| matches!(
-                        edge,
-                        EdgeType::Backedge
-                    ))),
-                }
-            }
-        }
-    }
-}
-
-#[test]
-fn for_in_initializer_runs_before_collection() {
-    let tester = SemanticTester::new(
-        "for (var key = initialize() in getValues()) { body(); }",
-        SourceType::cjs(),
-    )
-    .with_cfg(true);
-    let semantic = tester.build();
-    let nodes = semantic.nodes();
-    let calls: Vec<_> = nodes
-        .iter()
-        .filter(|node| matches!(node.kind(), AstKind::CallExpression(_)))
-        .map(|node| nodes.cfg_id(node.id()))
-        .collect();
-    let [initializer, collection, body] = calls.as_slice() else { panic!("expected three calls") };
-    let cfg = semantic.cfg().unwrap();
-    assert!(
-        cfg.graph
-            .edges_connecting(*initializer, *collection)
-            .any(|edge| matches!(edge.weight(), EdgeType::Normal))
-    );
-    assert_ne!(initializer, body);
-    assert_ne!(collection, body);
 }

--- a/crates/oxc_semantic/tests/integration/cfg.rs
+++ b/crates/oxc_semantic/tests/integration/cfg.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 
+use oxc_ast::AstKind;
+use oxc_cfg::{EdgeType, InstructionKind};
 use oxc_span::SourceType;
 
 use crate::util::SemanticTester;
@@ -18,4 +20,95 @@ fn test_cfg_files() {
             insta::assert_snapshot!(name, snapshot);
         });
     });
+}
+
+#[test]
+fn for_iteration_targets_run_on_success() {
+    for operator in ["in", "of"] {
+        for target in [
+            "getTarget().x",
+            "getTarget()[getKey()]",
+            "[getTarget().x = getDefault()]",
+            "const { [getKey()]: value = getDefault() }",
+        ] {
+            for next in ["", "continue;", "break;"] {
+                let code =
+                    format!("for ({target} {operator} getValues()) {{ body(); {next} }} after();");
+                let tester = SemanticTester::new(&code, SourceType::mjs()).with_cfg(true);
+                let semantic = tester.build();
+                let cfg = semantic.cfg().unwrap();
+                let nodes = semantic.nodes();
+                let call_block = |name: &str| {
+                    nodes
+                        .iter()
+                        .find_map(|node| {
+                            let AstKind::CallExpression(call) = node.kind() else { return None };
+                            (call.callee.get_identifier_reference()?.name == name)
+                                .then(|| nodes.cfg_id(node.id()))
+                        })
+                        .unwrap()
+                };
+                let body = call_block("body");
+                let values = call_block("getValues");
+                let after = call_block("after");
+                let iteration = cfg
+                    .graph
+                    .node_indices()
+                    .find(|&id| {
+                        cfg.basic_block(id).instructions.iter().any(|instruction| {
+                            matches!(instruction.kind, InstructionKind::Iteration(_))
+                        })
+                    })
+                    .unwrap();
+                let has_edge = |from, to, predicate: fn(&EdgeType) -> bool| {
+                    cfg.graph.edges_connecting(from, to).any(|edge| predicate(edge.weight()))
+                };
+                assert!(has_edge(values, iteration, |edge| matches!(edge, EdgeType::Normal)));
+                assert!(has_edge(iteration, body, |edge| matches!(edge, EdgeType::Jump)));
+                assert!(has_edge(iteration, after, |edge| matches!(edge, EdgeType::Normal)));
+                for name in ["getTarget", "getKey", "getDefault"] {
+                    if target.contains(name) {
+                        assert_eq!(call_block(name), body, "{code}: {name}");
+                    }
+                }
+                match next {
+                    "continue;" => {
+                        assert!(has_edge(body, iteration, |edge| matches!(edge, EdgeType::Jump)))
+                    }
+                    "break;" => {
+                        assert!(has_edge(body, after, |edge| matches!(edge, EdgeType::Jump)))
+                    }
+                    _ => assert!(has_edge(body, iteration, |edge| matches!(
+                        edge,
+                        EdgeType::Backedge
+                    ))),
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn for_in_initializer_runs_before_collection() {
+    let tester = SemanticTester::new(
+        "for (var key = initialize() in getValues()) { body(); }",
+        SourceType::cjs(),
+    )
+    .with_cfg(true);
+    let semantic = tester.build();
+    let nodes = semantic.nodes();
+    let calls: Vec<_> = nodes
+        .iter()
+        .filter(|node| matches!(node.kind(), AstKind::CallExpression(_)))
+        .map(|node| nodes.cfg_id(node.id()))
+        .collect();
+    let [initializer, collection, body] = calls.as_slice() else { panic!("expected three calls") };
+    let cfg = semantic.cfg().unwrap();
+    assert!(
+        cfg.graph
+            .edges_connecting(*initializer, *collection)
+            .any(|edge| matches!(edge.weight(), EdgeType::Normal))
+    );
+    assert_ne!(initializer, body);
+    assert_ne!(collection, body);
 }

--- a/crates/oxc_semantic/tests/integration/cfg_fixtures/for_iteration_target.js
+++ b/crates/oxc_semantic/tests/integration/cfg_fixtures/for_iteration_target.js
@@ -1,0 +1,18 @@
+// Branching targets make their evaluation visible in the CFG snapshot.
+for ((getTarget() || fallback()).x of getValues()) {
+    body();
+    continue;
+}
+afterOf();
+
+for (getTarget()[getKey() || defaultKey()] in getObject()) {
+    body();
+}
+afterIn();
+
+// Legacy initializers still run once, before collection evaluation.
+for (var key = initialize() || fallback() in getObject()) {
+    body(key);
+    break;
+}
+afterInitializer();

--- a/crates/oxc_semantic/tests/integration/main.rs
+++ b/crates/oxc_semantic/tests/integration/main.rs
@@ -4,6 +4,7 @@ pub mod cfg;
 pub mod classes;
 pub mod enum_values;
 pub mod modules;
+pub mod nodes;
 pub mod scopes;
 pub mod symbols;
 pub mod util;

--- a/crates/oxc_semantic/tests/integration/nodes.rs
+++ b/crates/oxc_semantic/tests/integration/nodes.rs
@@ -1,0 +1,24 @@
+use oxc_ast::AstKind;
+use oxc_span::SourceType;
+
+use crate::util::SemanticTester;
+
+#[test]
+fn for_loop_targets_precede_collection_in_node_order() {
+    for operator in ["in", "of"] {
+        for build_cfg in [false, cfg!(feature = "cfg")] {
+            let code = format!("for (const [x = afterEach(f)] {operator} beforeAll(f)) {{}}");
+            let tester = SemanticTester::new(&code, SourceType::mjs()).with_cfg(build_cfg);
+            let semantic = tester.build();
+            let calls: Vec<_> = semantic
+                .nodes()
+                .iter()
+                .filter_map(|node| {
+                    let AstKind::CallExpression(call) = node.kind() else { return None };
+                    Some(call.callee.get_identifier_reference().unwrap().name.as_str())
+                })
+                .collect();
+            assert_eq!(calls, ["afterEach", "beforeAll"], "{code}, cfg={build_cfg}");
+        }
+    }
+}

--- a/crates/oxc_semantic/tests/integration/snapshots/for_iteration_target.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/for_iteration_target.snap
@@ -1,0 +1,218 @@
+---
+source: crates/oxc_semantic/tests/integration/cfg.rs
+expression: snapshot
+input_file: crates/oxc_semantic/tests/integration/cfg_fixtures/for_iteration_target.js
+---
+bb0: {
+
+}
+
+bb1: {
+	statement
+}
+
+bb2: {
+
+}
+
+bb3: {
+	iteration <of>
+}
+
+bb4: {
+
+}
+
+bb5: {
+	condition
+}
+
+bb6: {
+
+}
+
+bb7: {
+	statement
+	statement
+	continue
+}
+
+bb8: {
+	unreachable
+}
+
+bb9: {
+	statement
+	statement
+}
+
+bb10: {
+
+}
+
+bb11: {
+	iteration <in>
+}
+
+bb12: {
+
+}
+
+bb13: {
+	condition
+}
+
+bb14: {
+
+}
+
+bb15: {
+	statement
+	statement
+}
+
+bb16: {
+	statement
+	statement
+	statement
+}
+
+bb17: {
+	condition
+}
+
+bb18: {
+
+}
+
+bb19: {
+
+}
+
+bb20: {
+
+}
+
+bb21: {
+	iteration <in>
+}
+
+bb22: {
+	statement
+	statement
+	break
+}
+
+bb23: {
+	unreachable
+}
+
+bb24: {
+	statement
+}
+
+digraph {
+    0 [ label = "bb0" shape = box]
+    1 [ label = "bb1
+ForOfStatement" shape = box]
+    2 [ label = "bb2" shape = box]
+    3 [ label = "bb3
+Iteration(CallExpression(getValues) of expr)" shape = box]
+    4 [ label = "bb4" shape = box]
+    5 [ label = "bb5
+Condition(CallExpression(getTarget))" shape = box]
+    6 [ label = "bb6" shape = box]
+    7 [ label = "bb7
+BlockStatement
+ExpressionStatement
+continue" shape = box]
+    8 [ label = "bb8
+unreachable" shape = box]
+    9 [ label = "bb9
+ExpressionStatement
+ForInStatement" shape = box]
+    10 [ label = "bb10" shape = box]
+    11 [ label = "bb11
+Iteration(CallExpression(getObject) in expr)" shape = box]
+    12 [ label = "bb12" shape = box]
+    13 [ label = "bb13
+Condition(CallExpression(getKey))" shape = box]
+    14 [ label = "bb14" shape = box]
+    15 [ label = "bb15
+BlockStatement
+ExpressionStatement" shape = box]
+    16 [ label = "bb16
+ExpressionStatement
+ForInStatement
+VariableDeclaration" shape = box]
+    17 [ label = "bb17
+Condition(CallExpression(initialize))" shape = box]
+    18 [ label = "bb18" shape = box]
+    19 [ label = "bb19" shape = box]
+    20 [ label = "bb20" shape = box]
+    21 [ label = "bb21
+Iteration(CallExpression(getObject) in expr)" shape = box]
+    22 [ label = "bb22
+BlockStatement
+ExpressionStatement
+break" shape = box]
+    23 [ label = "bb23
+unreachable" shape = box]
+    24 [ label = "bb24
+ExpressionStatement" shape = box]
+    1 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    2 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    3 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    4 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    5 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    6 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    7 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    4 -> 5 [ label="Normal"]
+    5 -> 6 [ label="Normal"]
+    5 -> 7 [ label="Normal"]
+    6 -> 7 [ label="Normal"]
+    8 -> 0 [ label="Error(Implicit)", style=dashed, color=red]
+    7 -> 8 [ label="Unreachable", style="dotted"]
+    9 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    1 -> 2 [ label="Normal"]
+    2 -> 3 [ label="Normal"]
+    3 -> 4 [ label="Jump", color=green]
+    8 -> 3 [ label="Backedge", style="dotted", color=grey]
+    3 -> 9 [ label="Normal"]
+    7 -> 3 [ label="Jump", color=green]
+    10 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    11 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    12 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    13 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    14 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    15 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    12 -> 13 [ label="Normal"]
+    13 -> 14 [ label="Normal"]
+    13 -> 15 [ label="Normal"]
+    14 -> 15 [ label="Normal"]
+    16 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    9 -> 10 [ label="Normal"]
+    10 -> 11 [ label="Normal"]
+    11 -> 12 [ label="Jump", color=green]
+    15 -> 11 [ label="Backedge", color=grey]
+    11 -> 16 [ label="Normal"]
+    17 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    18 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    19 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    16 -> 17 [ label="Normal"]
+    17 -> 18 [ label="Normal"]
+    17 -> 19 [ label="Normal"]
+    18 -> 19 [ label="Normal"]
+    20 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    21 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    22 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    23 -> 0 [ label="Error(Implicit)", style=dashed, color=red]
+    22 -> 23 [ label="Unreachable", style="dotted"]
+    24 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    19 -> 20 [ label="Normal"]
+    20 -> 21 [ label="Normal"]
+    21 -> 22 [ label="Jump", color=green]
+    23 -> 21 [ label="Backedge", style="dotted", color=grey]
+    21 -> 24 [ label="Normal"]
+    22 -> 24 [ label="Jump", color=green]
+}

--- a/crates/oxc_semantic/tests/integration/snapshots/for_iteration_target.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/for_iteration_target.snap
@@ -16,7 +16,7 @@ bb2: {
 }
 
 bb3: {
-	iteration <of>
+	condition
 }
 
 bb4: {
@@ -24,7 +24,9 @@ bb4: {
 }
 
 bb5: {
-	condition
+	statement
+	statement
+	continue
 }
 
 bb6: {
@@ -32,9 +34,7 @@ bb6: {
 }
 
 bb7: {
-	statement
-	statement
-	continue
+	iteration <of>
 }
 
 bb8: {
@@ -51,7 +51,7 @@ bb10: {
 }
 
 bb11: {
-	iteration <in>
+	condition
 }
 
 bb12: {
@@ -59,7 +59,8 @@ bb12: {
 }
 
 bb13: {
-	condition
+	statement
+	statement
 }
 
 bb14: {
@@ -67,8 +68,7 @@ bb14: {
 }
 
 bb15: {
-	statement
-	statement
+	iteration <in>
 }
 
 bb16: {
@@ -117,15 +117,15 @@ digraph {
 ForOfStatement" shape = box]
     2 [ label = "bb2" shape = box]
     3 [ label = "bb3
-Iteration(CallExpression(getValues) of expr)" shape = box]
+Condition(CallExpression(getTarget))" shape = box]
     4 [ label = "bb4" shape = box]
     5 [ label = "bb5
-Condition(CallExpression(getTarget))" shape = box]
-    6 [ label = "bb6" shape = box]
-    7 [ label = "bb7
 BlockStatement
 ExpressionStatement
 continue" shape = box]
+    6 [ label = "bb6" shape = box]
+    7 [ label = "bb7
+Iteration(CallExpression(getValues) of expr)" shape = box]
     8 [ label = "bb8
 unreachable" shape = box]
     9 [ label = "bb9
@@ -133,14 +133,14 @@ ExpressionStatement
 ForInStatement" shape = box]
     10 [ label = "bb10" shape = box]
     11 [ label = "bb11
-Iteration(CallExpression(getObject) in expr)" shape = box]
+Condition(CallExpression(getKey))" shape = box]
     12 [ label = "bb12" shape = box]
     13 [ label = "bb13
-Condition(CallExpression(getKey))" shape = box]
-    14 [ label = "bb14" shape = box]
-    15 [ label = "bb15
 BlockStatement
 ExpressionStatement" shape = box]
+    14 [ label = "bb14" shape = box]
+    15 [ label = "bb15
+Iteration(CallExpression(getObject) in expr)" shape = box]
     16 [ label = "bb16
 ExpressionStatement
 ForInStatement
@@ -165,37 +165,37 @@ ExpressionStatement" shape = box]
     3 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     4 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     5 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    2 -> 3 [ label="Normal"]
+    3 -> 4 [ label="Normal"]
+    3 -> 5 [ label="Normal"]
+    4 -> 5 [ label="Normal"]
     6 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     7 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    4 -> 5 [ label="Normal"]
-    5 -> 6 [ label="Normal"]
-    5 -> 7 [ label="Normal"]
-    6 -> 7 [ label="Normal"]
     8 -> 0 [ label="Error(Implicit)", style=dashed, color=red]
-    7 -> 8 [ label="Unreachable", style="dotted"]
+    5 -> 8 [ label="Unreachable", style="dotted"]
     9 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    1 -> 2 [ label="Normal"]
-    2 -> 3 [ label="Normal"]
-    3 -> 4 [ label="Jump", color=green]
-    8 -> 3 [ label="Backedge", style="dotted", color=grey]
-    3 -> 9 [ label="Normal"]
-    7 -> 3 [ label="Jump", color=green]
+    1 -> 6 [ label="Normal"]
+    6 -> 7 [ label="Normal"]
+    7 -> 2 [ label="Jump", color=green]
+    8 -> 7 [ label="Backedge", style="dotted", color=grey]
+    7 -> 9 [ label="Normal"]
+    5 -> 7 [ label="Jump", color=green]
     10 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     11 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     12 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     13 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
+    10 -> 11 [ label="Normal"]
+    11 -> 12 [ label="Normal"]
+    11 -> 13 [ label="Normal"]
+    12 -> 13 [ label="Normal"]
     14 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     15 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    12 -> 13 [ label="Normal"]
-    13 -> 14 [ label="Normal"]
-    13 -> 15 [ label="Normal"]
-    14 -> 15 [ label="Normal"]
     16 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
-    9 -> 10 [ label="Normal"]
-    10 -> 11 [ label="Normal"]
-    11 -> 12 [ label="Jump", color=green]
-    15 -> 11 [ label="Backedge", color=grey]
-    11 -> 16 [ label="Normal"]
+    9 -> 14 [ label="Normal"]
+    14 -> 15 [ label="Normal"]
+    15 -> 10 [ label="Jump", color=green]
+    13 -> 15 [ label="Backedge", color=grey]
+    15 -> 16 [ label="Normal"]
     17 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     18 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     19 -> 0 [ label="Error(Implicit)", color=red, style=dashed]

--- a/crates/oxc_semantic/tests/integration/snapshots/if_stmt_in_for_in.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/if_stmt_in_for_in.snap
@@ -17,7 +17,6 @@ bb2: {
 
 bb3: {
 	statement
-	statement
 }
 
 bb4: {
@@ -29,6 +28,7 @@ bb5: {
 }
 
 bb6: {
+	statement
 	statement
 	statement
 }
@@ -88,12 +88,12 @@ digraph {
     1 [ label = "bb1" shape = box]
     2 [ label = "bb2" shape = box]
     3 [ label = "bb3
-ForInStatement
-VariableDeclaration" shape = box]
+ForInStatement" shape = box]
     4 [ label = "bb4" shape = box]
     5 [ label = "bb5
 Iteration(IdentifierReference(array) in expr)" shape = box]
     6 [ label = "bb6
+VariableDeclaration
 BlockStatement
 IfStatement" shape = box]
     7 [ label = "bb7

--- a/crates/oxc_semantic/tests/integration/snapshots/if_stmt_in_for_in.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/if_stmt_in_for_in.snap
@@ -20,17 +20,17 @@ bb3: {
 }
 
 bb4: {
-
+	statement
+	statement
+	statement
 }
 
 bb5: {
-	iteration <in>
+
 }
 
 bb6: {
-	statement
-	statement
-	statement
+	iteration <in>
 }
 
 bb7: {
@@ -89,13 +89,13 @@ digraph {
     2 [ label = "bb2" shape = box]
     3 [ label = "bb3
 ForInStatement" shape = box]
-    4 [ label = "bb4" shape = box]
-    5 [ label = "bb5
-Iteration(IdentifierReference(array) in expr)" shape = box]
-    6 [ label = "bb6
+    4 [ label = "bb4
 VariableDeclaration
 BlockStatement
 IfStatement" shape = box]
+    5 [ label = "bb5" shape = box]
+    6 [ label = "bb6
+Iteration(IdentifierReference(array) in expr)" shape = box]
     7 [ label = "bb7
 Condition(if cond)" shape = box]
     8 [ label = "bb8
@@ -143,19 +143,19 @@ return" shape = box]
     13 -> 14 [ label="Normal", style="dotted"]
     11 -> 14 [ label="Jump", color=green]
     15 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    6 -> 7 [ label="Normal"]
+    4 -> 7 [ label="Normal"]
     7 -> 8 [ label="Jump", color=green]
     9 -> 15 [ label="Normal", style="dotted"]
     7 -> 10 [ label="Jump", color=green]
     14 -> 15 [ label="Normal"]
     16 -> 2 [ label="Error(Implicit)", color=red, style=dashed]
-    3 -> 4 [ label="Normal"]
-    4 -> 5 [ label="Normal"]
-    5 -> 6 [ label="Jump", color=green]
-    15 -> 5 [ label="Backedge", color=grey]
-    5 -> 16 [ label="Normal"]
+    3 -> 5 [ label="Normal"]
+    5 -> 6 [ label="Normal"]
+    6 -> 4 [ label="Jump", color=green]
+    15 -> 6 [ label="Backedge", color=grey]
+    6 -> 16 [ label="Normal"]
     8 -> 16 [ label="Jump", color=green]
-    12 -> 5 [ label="Jump", color=green]
+    12 -> 6 [ label="Jump", color=green]
     17 -> 0 [ label="Error(Implicit)", color=red, style=dashed]
     1 -> 17 [ label="Normal"]
 }


### PR DESCRIPTION
For `for (getTarget().x of getValues())` and equivalent `for-in` loops, evaluate the runtime target after collection evaluation and only when an iteration succeeds. This skips target evaluation for empty collections and repeats it on each iteration, including after `continue`.

Preserve the one-time, pre-collection initializer allowed by legacy `for (var key = initialize() in object)` syntax.

AI assistance: implemented and reviewed with Codex.
