### PR TITLE
fix(packages/codegen): print accessibility modifiers before abstract

### DIFF
--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -393,15 +393,15 @@ function printAccessorProperty(node: AccessorPropertyNode, state: State): void {
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
 
-  if (TS && (node.type === "TSAbstractAccessorProperty" || node.abstract)) {
-    printSpaceBeforeIdentifier(state);
-    write(state, "abstract ", CAT_OTHER);
-  }
-
   if (TS && node.accessibility != null) {
     printSpaceBeforeIdentifier(state);
     writeNoLast(state, node.accessibility);
     write(state, " ", CAT_OTHER);
+  }
+
+  if (TS && (node.type === "TSAbstractAccessorProperty" || node.abstract)) {
+    printSpaceBeforeIdentifier(state);
+    write(state, "abstract ", CAT_OTHER);
   }
 
   if (node.static) {

--- a/packages/codegen/test/fixtures/abstract-accessor-modifiers.ts
+++ b/packages/codegen/test/fixtures/abstract-accessor-modifiers.ts
@@ -1,0 +1,16 @@
+abstract class C extends B {
+  public abstract accessor x: number;
+  protected abstract accessor y: string;
+  public abstract override accessor z: number;
+  protected abstract override accessor w: string;
+  abstract accessor a: number;
+}
+
+class D extends B {
+  public static accessor x = 1;
+  protected static accessor y = 1;
+  private accessor z = 1;
+  public override accessor w = 1;
+  accessor #a = 1;
+  public accessor b!: number;
+}


### PR DESCRIPTION
`packages/codegen` emits invalid TypeScript for abstract accessors with an explicit accessibility modifier. The JavaScript printer writes `abstract` before `public` or `protected`, but TypeScript requires accessibility to come first and reports TS1029 for the generated declaration.

For example, this valid input:

```ts
abstract class C {
  public abstract accessor x: number;
  protected abstract accessor y: string;
}
```

was printed as:

```ts
abstract class C {
  abstract public accessor x: number;
  abstract protected accessor y: string;
}
```

The printer now preserves the valid modifier order:

```ts
abstract class C {
  public abstract accessor x: number;
  protected abstract accessor y: string;
}
```

`printAccessorProperty` now emits accessibility before `abstract`, matching the neighboring method and property printers. The same ordering also handles declarations such as `protected abstract override accessor x: number` and applies to both the ordinary and source-map-enabled builds.

This brings the JavaScript printer in line with the Rust codegen correction in #26392. The change is confined to accessor modifier ordering; subsequent `static`, `override`, and `accessor` emission and source-map anchoring retain their existing behavior.
