### PR TITLE
docs(transformer): document ES2015 target floor

### DIFF
--- a/crates/oxc_transformer/AGENTS.md
+++ b/crates/oxc_transformer/AGENTS.md
@@ -1,5 +1,16 @@
 # Coding agent guides for `crates/oxc_transformer`
 
+## Supported output target
+
+Oxc Transformer lowers modern JavaScript to ES2015 (ES6) syntax. It does not
+generate complete ES5 output, and `es5` is rejected as a target.
+
+A target for an older runtime may still enable the transforms Oxc implements,
+but the result is not guaranteed to run in a pre-ES2015 environment. Before
+treating target-dependent behavior as a regression, verify that public target
+selection can produce the transform combination. Conformance fixtures that
+enable plugins directly may create unsupported combinations.
+
 ## Testing transformer behavior
 
 Most transformer behavior regressions should be tested through transform conformance fixtures, not Rust integration tests in this crate.

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -117,9 +117,10 @@ impl TransformOptions {
         }
     }
 
-    /// Initialize from a comma separated list of `target`s and `environmens`s.
+    /// Initialize from a comma-separated list of targets and environments.
     ///
-    /// e.g. `es2022,chrome58,edge16`.
+    /// For example, `es2022,chrome58,edge16`.
+    /// See [`Self::from_target_list`] for supported target values.
     ///
     /// # Errors
     ///
@@ -130,11 +131,15 @@ impl TransformOptions {
         EnvOptions::from_target(s).map(|env| Self { env, ..Self::default() })
     }
 
-    /// Initialize from a list of `target`s and `environmens`s.
+    /// Initialize from a list of targets and environments.
     ///
-    /// e.g. `["es2020", "chrome58", "edge16", "firefox57", "node12", "safari11"]`.
+    /// For example, `["es2020", "chrome58", "edge16", "firefox57", "node12", "safari11"]`.
     ///
-    /// `target`: `es5`, `es2015` ... `es2024`, `esnext`.
+    /// The minimum supported ECMAScript target is `es2015`. Targets for older runtimes
+    /// may still enable available transforms, but do not guarantee fully compatible
+    /// pre-ES2015 output.
+    ///
+    /// `target`: `es2015` ... `es2024`, `esnext`.
     /// `environment`: `chrome`, `deno`, `edge`, `firefox`, `hermes`, `ie`, `ios`, `node`, `opera`, `rhino`, `safari`
     ///
     /// <https://esbuild.github.io/api/#target>


### PR DESCRIPTION
Oxc Transformer supports output down to ES2015, but the contributor guidance
did not state that floor and the Rust API docs still listed `es5`. This made
plugin-only transform combinations look like supported target configurations.

Document the ES2015 floor and require target-dependent regressions to be
reproducible through public target selection. Legacy runtime targets may still
select available transforms, but do not imply complete compatibility with
pre-ES2015 engines.

Stacked on #26326.

Verified with `cargo fmt --check`, `just doc`, and
`cargo test -p oxc_transformer`. `just ready` completed formatting and workspace
checks, but stopped in the test phase on the existing Node-version-only
`stacktrace_is_correct` snapshot difference (`v25.8.1` locally versus `v26.5.0`
recorded).

AI assistance was used to investigate the documentation gap, edit the guidance,
and run verification. I remain responsible for reviewing and understanding the
changes before merge.