### PR TITLE
fix(formatter_css): keep comment inside important and simple-vars colon

### DIFF
--- a/crates/oxc_formatter_css/DIVERGENCES.md
+++ b/crates/oxc_formatter_css/DIVERGENCES.md
@@ -767,7 +767,7 @@ so the entry BEFORE the comment (`in a,`) breaks away from `$k` too; the same so
 ## less-variable-value-comments
 
 - Why: invariant
-- Pin: `tests/fixtures/format/less/variable-value-comments.less`
+- Pin: `tests/fixtures/format/less/variable-value-comments.less`, `tests/fixtures/format/less/important-comments.less`
 
 ```less
 /* input */
@@ -1127,3 +1127,33 @@ postcss-simple-vars substitutes a variable's value textually.
 With the plugin, the input produces `--fragment: */`, while Prettier's output produces `--fragment: * /`;
 the added whitespace changes the custom property's preserved token stream.
 A `$var` value the typed grammar cannot read therefore prints verbatim, like a raw custom-property value.
+
+## important-comment-run
+
+- Why: uniform-rule (same construct, same output: `!IMPORTANT`, which Prettier prints `!important`)
+- Pin: `tests/fixtures/format/css/important-comments.css`
+
+```css
+/* input */
+a {
+  y: red ! /* a */ IMPORTANT;
+  v: red !/* glued */important;
+}
+
+/* ours */
+a {
+  y: red ! /* a */ important;
+  v: red ! /* glued */ important;
+}
+
+/* prettier */
+a {
+  y: red ! /* a */ IMPORTANT;
+  v: red !/* glued */important;
+}
+```
+
+`!important` is normalized the same way whether or not a comment sits between `!` and the keyword:
+lowercase keyword, one space around the comment.
+Prettier normalizes only the plain shape (`raws.important` is replaced when it matches `\s*!\s*important`)
+and prints any other run verbatim, so a comment inside freezes the keyword's case and the glue.

--- a/crates/oxc_formatter_css/src/print/less.rs
+++ b/crates/oxc_formatter_css/src/print/less.rs
@@ -143,8 +143,8 @@ pub(super) fn write_less_mixin_call_statement<'a>(
     let raw = source.slice_range(span.start, end).trim_end();
     let _ = f.context().comments().take_before(end);
     value::write_adjusted_verbatim(raw, f);
-    if call.important.is_some() {
-        write!(f, [space(), "!important"]);
+    if let Some(important) = &call.important {
+        value::write_trailing_important(important, f);
     }
 }
 
@@ -183,8 +183,8 @@ fn write_less_mixin_call<'a>(call: &LessMixinCall<'a>, f: &mut CssFormatter<'_, 
         }
         write!(f, ")");
     }
-    if call.important.is_some() {
-        write!(f, [space(), "!important"]);
+    if let Some(important) = &call.important {
+        value::write_trailing_important(important, f);
     }
 }
 

--- a/crates/oxc_formatter_css/src/print/postcss_simple_vars.rs
+++ b/crates/oxc_formatter_css/src/print/postcss_simple_vars.rs
@@ -27,21 +27,23 @@ pub(super) fn write_postcss_simple_var_declaration<'a>(
     f: &mut CssFormatter<'_, 'a>,
 ) {
     write_postcss_simple_var(&decl.name, f);
-    write!(f, ":");
-    write!(f, space());
+    statement::write_colon_run(to_span(&decl.name.span).end, to_span(&decl.colon_span).end, f);
 
+    // An empty value prints as `$x:;`, as Prettier does.
     let end = to_span(&decl.span).end;
-    if decl.value_is_raw && !decl.value.is_empty() {
-        // postcss-simple-vars substitutes the value textually,
-        // so re-spacing a raw fallback would change the substituted token stream
-        // (DIVERGENCES.md "postcss-simple-var-raw-verbatim").
-        let value_start = to_span(decl.value[0].span()).start;
-        value::write_verbatim_value(Span::new(value_start, end), f);
-    } else {
-        // The typed value stream (including any trailing `ImportantAnnotation` pushed by the parser)
-        // prints like any declaration value:
-        // gap-driven rules and Prettier's multi-value list break apply here too.
-        value::write_declaration_value(&decl.value, ValueContext::default(), f);
+    if !decl.value.is_empty() {
+        write!(f, space());
+        if decl.value_is_raw {
+            // postcss-simple-vars substitutes the value textually,
+            // so re-spacing a raw fallback would change the substituted token stream
+            // (DIVERGENCES.md "postcss-simple-var-raw-verbatim").
+            let value_start = to_span(decl.value[0].span()).start;
+            value::write_verbatim_value(Span::new(value_start, end), f);
+        } else {
+            // The typed value stream (including any trailing `ImportantAnnotation` pushed by the parser)
+            // prints like any declaration value: gap-driven rules and Prettier's multi-value list break apply here too.
+            value::write_declaration_value(&decl.value, ValueContext::default(), f);
+        }
     }
     statement::write_terminator_tail_comments(end, f);
 }

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -39,15 +39,7 @@ pub(super) fn write_sass_variable_declaration<'a>(
     write!(f, "$");
     let name_span = to_span(decl.name.name.span());
     write!(f, text(source.text_for(&name_span)));
-    // Comments between the name and the colon are kept verbatim
-    let colon_end = to_span(&decl.colon_span).end;
-    let between = source.slice_range(name_span.end, colon_end);
-    if between.trim() == ":" {
-        write!(f, ":");
-    } else {
-        write!(f, text(between.trim_ascii()));
-        let _ = f.context().comments().take_before(colon_end);
-    }
+    statement::write_colon_run(name_span.end, to_span(&decl.colon_span).end, f);
     write!(f, space());
 
     let ctx = ValueContext { decl_prop: Some("$"), map_break: true, ..ValueContext::default() };

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -417,16 +417,19 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
         }
     }
     if decl.value.is_empty() {
-        // Custom properties with a whitespace-only value keep it verbatim
-        // (`--one-space: ;` stays as-is). Scan up to the `;` in the source.
-        let colon_end = to_span(&decl.colon_span).end;
-        let bytes = source.as_bytes();
-        let mut i = colon_end as usize;
-        while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
-            i += 1;
-        }
-        if i < bytes.len() && bytes[i] == b';' && i > colon_end as usize {
-            write!(f, text(source.slice_range(colon_end, u32::try_from(i).unwrap())));
+        // An empty value prints as `prop:;`, except a custom property's whitespace-only value,
+        // which is its value: `--x: ;` substitutes a space where `--x:;` substitutes nothing, so it is kept verbatim.
+        // Scan up to the `;` in the source.
+        if is_custom_property {
+            let colon_end = to_span(&decl.colon_span).end;
+            let bytes = source.as_bytes();
+            let mut i = colon_end as usize;
+            while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+                i += 1;
+            }
+            if i < bytes.len() && bytes[i] == b';' && i > colon_end as usize {
+                write!(f, text(source.slice_range(colon_end, u32::try_from(i).unwrap())));
+            }
         }
     } else {
         write!(f, space());
@@ -544,10 +547,22 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
         }
     }
     if let Some(important) = &decl.important {
-        value::flush_trailing_value_comments(to_span(important.span()).start, f);
-        write!(f, [space(), "!important"]);
+        value::write_trailing_important(important, f);
     }
     write_terminator_tail_comments(to_span(decl.span()).end, f);
+}
+
+/// The run between a variable name and its `:`: normally just the colon,
+/// but a comment there stays on its side of the `:` (`$x/* c */: 1`, as Prettier prints it).
+pub(super) fn write_colon_run(name_end: u32, colon_end: u32, f: &mut CssFormatter<'_, '_>) {
+    let source = f.context().source_text();
+    let between = source.slice_range(name_end, colon_end).trim_ascii();
+    if between == ":" {
+        write!(f, ":");
+    } else {
+        write!(f, text(between));
+        let _ = f.context().comments().take_before(colon_end);
+    }
 }
 
 /// Comments between a declaration's content and its `;` (`value /* c */;`), kept in place.

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -16,9 +16,9 @@ use cow_utils::CowUtils;
 use oxc_css_parser::{
     ast::{
         BracketBlock, Calc, CalcOperatorKind, ComponentValue, Delimiter, DelimiterKind, Dimension,
-        Function, FunctionName, InterpolableIdent, InterpolableStr, LessBinaryOperation,
-        LessOperationOperatorKind, LessParenthesizedOperation, Number, SassBinaryExpression,
-        SassBinaryOperator, SassBinaryOperatorKind, SassInterpolatedIdent,
+        Function, FunctionName, ImportantAnnotation, InterpolableIdent, InterpolableStr,
+        LessBinaryOperation, LessOperationOperatorKind, LessParenthesizedOperation, Number,
+        SassBinaryExpression, SassBinaryOperator, SassBinaryOperatorKind, SassInterpolatedIdent,
         SassInterpolatedIdentElement, SassUnaryOperatorKind, Str, Url, UrlValue,
     },
     token::Token,
@@ -1015,18 +1015,45 @@ pub(super) fn flush_same_line_comments(
 
 /// Emits pending comments before `upper_bound` as ` /* c */` suffixes
 /// (used after the last value component, before `;` / `!important`).
-/// Returns the end offset of the last emitted comment.
-pub(super) fn flush_trailing_value_comments(
-    upper_bound: u32,
-    f: &mut CssFormatter<'_, '_>,
-) -> Option<u32> {
-    let mut last_end = None;
+pub(super) fn flush_trailing_value_comments(upper_bound: u32, f: &mut CssFormatter<'_, '_>) {
     for &comment in f.context().comments().take_before(upper_bound) {
         write!(f, " ");
         write!(f, FormatCommentBeforeContent::new(comment, BlockCommentAfter::None));
-        last_end = Some(comment.span.end);
     }
-    last_end
+}
+
+/// `!important`, normalized (`!  IMPORTANT` too), with a comment between `!` and the identifier kept there:
+/// `! /* c */ important` (DIVERGENCES.md "important-comment-run").
+/// Comments BEFORE the `!` are the caller's (a trailing flush, or the value list's separator).
+pub(super) fn write_important_annotation(
+    important: &ImportantAnnotation<'_>,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    let span = to_span(&important.span);
+    let ident_start = to_span(&important.ident.span).start;
+    let has_inner_comment = f
+        .context()
+        .comments()
+        .peek()
+        .is_some_and(|c| c.span.start >= span.start && c.span.end <= ident_start);
+    if !has_inner_comment {
+        write!(f, "!important");
+        return;
+    }
+    write!(f, "!");
+    flush_trailing_value_comments(ident_start, f);
+    write!(f, [space(), "important"]);
+}
+
+/// A trailing `!important` (declaration, Less mixin call):
+/// the comments before it, then ` !important`.
+pub(super) fn write_trailing_important(
+    important: &ImportantAnnotation<'_>,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    flush_trailing_value_comments(to_span(&important.span).start, f);
+    write!(f, space());
+    write_important_annotation(important, f);
 }
 
 /// A value that is exactly one sass interpolation (`--p: #{fn(...)};`).
