### PR TITLE
docs(ci): discourage speculative compiler errors in copilot AI PR reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,7 @@
 
 When reviewing pull requests in this repository:
 
+- Do not guess or infer compiler errors. Only report them when supported by actual compiler diagnostics.
 - Treat files inside any `fixtures` directories as test data, not production code.
 - Fixture files may intentionally contain buggy, unsafe, or syntactically invalid code to validate parser/linter/transformer behavior.
 - Do not report normal code-quality or correctness issues for fixture files.


### PR DESCRIPTION
Prompted by [this Copilot review comment](https://github.com/oxc-project/oxc/pull/26386#discussion_r3948410351), which incorrectly claimed a variant check moves a non-`Copy` field out of a borrow. The wildcard pattern does not bind or move the payload. All code is tested/checked in CI, so a compile error should fail there.
