### PR TITLE
refactor(lexer): move `carve` implementation selection out of `lex_raw`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/carve/js.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/js.rs
@@ -8,7 +8,7 @@ use super::super::{
 
 use super::common::{lex_slash, lex_string, lex_template_segment, skip_unicode_brace_escape};
 
-pub unsafe fn carve(
+pub(super) unsafe fn carve_js(
     t: &Tables,
     srcs: &[u8],
     n: usize,

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
@@ -71,7 +71,7 @@ enum JFrameKind {
 /// start byte keeps its `st` bit yet may be a digit/keyword/operator char,
 /// so those bits are cleared there to keep `coalesce` and `keywords` from
 /// re-interpreting it.
-pub unsafe fn carve_jsx(
+pub(super) unsafe fn carve_jsx(
     t: &Tables,
     srcs: &[u8],
     n: usize,

--- a/crates/oxc_lexer/src/pipeline/carve/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/mod.rs
@@ -1,6 +1,31 @@
+use crate::{lanes::Lanes, tables::Tables};
+
 mod common;
 mod js;
 mod jsx;
 
-pub use js::carve;
-pub use jsx::carve_jsx;
+use js::carve_js;
+use jsx::carve_jsx;
+
+#[inline]
+pub unsafe fn carve(
+    t: &Tables,
+    srcs: &[u8],
+    n: usize,
+    st: *mut u64,
+    kind: *mut u8,
+    opch: *mut u64,
+    word: *const u64,
+    digit: *mut u64,
+    dot: *mut u64,
+    kwinit: *mut u64,
+    jsx: bool,
+    ts: bool,
+    lanes: &mut Lanes,
+) {
+    if jsx {
+        carve_jsx(t, srcs, n, st, kind, opch, word, digit, dot, kwinit, ts, lanes);
+    } else {
+        carve_js(t, srcs, n, st, kind, opch, word, digit, ts, lanes);
+    }
+}

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -29,7 +29,7 @@ use crate::tables::Tables;
 use crate::token::SPAN_SENTINELS;
 
 use bitmap::bm_any;
-use carve::{carve, carve_jsx};
+use carve::carve;
 use classify::{classify, misc_post, misc_pre};
 use coalesce::coalesce;
 use compress::{build_spans, compress, lanes_post, write_sentinels};
@@ -222,11 +222,7 @@ impl Lexer {
                 misc_pre::<false>(sp, n, st, word, misc, kind, &mut self.lanes)
             };
         }
-        if jsx {
-            carve_jsx(t, src, n, st, kind, opch, word, digit, dot, kwinit, ts, &mut self.lanes);
-        } else {
-            carve(t, src, n, st, kind, opch, word, digit, ts, &mut self.lanes);
-        }
+        carve(t, src, n, st, kind, opch, word, digit, dot, kwinit, jsx, ts, &mut self.lanes);
         coalesce(t, kws, sp, n, st, opch, word, digit, dot, kwinit, kind, kwpos, &mut self.lanes);
         if nesc != 0 {
             misc_post(sp, n, st, word, misc, kind);


### PR DESCRIPTION
Pure refactor.

`carve` has 2 different implementations for JS and JSX. Move selecting which to use to within the `carve` module, to make `lex_raw` clearer to read.

`carve` function is marked `#[inline]` so this should make no difference whatsoever to codegen.