@@ -1802,14 +1829,16 @@ pub(super) fn write_component_value<'a>(
         ComponentValue::PostcssSimpleVar(variable) => {
             super::postcss_simple_vars::write_postcss_simple_var(variable, f);
         }
+        // A mid-value or variable-value `!important` (the trailing one of a declaration is `Declaration::important`)
+        ComponentValue::ImportantAnnotation(important) => write_important_annotation(important, f),
         // Everything else (Sass/Less constructs, interpolations, token fallbacks):
         // print the source verbatim until ported structurally.
         _ => {
             if less::write_less_component_value(value, f) {
                 return;
             }
-            let span = to_span(value.span());
-            write!(f, text(source.text_for(&span)));
+            // The slice holds any comment inside the node; claim it so no later flush repeats it
+            write_verbatim_value(to_span(value.span()), f);
         }
     }
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/empty-value.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/empty-value.css
@@ -1,0 +1,13 @@
+/* An empty value prints as `prop:;`.
+   A custom property's whitespace-only value IS its value
+   (`var(--x)` substitutes a space for `--x: ;`, nothing for `--x:;`), so it stays verbatim. */
+a {
+  color: ;
+  color:;
+  *zoom: ;
+  --x: ;
+  --y:;
+  --z:   ;
+}
+$e: ;
+$f:;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/empty-value.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/empty-value.css.snap
@@ -1,0 +1,54 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* An empty value prints as `prop:;`.
+   A custom property's whitespace-only value IS its value
+   (`var(--x)` substitutes a space for `--x: ;`, nothing for `--x:;`), so it stays verbatim. */
+a {
+  color: ;
+  color:;
+  *zoom: ;
+  --x: ;
+  --y:;
+  --z:   ;
+}
+$e: ;
+$f:;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* An empty value prints as `prop:;`.
+   A custom property's whitespace-only value IS its value
+   (`var(--x)` substitutes a space for `--x: ;`, nothing for `--x:;`), so it stays verbatim. */
+a {
+  color:;
+  color:;
+  *zoom:;
+  --x: ;
+  --y:;
+  --z:   ;
+}
+$e:;
+$f:;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* An empty value prints as `prop:;`.
+   A custom property's whitespace-only value IS its value
+   (`var(--x)` substitutes a space for `--x: ;`, nothing for `--x:;`), so it stays verbatim. */
+a {
+  color:;
+  color:;
+  *zoom:;
+  --x: ;
+  --y:;
+  --z:   ;
+}
+$e:;
+$f:;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/important-comments.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/important-comments.css
@@ -1,0 +1,13 @@
+/* A comment between `!` and `important` stays there, printed once.
+   The keyword is still normalized: `y` and `v` DIVERGE from Prettier,
+   which keeps such a run verbatim (DIVERGENCES.md "important-comment-run"). */
+a {
+  color: red ! /* typed declaration */ important;
+  x: .foo > bar ! /* raw declaration */ important;
+  y: red ! /* a */ /* b */ IMPORTANT;
+  v: red !/* glued */important;
+  z: red /* before */ ! /* inside */ important /* after */;
+  w: red   !   important;
+}
+
+$var: red ! /* postcss-simple-vars */ important;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/important-comments.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/important-comments.css.snap
@@ -1,0 +1,54 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* A comment between `!` and `important` stays there, printed once.
+   The keyword is still normalized: `y` and `v` DIVERGE from Prettier,
+   which keeps such a run verbatim (DIVERGENCES.md "important-comment-run"). */
+a {
+  color: red ! /* typed declaration */ important;
+  x: .foo > bar ! /* raw declaration */ important;
+  y: red ! /* a */ /* b */ IMPORTANT;
+  v: red !/* glued */important;
+  z: red /* before */ ! /* inside */ important /* after */;
+  w: red   !   important;
+}
+
+$var: red ! /* postcss-simple-vars */ important;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* A comment between `!` and `important` stays there, printed once.
+   The keyword is still normalized: `y` and `v` DIVERGE from Prettier,
+   which keeps such a run verbatim (DIVERGENCES.md "important-comment-run"). */
+a {
+  color: red ! /* typed declaration */ important;
+  x: .foo > bar ! /* raw declaration */ important;
+  y: red ! /* a */ /* b */ important;
+  v: red ! /* glued */ important;
+  z: red /* before */ ! /* inside */ important /* after */;
+  w: red !important;
+}
+
+$var: red ! /* postcss-simple-vars */ important;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* A comment between `!` and `important` stays there, printed once.
+   The keyword is still normalized: `y` and `v` DIVERGE from Prettier,
+   which keeps such a run verbatim (DIVERGENCES.md "important-comment-run"). */
+a {
+  color: red ! /* typed declaration */ important;
+  x: .foo > bar ! /* raw declaration */ important;
+  y: red ! /* a */ /* b */ important;
+  v: red ! /* glued */ important;
+  z: red /* before */ ! /* inside */ important /* after */;
+  w: red !important;
+}
+
+$var: red ! /* postcss-simple-vars */ important;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/colon-comments.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/colon-comments.css
@@ -1,0 +1,9 @@
+/* A comment between the name and the colon never crosses the `:`
+   (kept verbatim, glued, as Prettier prints it). */
+$x /* between */: red;
+$y /* between-empty */: ;
+$z /* prettier-ignore */: red   blue;
+$w/* glued */:red;
+
+/* A comment after the colon stays before the `;`. */
+$g: /* c */;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/colon-comments.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/colon-comments.css.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* A comment between the name and the colon never crosses the `:`
+   (kept verbatim, glued, as Prettier prints it). */
+$x /* between */: red;
+$y /* between-empty */: ;
+$z /* prettier-ignore */: red   blue;
+$w/* glued */:red;
+
+/* A comment after the colon stays before the `;`. */
+$g: /* c */;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* A comment between the name and the colon never crosses the `:`
+   (kept verbatim, glued, as Prettier prints it). */
+$x/* between */: red;
+$y/* between-empty */:;
+$z/* prettier-ignore */: red blue;
+$w/* glued */: red;
+
+/* A comment after the colon stays before the `;`. */
+$g: /* c */;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* A comment between the name and the colon never crosses the `:`
+   (kept verbatim, glued, as Prettier prints it). */
+$x/* between */: red;
+$y/* between-empty */:;
+$z/* prettier-ignore */: red blue;
+$w/* glued */: red;
+
+/* A comment after the colon stays before the `;`. */
+$g: /* c */;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/important-comments.less
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/important-comments.less
@@ -1,0 +1,9 @@
+// A comment between `!` and `important` stays there, printed once.
+a {
+  .mixin() ! /* mixin call */ important;
+  .mixin(1) /* before */ ! /* inside */ important;
+}
+
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"):
+// Prettier DROPS the comment (`@var: red ! important;`).
+@var: red ! /* Less variable */ important;

