### PR TITLE
fix(oxfmt): keep a Fill's entries as separate Prettier Doc parts

### DIFF
--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -371,6 +371,23 @@ fn convert_elements(
                     }
                     printer.pending_space = false;
                 }
+                // A `Fill`'s children are its `parts`, and Prettier requires that to be the
+                // flat, alternating content/separator list. Pushing a `_REF` here would make the
+                // whole entry list a *single* part; on the JS side that ref expands to an array,
+                // leaving `parts: [[content, line, content, ...]]`. Prettier's `cleanDoc()` then
+                // collapses `parts.length === 1` to `parts[0]`, discarding the fill entirely and
+                // leaving a bare `line` inside a broken group, which always breaks. So inline the
+                // interned content into the fill instead of sharing it, keeping each entry its
+                // own part.
+                if matches!(
+                    stack.last().and_then(|entry| entry.start_info.as_ref()),
+                    Some(StartTagInfo::Fill)
+                ) {
+                    let converted = convert_shared_elements(interned, state)?;
+                    current_children_mut(&mut stack)?.extend(converted);
+                    printer.line = LineState::Content;
+                    continue;
+                }
                 let key = interned_cache_key(interned);
                 let id = if let Some(&id) = state.interned_to_ref.get(&key) {
                     id

--- a/apps/oxfmt/test/api/js-in-vue.test.ts
+++ b/apps/oxfmt/test/api/js-in-vue.test.ts
@@ -276,6 +276,67 @@ const f = () => {
     expect(result2.errors).toStrictEqual([]);
   });
 
+  // https://github.com/oxc-project/oxc/issues/26398
+  it("should keep JSX text filled when the element has multiple attributes", async () => {
+    // A `Fill`'s children are its `parts`, which Prettier requires to be the flat, alternating
+    // content/separator list. Interning them emits a single `_REF` that expands to an array, so
+    // `parts` becomes `[[...]]`; `cleanDoc()` then collapses `parts.length === 1` to `parts[0]`,
+    // dropping the fill and leaving a bare `line` inside a broken group. That always breaks, so
+    // every word landed on its own line. Only elements with 2+ attributes take the path that
+    // builds a fill, hence the two attributes here.
+    const input = `
+<script setup lang="tsx">
+defineRender(
+  <div>
+    <label for="d" class={[c]}>
+      Payment date
+    </label>
+  </div>,
+);
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    expect(result.code).toContain("Payment date");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  // https://github.com/oxc-project/oxc/issues/26398
+  it("should reflow long JSX text at printWidth rather than one word per line", async () => {
+    // Guards the fill semantics themselves, not just that the words stay joined:
+    // the text must wrap where it exceeds `printWidth`.
+    const input = `
+<script setup lang="tsx">
+defineRender(
+  <div>
+    <label for="d" class={[c]}>
+      This will create a new survey for this audience. Are you sure you want to continue today?
+    </label>
+  </div>,
+);
+</script>
+`;
+    const result = await format("a.vue", input, { printWidth: 80 });
+
+    // Format again to verify idempotency
+    const result2 = await format("a.vue", result.code, { printWidth: 80 });
+
+    expect(result.code).toBe(`<script setup lang="tsx">
+defineRender(
+  <div>
+    <label for="d" class={[c]}>
+      This will create a new survey for this audience. Are you sure you want to
+      continue today?
+    </label>
+  </div>,
+);
+</script>
+`);
+    expect(result.errors).toStrictEqual([]);
+    expect(result2.code).toBe(result.code);
+    expect(result2.errors).toStrictEqual([]);
+  });
+
   it("should not indent a comment-only script block", async () => {
     // The comment's leading IR `Space` must be dropped at the line start,
     // like the Rust printer does, or `/**` gains a spurious leading space.


### PR DESCRIPTION
Closes #26398.

## Problem

In a Vue SFC with `<script setup lang="tsx">`, JSX text is broken onto one word per line when the enclosing element has two or more attributes, at any `printWidth`. The same JSX in a `.tsx` file is fine.

```vue
<script setup lang="tsx">
defineRender(
  <div>
    <label for="d" class={[c]}>
      Please
      enter
      the
      scheduled
      payment
      date
      below
    </label>
  </div>,
);
</script>
```

## Cause

A `Fill`'s children become its `parts`, and Prettier requires `parts` to be the flat, alternating content/separator list.

When the fill's entries are interned, `FormatElement::Interned` pushes a single `{"_REF": id}` into the fill's children, so `parts` has length 1. On the JS side `resolveRefs()` expands that ref to the entry array, leaving:

```json
{"type": "fill", "parts": [["Payment", {"type": "line"}, "date"]]}
```

For `.vue`, Prettier applies `stripTrailingHardline` → `cleanDoc` to the embedded doc, and `cleanDocFn` collapses a degenerate one-part fill:

```js
case DOC_TYPE_FILL: {
  const { parts } = doc;
  if (parts.every((part) => part === "")) return "";
  if (parts.length === 1) return parts[0];   // fill wrapper discarded
  break;
}
```

The array is spliced into its parent, so the printer sees a bare `line` inside a group with `break: true`. That always breaks, so no per-word measurement survives — hence one word per line regardless of width.

`.tsx` files never reach this converter, and oxc's own printer renders a one-part fill correctly, so the malformed doc only becomes observable on the embedded path. The attribute count is just a selector for which form is emitted: with 0–1 attributes the element prints as a single flat group containing no fill at all.

## Fix

Inline interned content directly into a `Fill` rather than sharing it by ref, so each entry stays its own part. Sharing is the wrong trade here — a fill's parts carry structural meaning that a single ref erases.

The check is on the immediate parent frame, so an `Interned` inside a `StartEntry` is untouched and still interned normally; only a `Fill`'s direct children are inlined.

## Tests

Two cases in `apps/oxfmt/test/api/js-in-vue.test.ts`:

- text stays filled when the element has multiple attributes
- long text reflows at `printWidth` rather than one word per line, and is idempotent

The second matters because it pins the fill semantics themselves — a fix that merely joined the words would pass the first test but still be wrong.

## Verification

- `apps/oxfmt` vitest: 16/16 in `js-in-vue.test.ts`, 469 passing overall
- `pnpm --filter ./apps/oxfmt conformance`: **snapshots unchanged** — no existing output moves
- `cargo test -p oxfmt`: 84 passed
- `cargo clippy -p oxfmt --all-targets --all-features` with `CARGO_BUILD_WARNINGS=deny`: clean
- `cargo fmt -p oxfmt -- --check`: clean

Two snapshot failures in `test/cli/cli.test.ts > vite_plus` reproduce on an unmodified checkout of this commit's base, so they are pre-existing and unrelated — the placeholder `<Vite+ diagnostic>` is not matching a locally-produced rolldown `UNRESOLVED_IMPORT` message.

## AI usage disclosure

Per the AI usage policy in `CONTRIBUTING.md`: I used Claude to help diagnose and implement this. The investigation was empirical — bisecting oxfmt versions to find the 0.62.0 boundary, then instrumenting the bundled Prettier to trace where the fill was lost (`cleanDoc: fills 1 -> 0`) and dumping the Doc IR at the `textToDoc` boundary to confirm the `parts: [{"_REF": n}]` shape. I have reviewed the change and run the tests locally.
