### PR TITLE
fix(linter): print rules in agent output

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1702,6 +1702,16 @@ mod test {
     }
 
     #[test]
+    fn test_rules_agent_output() {
+        let tester = Tester::new().with_cwd("fixtures".into());
+        let (stdout, _) = tester.test_output(&["--rules"]);
+        let (agent_stdout, _) = tester.test_output(&["--rules", "-f=agent"]);
+
+        // Agent auto-detection selects this formatter, so it must support `--rules`.
+        assert_eq!(agent_stdout, stdout);
+    }
+
+    #[test]
     fn test_disable_directive_issue_13311() {
         // Test that exhaustive-deps diagnostics are reported at the dependency array
         // so that disable directives work correctly

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -4,13 +4,18 @@ use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
 };
+use rustc_hash::FxHashSet;
 
-use crate::output_formatter::InternalFormatter;
+use crate::output_formatter::{InternalFormatter, default::DefaultOutputFormatter};
 
 #[derive(Debug, Default)]
 pub struct AgentOutputFormatter;
 
 impl InternalFormatter for AgentOutputFormatter {
+    fn all_rules(&self, enabled_rules: FxHashSet<(&str, &str)>) -> Option<String> {
+        DefaultOutputFormatter.all_rules(enabled_rules)
+    }
+
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
         Box::new(AgentReporter)
     }


### PR DESCRIPTION
  Fix `oxlint --rules` producing no output when the agent formatter is selected by reusing the default rule table, and add a regression test.

  Fixes #26343