--- a/crates/oxc_formatter_css/tests/fixtures/format/less/important-comments.less.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/less/important-comments.less.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between `!` and `important` stays there, printed once.
+a {
+  .mixin() ! /* mixin call */ important;
+  .mixin(1) /* before */ ! /* inside */ important;
+}
+
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"):
+// Prettier DROPS the comment (`@var: red ! important;`).
+@var: red ! /* Less variable */ important;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between `!` and `important` stays there, printed once.
+a {
+  .mixin() ! /* mixin call */ important;
+  .mixin(1) /* before */ ! /* inside */ important;
+}
+
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"):
+// Prettier DROPS the comment (`@var: red ! important;`).
+@var: red ! /* Less variable */ important;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between `!` and `important` stays there, printed once.
+a {
+  .mixin() ! /* mixin call */ important;
+  .mixin(1) /* before */ ! /* inside */ important;
+}
+
+// DIVERGENCE (DIVERGENCES.md "less-variable-value-comments"):
+// Prettier DROPS the comment (`@var: red ! important;`).
+@var: red ! /* Less variable */ important;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/important-comments.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/important-comments.scss
@@ -1,0 +1,9 @@
+// A comment between `!` and `important` stays there, printed once,
+// in the value positions Sass adds to the declaration form.
+a {
+  mid: red ! /* mid-value */ important blue;
+  fn: call(red ! /* function argument */ important);
+}
+
+$var: red ! /* Sass variable */ important;
+$flags: red ! /* c */ important !default;

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/important-comments.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/important-comments.scss.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between `!` and `important` stays there, printed once,
+// in the value positions Sass adds to the declaration form.
+a {
+  mid: red ! /* mid-value */ important blue;
+  fn: call(red ! /* function argument */ important);
+}
+
+$var: red ! /* Sass variable */ important;
+$flags: red ! /* c */ important !default;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between `!` and `important` stays there, printed once,
+// in the value positions Sass adds to the declaration form.
+a {
+  mid: red ! /* mid-value */ important blue;
+  fn: call(red ! /* function argument */ important);
+}
+
+$var: red ! /* Sass variable */ important;
+$flags: red ! /* c */ important !default;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between `!` and `important` stays there, printed once,
+// in the value positions Sass adds to the declaration form.
+a {
+  mid: red ! /* mid-value */ important blue;
+  fn: call(red ! /* function argument */ important);
+}
+
+$var: red ! /* Sass variable */ important;
+$flags: red ! /* c */ important !default;
+
+===================== End =====================


### PR DESCRIPTION
Follow up on #26337 

Also, normalize `important` token with/without comments.