### PR TITLE
fix(formatter): keep array hole slot comments beside their commas

### DIFF
--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -2,6 +2,30 @@
 
 Admission reasons and rules: see `crates/oxc_formatter_core/FORMATTER_POLICY.md` "Known divergences".
 
+## array-hole-leading-comment
+
+- Why: invariant (oxc#22799)
+- Pin: `tests/fixtures/js/comments/array-holes.js`
+
+```js
+// input
+;[a, /* c */, b] = x;
+
+// ours
+[a, /* c */, b] = x;
+
+// prettier
+[a /* c */, , b] = x;
+```
+
+A comment between the commas sits in the hole's slot; Prettier's attachment relocates it across a comma
+(backward to the previous element, or forward past the hole's comma when own-line: `[, /* lead */ 2]` for `[/* lead */, 2]`).
+We print it as the hole's leading comment, keeping its side of both commas.
+A same-line line comment after the separator still trails the previous element (`[a, // c`),
+per the riding-the-separator rule in FORMATTER_POLICY.md.
+Affects conformance `js/arrays/numbers-with-holes.js`: matching Prettier's relocated output there had no fixpoint
+(the comment moved again on our second pass, the file was listed under "Not idempotent"); keeping the slot is idempotent.
+
 ## array-hole-trailing-comment
 
 - Why: invariant

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -70,6 +70,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ArrayElementList<'a, '_> {
                 filler.finish();
             }
             ArrayLayout::OnePerLine => write_array_node(
+                self.elements.parent().span(),
                 self.elements.len(),
                 self.elements.iter().map(|e| if e.is_elision() { None } else { Some(e) }),
                 f,

--- a/crates/oxc_formatter/src/print/array_pattern.rs
+++ b/crates/oxc_formatter/src/print/array_pattern.rs
@@ -36,6 +36,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatArrayPattern<'a, '_> {
                     let has_element = !self.elements.is_empty();
                     if has_element {
                         write_array_node(
+                            self.span(),
                             self.elements.len() + usize::from(self.rest.is_some()),
                             self.elements().iter().map(AstNode::as_ref),
                             f,

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -424,6 +424,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
                     let has_element = !self.elements.is_empty();
                     if has_element {
                         write_array_node(
+                            self.span(),
                             self.elements.len() + usize::from(self.rest.is_some()),
                             self.elements().iter().map(AstNode::as_ref),
                             f,

--- a/crates/oxc_formatter/src/utils/array.rs
+++ b/crates/oxc_formatter/src/utils/array.rs
@@ -1,9 +1,18 @@
+use oxc_ast::Comment;
+use oxc_formatter_core::SourceText;
 use oxc_span::{GetSpan, SPAN, Span};
 
-use crate::{formatter::prelude::*, options::FormatTrailingCommas, write};
+use crate::{
+    formatter::{prelude::*, trivia::FormatCommentBeforeContent},
+    options::FormatTrailingCommas,
+    write,
+};
 
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)
+///
+/// `span` is the bracketed node's span, used to locate the `,` of a leading hole.
 pub fn write_array_node<'a, 'b, N>(
+    span: Span,
     len: usize,
     array: impl IntoIterator<Item = Option<&'a N>> + 'b,
     f: &mut JsFormatter<'_, 'a>,
@@ -19,6 +28,12 @@ pub fn write_array_node<'a, 'b, N>(
     let mut join = f.join_nodes_with_soft_line();
     let mut has_seen_elision = false;
 
+    // Position after the previous slot (the `[`, an element's separator `,`, or a hole's `,`),
+    // maintained so each hole's own `,` can be located in the source.
+    // Only holes read it, so it is refreshed lazily: when a hole is printed,
+    // and when an element knows a hole follows it.
+    let mut cursor = span.start;
+
     let mut array_iter = array.into_iter().enumerate().peekable();
 
     while let Some((index, element)) = array_iter.next() {
@@ -30,6 +45,46 @@ pub fn write_array_node<'a, 'b, N>(
 
         let is_disallow = matches!(separator_mode, TrailingSeparatorMode::Disallow);
         let is_force = matches!(separator_mode, TrailingSeparatorMode::Force);
+        let next_is_hole = array_iter.peek().is_some_and(|(_, next)| next.is_none());
+
+        // A hole owns the comments in its slot (between the previous `,` and its own `,`):
+        // they print as its leading comments, keeping their side of both commas
+        // (`[a, /* c */, b]` stays `[a, /* c */, b]`).
+        let hole_comma = if element.is_none() {
+            let comma = next_comma_position(
+                source_text,
+                join.fmt().comments().unprinted_comments(),
+                cursor,
+            );
+            if let Some(comma) = comma {
+                cursor = comma + 1;
+            }
+            comma
+        } else {
+            None
+        };
+
+        // A following hole's slot begins at the first same-line block comment behind this
+        // element's separator `,`; hide the slot from this element's trailing pass so its
+        // comments are not claimed backward across the separator.
+        // A same-line line comment stays trailing: it rides the separator on a `line_suffix`
+        // and never leaves its line (`[a, // c` stays `a, // c`).
+        let trailing_limit = if let Some(element) = element
+            && next_is_hole
+        {
+            let comments = join.fmt().comments().unprinted_comments();
+            next_comma_position(source_text, comments, element.span().end).and_then(|sep_comma| {
+                cursor = sep_comma + 1;
+                let hole_comma = next_comma_position(source_text, comments, cursor)?;
+                comments
+                    .iter()
+                    .filter(|c| c.span.start > sep_comma && c.span.end <= hole_comma)
+                    .find(|c| c.is_block() && !c.preceded_by_newline())
+                    .map(|c| c.span.start)
+            })
+        } else {
+            None
+        };
 
         join.entry(
             // Note(different-with-Biome): this implementation isn't the same as Biome, because its output doesn't exactly match Prettier.
@@ -37,29 +92,20 @@ pub fn write_array_node<'a, 'b, N>(
                 // Use fake span to avoid add any empty line between elision and expression element.
                 SPAN
             } else {
-                has_seen_elision = false;
                 element.map_or_else(
-                    || {
-                        // TODO: improve the `ArrayPattern` AST to simplify this logic.
-                        // Since `ArrayPattern` doesn't have a elision node, so that we have to find the comma position
-                        // by looking through the source text.
-                        let next_span =
-                            array_iter.peek().map_or(SPAN, |e| e.1.map_or(SPAN, GetSpan::span));
-
-                        let comma_position =
-                            source_text.bytes_to(next_span.start).position(|c| c == b',');
-
-                        // comma span
-                        #[expect(clippy::cast_possible_truncation)]
-                        comma_position
-                            .map_or(SPAN, |pos| Span::sized(next_span.start - pos as u32, 1))
-                    },
+                    || hole_comma.map_or(SPAN, |comma| Span::sized(comma, 1)),
                     GetSpan::span,
                 )
             },
             &format_once(|f| {
                 if let Some(element) = element {
-                    write!(f, group(&element));
+                    if let Some(limit) = trailing_limit {
+                        let saved = f.context_mut().comments_mut().limit_comments_up_to(limit);
+                        write!(f, group(&element));
+                        f.context_mut().comments_mut().restore_view_limit(saved);
+                    } else {
+                        write!(f, group(&element));
+                    }
 
                     if is_disallow {
                     } else if is_force || index != last_index {
@@ -69,11 +115,54 @@ pub fn write_array_node<'a, 'b, N>(
                     }
                 } else {
                     has_seen_elision = true;
+                    if let Some(comma) = hole_comma {
+                        write_hole_leading_comments(comma, f);
+                    }
                     write!(f, ",");
                 }
             }),
         );
     }
+}
+
+/// Prints the comments sitting in a hole's slot, right before the hole's `,`.
+fn write_hole_leading_comments(hole_comma: u32, f: &mut JsFormatter<'_, '_>) {
+    let comments = f.context().comments().comments_before(hole_comma);
+    let mut comments_iter = comments.iter().peekable();
+    while let Some(comment) = comments_iter.next() {
+        // Marks the comment printed; a line comment ends its line, so the `,` breaks below it.
+        FormatCommentBeforeContent::new(comment).fmt(f);
+        if comment.is_block() {
+            if f.source_text().has_line_terminator_after(comment.span.end) {
+                write!(f, hard_line_break());
+            } else if comments_iter.peek().is_some() {
+                write!(f, space());
+            }
+        }
+    }
+}
+
+/// Position of the first `,` at or after `pos` that is not inside a comment.
+fn next_comma_position(
+    source_text: SourceText<'_>,
+    comments: &[Comment],
+    mut pos: u32,
+) -> Option<u32> {
+    #[expect(clippy::cast_possible_truncation)]
+    let find = |start: u32, bytes: &[u8]| {
+        bytes.iter().position(|&b| b == b',').map(|offset| start + offset as u32)
+    };
+    for comment in comments {
+        if comment.span.end <= pos {
+            continue;
+        }
+        if let Some(comma) = find(pos, source_text.bytes_range(pos, comment.span.start)) {
+            return Some(comma);
+        }
+        pos = comment.span.end;
+    }
+    let text: &str = &source_text;
+    find(pos, &text.as_bytes()[pos as usize..])
 }
 
 /// Determines if a trailing separator should be inserted after an array element

--- a/crates/oxc_formatter/tests/fixtures/js/comments/array-holes.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/array-holes.js
@@ -11,3 +11,14 @@ const d = [,, // line
 ];
 // Comments trailing a real element are unaffected
 const e = [1, 2 /* t */];
+// A comment in a hole's slot leads the hole, keeping its side of both commas
+// (DIVERGENCES.md#array-hole-leading-comment: Prettier relocates it across a comma)
+;[f, /* repeatable */, optional] = params;
+const g = [1, /* c */, 3];
+const h = [1, /* c1 */, /* c2 */, 4];
+const i = [/* lead */, 2];
+const j = [1,
+  // own-line
+  , 3];
+// A comment before the separator still trails the element, the slot begins after the `,`
+const k = [1 /* t */, /* slot */, 3];

--- a/crates/oxc_formatter/tests/fixtures/js/comments/array-holes.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/array-holes.js.snap
@@ -15,6 +15,17 @@ const d = [,, // line
 ];
 // Comments trailing a real element are unaffected
 const e = [1, 2 /* t */];
+// A comment in a hole's slot leads the hole, keeping its side of both commas
+// (DIVERGENCES.md#array-hole-leading-comment: Prettier relocates it across a comma)
+;[f, /* repeatable */, optional] = params;
+const g = [1, /* c */, 3];
+const h = [1, /* c1 */, /* c2 */, 4];
+const i = [/* lead */, 2];
+const j = [1,
+  // own-line
+  , 3];
+// A comment before the separator still trails the element, the slot begins after the `,`
+const k = [1 /* t */, /* slot */, 3];
 
 ==================== Output ====================
 ------------------
@@ -31,6 +42,20 @@ const d = [
 ];
 // Comments trailing a real element are unaffected
 const e = [1, 2 /* t */];
+// A comment in a hole's slot leads the hole, keeping its side of both commas
+// (DIVERGENCES.md#array-hole-leading-comment: Prettier relocates it across a comma)
+[f, /* repeatable */, optional] = params;
+const g = [1, /* c */, 3];
+const h = [1, /* c1 */, /* c2 */, 4];
+const i = [/* lead */, 2];
+const j = [
+  1,
+  // own-line
+  ,
+  3,
+];
+// A comment before the separator still trails the element, the slot begins after the `,`
+const k = [1 /* t */, /* slot */, 3];
 
 -------------------
 { printWidth: 100 }
@@ -46,5 +71,19 @@ const d = [
 ];
 // Comments trailing a real element are unaffected
 const e = [1, 2 /* t */];
+// A comment in a hole's slot leads the hole, keeping its side of both commas
+// (DIVERGENCES.md#array-hole-leading-comment: Prettier relocates it across a comma)
+[f, /* repeatable */, optional] = params;
+const g = [1, /* c */, 3];
+const h = [1, /* c1 */, /* c2 */, 4];
+const i = [/* lead */, 2];
+const j = [
+  1,
+  // own-line
+  ,
+  3,
+];
+// A comment before the separator still trails the element, the slot begins after the `,`
+const k = [1 /* t */, /* slot */, 3];
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -3,12 +3,13 @@ source: crates/oxc_formatter/tests/conformance.rs
 assertion_line: 172
 expression: report
 ---
-js compatibility: 765/810 (94.44%), 23 files skipped
+js compatibility: 764/810 (94.32%), 23 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| js/arrays/numbers-with-holes.js | 💥 | 92.86% |
 | js/arrows/arrow-chain-with-trailing-comments.js | 💥💥 | 93.75% |
 | js/arrows/issue-17421.js | 💥💥 | 88.70% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
@@ -84,7 +85,6 @@ js compatibility: 765/810 (94.44%), 23 files skipped
 # Not idempotent
 
 - js/arrays/numbers-negative-comment-after-minus.js
-- js/arrays/numbers-with-holes.js
 - js/comments/return-statement.js
 - js/comments/first-argument/first-argument.js
 - js/for/continue-and-break-comment-without-blocks.js


### PR DESCRIPTION
A comment sitting in an array hole's slot (between the previous `,` and the hole's own `,`) was relocated across a comma: backward onto the previous element in patterns/assignment targets
(`[a, /* c */, b] = x` -> `[a /* c */, , b] = x`), or forward past the hole's comma in array expressions (`[1, /* c */, 3]` -> `[1, , /* c */ 3]`).

Print such comments as the hole's leading comments instead, keeping their side of both commas, and hide the slot from the previous element's trailing pass so it cannot claim them backward. A same-line line comment after the separator still rides it (`[a, // c`), and comments after a trailing hole still print as dangling comments.

This also makes `js/arrays/numbers-with-holes.js` idempotent; its remaining mismatch is pinned as DIVERGENCES.md#array-hole-leading-comment.

Closes #22799