### PR TITLE
perf(ci): skip Miri cache setup when checks are skipped

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -50,6 +50,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        if: steps.filter.outputs.changed == 'true'
         with:
           path: /home/runner/.rustup
           cache: rust


### PR DESCRIPTION
Skip Namespace Rust cache setup when change detection skips the Miri checks, avoiding unnecessary cache initialization.
