### PR TITLE
fix(linter/unicorn/numeric-separators-style): correct schema defaults

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -6844,12 +6844,48 @@ export interface NumericSeparatorsStyleConfig {
    * Configuration for binary literals (e.g. `0b1010_0001` and bigint variants).
    * Controls how digits are grouped and when separators are applied.
    */
-  binary?: NumericBaseConfig;
+  binary?: {
+    /**
+     * The number of digits per group when inserting numeric separators.
+     * For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
+     */
+    groupLength?: number;
+    /**
+     * The minimum number of digits required before grouping is applied.
+     * Values with fewer digits than this threshold will not be grouped.
+     */
+    minimumDigits?: number;
+    /**
+     * Only enforce the rule when the numeric literal already contains a separator (`_`).
+     *
+     * When `true`, numbers without separators are left as-is; when `false` (default),
+     * grouping will be enforced for eligible numbers even if they don't include separators yet.
+     */
+    onlyIfContainsSeparator?: boolean;
+  };
   /**
    * Configuration for hexadecimal literals (e.g. `0xAB_CD`, `0Xab_cd`, and bigint variants).
    * Controls how digits are grouped and when separators are applied.
    */
-  hexadecimal?: NumericBaseConfig;
+  hexadecimal?: {
+    /**
+     * The number of digits per group when inserting numeric separators.
+     * For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
+     */
+    groupLength?: number;
+    /**
+     * The minimum number of digits required before grouping is applied.
+     * Values with fewer digits than this threshold will not be grouped.
+     */
+    minimumDigits?: number;
+    /**
+     * Only enforce the rule when the numeric literal already contains a separator (`_`).
+     *
+     * When `true`, numbers without separators are left as-is; when `false` (default),
+     * grouping will be enforced for eligible numbers even if they don't include separators yet.
+     */
+    onlyIfContainsSeparator?: boolean;
+  };
   /**
    * Configuration for decimal numbers (integers, fraction parts, and exponents).
    * Controls how digits are grouped and when separators are applied.
@@ -6859,26 +6895,25 @@ export interface NumericSeparatorsStyleConfig {
    * Configuration for octal literals (e.g. `0o1234_5670` and bigint variants).
    * Controls how digits are grouped and when separators are applied.
    */
-  octal?: NumericBaseConfig;
-  /**
-   * Only enforce the rule when the numeric literal already contains a separator (`_`).
-   *
-   * When `true`, numbers without separators are left as-is; when `false` (default),
-   * grouping will be enforced for eligible numbers even if they don't include separators yet.
-   */
-  onlyIfContainsSeparator?: boolean;
-}
-export interface NumericBaseConfig {
-  /**
-   * The number of digits per group when inserting numeric separators.
-   * For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
-   */
-  groupLength?: number;
-  /**
-   * The minimum number of digits required before grouping is applied.
-   * Values with fewer digits than this threshold will not be grouped.
-   */
-  minimumDigits?: number;
+  octal?: {
+    /**
+     * The number of digits per group when inserting numeric separators.
+     * For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
+     */
+    groupLength?: number;
+    /**
+     * The minimum number of digits required before grouping is applied.
+     * Values with fewer digits than this threshold will not be grouped.
+     */
+    minimumDigits?: number;
+    /**
+     * Only enforce the rule when the numeric literal already contains a separator (`_`).
+     *
+     * When `true`, numbers without separators are left as-is; when `false` (default),
+     * grouping will be enforced for eligible numbers even if they don't include separators yet.
+     */
+    onlyIfContainsSeparator?: boolean;
+  };
   /**
    * Only enforce the rule when the numeric literal already contains a separator (`_`).
    *

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -30,12 +30,15 @@ pub struct NumericSeparatorsStyleConfig {
     only_if_contains_separator: bool,
     /// Configuration for hexadecimal literals (e.g. `0xAB_CD`, `0Xab_cd`, and bigint variants).
     /// Controls how digits are grouped and when separators are applied.
+    #[schemars(schema_with = "NumericBaseConfig::schema_with_defaults::<2, 0>")]
     hexadecimal: NumericBaseConfig,
     /// Configuration for binary literals (e.g. `0b1010_0001` and bigint variants).
     /// Controls how digits are grouped and when separators are applied.
+    #[schemars(schema_with = "NumericBaseConfig::schema_with_defaults::<4, 0>")]
     binary: NumericBaseConfig,
     /// Configuration for octal literals (e.g. `0o1234_5670` and bigint variants).
     /// Controls how digits are grouped and when separators are applied.
+    #[schemars(schema_with = "NumericBaseConfig::schema_with_defaults::<4, 0>")]
     octal: NumericBaseConfig,
     /// Configuration for decimal numbers (integers, fraction parts, and exponents).
     /// Controls how digits are grouped and when separators are applied.
@@ -92,6 +95,20 @@ struct NumericBaseConfig {
 }
 
 impl NumericBaseConfig {
+    // The shared type's defaults differ from the defaults for each numeric base.
+    fn schema_with_defaults<const GROUP_LENGTH: u32, const MINIMUM_DIGITS: u32>(
+        generator: &mut SchemaGenerator,
+    ) -> Schema {
+        let mut schema = Self::json_schema(generator).into_object();
+        let properties = &mut schema.object.as_mut().unwrap().properties;
+        for (name, value) in [("groupLength", GROUP_LENGTH), ("minimumDigits", MINIMUM_DIGITS)] {
+            if let Schema::Object(property) = properties.get_mut(name).unwrap() {
+                property.metadata().default = Some(value.into());
+            }
+        }
+        schema.into()
+    }
+
     pub(self) fn set_numeric_base_from_config(&mut self, val: &serde_json::Value) {
         if let Some(group_length) = val.get("groupLength").and_then(serde_json::Value::as_u64) {
             self.group_length = u32::try_from(group_length).unwrap();
@@ -110,6 +127,7 @@ impl NumericBaseConfig {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct NumericNumberConfig {
     #[serde(flatten)]
+    #[schemars(schema_with = "NumericBaseConfig::schema_with_defaults::<3, 5>")]
     base: NumericBaseConfig,
     /// The size a group of digits in the fractional part (after the decimal point) should be.
     fraction_group_length: u32,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -16537,33 +16537,6 @@
         }
       ]
     },
-    "NumericBaseConfig": {
-      "type": "object",
-      "properties": {
-        "groupLength": {
-          "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
-          "default": 0,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
-        },
-        "minimumDigits": {
-          "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
-          "default": 0,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
-        },
-        "onlyIfContainsSeparator": {
-          "description": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet.",
-          "type": "boolean",
-          "markdownDescription": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet."
-        }
-      },
-      "additionalProperties": false
-    },
     "NumericNumberConfig": {
       "type": "object",
       "properties": {
@@ -16577,7 +16550,7 @@
         },
         "groupLength": {
           "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
-          "default": 0,
+          "default": 3,
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0,
@@ -16585,7 +16558,7 @@
         },
         "minimumDigits": {
           "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
-          "default": 0,
+          "default": 5,
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0,
@@ -16608,11 +16581,31 @@
             "groupLength": 4,
             "minimumDigits": 0
           },
-          "allOf": [
-            {
-              "$ref": "#/definitions/NumericBaseConfig"
+          "type": "object",
+          "properties": {
+            "groupLength": {
+              "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
+              "default": 4,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
+            },
+            "minimumDigits": {
+              "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
+              "default": 0,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
+            },
+            "onlyIfContainsSeparator": {
+              "description": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet.",
+              "type": "boolean",
+              "markdownDescription": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet."
             }
-          ],
+          },
+          "additionalProperties": false,
           "markdownDescription": "Configuration for binary literals (e.g. `0b1010_0001` and bigint variants).\nControls how digits are grouped and when separators are applied."
         },
         "hexadecimal": {
@@ -16621,11 +16614,31 @@
             "groupLength": 2,
             "minimumDigits": 0
           },
-          "allOf": [
-            {
-              "$ref": "#/definitions/NumericBaseConfig"
+          "type": "object",
+          "properties": {
+            "groupLength": {
+              "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
+              "default": 2,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
+            },
+            "minimumDigits": {
+              "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
+              "default": 0,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
+            },
+            "onlyIfContainsSeparator": {
+              "description": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet.",
+              "type": "boolean",
+              "markdownDescription": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet."
             }
-          ],
+          },
+          "additionalProperties": false,
           "markdownDescription": "Configuration for hexadecimal literals (e.g. `0xAB_CD`, `0Xab_cd`, and bigint variants).\nControls how digits are grouped and when separators are applied."
         },
         "number": {
@@ -16643,11 +16656,31 @@
             "groupLength": 4,
             "minimumDigits": 0
           },
-          "allOf": [
-            {
-              "$ref": "#/definitions/NumericBaseConfig"
+          "type": "object",
+          "properties": {
+            "groupLength": {
+              "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
+              "default": 4,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
+            },
+            "minimumDigits": {
+              "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
+              "default": 0,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
+            },
+            "onlyIfContainsSeparator": {
+              "description": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet.",
+              "type": "boolean",
+              "markdownDescription": "Only enforce the rule when the numeric literal already contains a separator (`_`).\n\nWhen `true`, numbers without separators are left as-is; when `false` (default),\ngrouping will be enforced for eligible numbers even if they don't include separators yet."
             }
-          ],
+          },
+          "additionalProperties": false,
           "markdownDescription": "Configuration for octal literals (e.g. `0o1234_5670` and bigint variants).\nControls how digits are grouped and when separators are applied."
         },
         "onlyIfContainsSeparator": {


### PR DESCRIPTION
## Summary

Fix the generated defaults for `unicorn/numeric-separators-style`. The rule already uses `number.minimumDigits: 5`, matching Unicorn, but the generated documentation and JSON schema advertise `0`. The same schema issue also advertises `groupLength: 0` for every numeric base.

## Why the defaults are wrong

`NumericBaseConfig` is shared by binary, hexadecimal, octal, and decimal configuration. Its derived `Default` initializes both numeric fields to zero. The rule supplies the actual defaults in `NumericSeparatorsStyleConfig::default()` and `NumericNumberConfig::default()`.

Schema generation uses the shared type's defaults for its individual properties. In particular, flattening `NumericBaseConfig` into `NumericNumberConfig` preserves the zero-valued property defaults instead of the decimal defaults. This makes the documented threshold disagree with the rule's existing behavior:

```js
1234;   // Allowed with the default configuration.
12345;  // Reported; the fix is 12_345.
```

## Change

Add a single parameterized schema helper for `NumericBaseConfig`, then select the appropriate defaults with `schemars(schema_with = ...)` on each field. The helper retains the derived schema's property descriptions, types, and constraints, and overrides only the `groupLength` and `minimumDigits` default metadata.

The resulting defaults are:

| Configuration | `groupLength` | `minimumDigits` |
| --- | --- | --- |
| `binary` | 4 | 0 |
| `hexadecimal` | 2 | 0 |
| `octal` | 4 | 0 |
| `number` | 3 | 5 |

The schema annotation on the flattened decimal base also corrects `number.minimumDigits`. `number.fractionGroupLength` remains unchanged, and the documentation continues to display its default as `Infinity`.

Regenerate the JSON configuration schema and the TypeScript configuration types from it. The generated TypeScript types inline the binary, hexadecimal, and octal option objects because those properties now have individual schemas; their accepted configuration shapes are unchanged.

This changes schema and documentation metadata only. Runtime defaults, option parsing, diagnostics, and autofixes are unchanged.

Fixes #26391
