### PR TITLE
fix(parser): reject rest parameters in getters

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -775,7 +775,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn check_getter(&mut self, function: &Function<'a>) {
         if let Some(type_parameters) = &function.type_parameters {
             self.error(diagnostics::accessor_cannot_have_type_parameters(type_parameters.span));
-        } else if !function.params.items.is_empty() {
+        } else if function.params.parameters_count() != 0 {
             self.error(diagnostics::getter_parameters(function.params.span));
         }
     }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1423,7 +1423,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         match kind {
             TSMethodSignatureKind::Get => {
-                if !params.items.is_empty() {
+                if params.parameters_count() != 0 {
                     self.error(diagnostics::getter_parameters(params.span));
                 }
             }

--- a/tasks/coverage/misc/fail/getter-rest-parameter.ts
+++ b/tasks/coverage/misc/fail/getter-rest-parameter.ts
@@ -1,0 +1,4 @@
+class C { get x(...args) {} }
+({ get x(...args) {} });
+interface I { get x(...args: any[]): string }
+type T = { get x(...args: any[]): string };

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 273/273 (100.00%)
-Positive Passed: 273/273 (100.00%)
+AST Parsed     : 274/274 (100.00%)
+Positive Passed: 274/274 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 86/86 (100.00%)
 Positive Passed: 86/86 (100.00%)
-Negative Passed: 187/187 (100.00%)
+Negative Passed: 188/188 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -454,6 +454,40 @@ Negative Passed: 187/187 (100.00%)
  1 │ export {} from "
    ·                ──
    ╰────
+
+  × A 'get' accessor must not have any formal parameters.
+   ╭─[misc/fail/getter-rest-parameter.ts:1:16]
+ 1 │ class C { get x(...args) {} }
+   ·                ─────────
+ 2 │ ({ get x(...args) {} });
+   ╰────
+  help: Remove these parameters here
+
+  × A 'get' accessor must not have any formal parameters.
+   ╭─[misc/fail/getter-rest-parameter.ts:2:9]
+ 1 │ class C { get x(...args) {} }
+ 2 │ ({ get x(...args) {} });
+   ·         ─────────
+ 3 │ interface I { get x(...args: any[]): string }
+   ╰────
+  help: Remove these parameters here
+
+  × A 'get' accessor must not have any formal parameters.
+   ╭─[misc/fail/getter-rest-parameter.ts:3:20]
+ 2 │ ({ get x(...args) {} });
+ 3 │ interface I { get x(...args: any[]): string }
+   ·                    ────────────────
+ 4 │ type T = { get x(...args: any[]): string };
+   ╰────
+  help: Remove these parameters here
+
+  × A 'get' accessor must not have any formal parameters.
+   ╭─[misc/fail/getter-rest-parameter.ts:4:17]
+ 3 │ interface I { get x(...args: any[]): string }
+ 4 │ type T = { get x(...args: any[]): string };
+   ·                 ────────────────
+   ╰────
+  help: Remove these parameters here
 
   × HTML comments are not allowed in modules
    ╭─[misc/fail/html-comment-in-module.mjs:1:1]


### PR DESCRIPTION
## Summary

Getter accessors must have no formal parameters, but Oxc currently accepts a getter whose only parameter is a rest parameter. This affects class and object getters, as well as getter signatures in TypeScript interfaces and type literals.

```ts
class C { get x(...args) {} }
({ get x(...args) {} });
interface I { get x(...args: any[]): string }
type T = { get x(...args: any[]): string };
```

Each declaration above previously parsed without a diagnostic. It now reports the existing error: `A 'get' accessor must not have any formal parameters.`

## Cause and correction

`FormalParameters` stores ordinary parameters in `items` and the rest parameter separately in `rest`. Both getter checks inspected only whether `items` was empty, so a rest-only parameter list looked like a zero-parameter list.

Use `parameters_count() != 0` in both checks so the count includes the rest parameter. The shared `check_getter` path covers class and object getters; `parse_getter_setter_signature_member` covers interface and type-literal getter signatures.

The diagnostic still points at the full parameter list. Zero-parameter getters remain valid, ordinary getter parameters retain their existing diagnostic, and class/object accessors with type parameters retain the current type-parameter diagnostic precedence. Setter validation is unchanged.
