### PR TITLE
refactor(lexer): group `coalesce` pipeline stage code into directory

### DIFF
--- a/crates/oxc_lexer/src/pipeline/coalesce/keywords.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/keywords.rs
@@ -1,18 +1,28 @@
 use crate::opmap::KwSet;
 
-use super::IDENT;
+use super::super::IDENT;
 
-pub(super) const KWB: usize = 64;
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+pub const KWB: usize = 64;
+
+/// Dispatch to the key-monomorphized verify without duplicating `coalesce`
+/// itself: one predictable branch per flush, not per candidate, keyed off
+/// the set itself so the walk carries no extra mode scalar.
 #[inline(always)]
-fn bzhi(x: u64, n: u32) -> u64 {
-    unsafe { core::arch::x86_64::_bzhi_u64(x, n) }
+pub(super) unsafe fn kw_flush(
+    kw: &KwSet,
+    src: *const u8,
+    word: *const u64,
+    kind: *mut u8,
+    kwpos: *const u32,
+    k: usize,
+) {
+    if kw.ts_key {
+        kw_verify_batch::<true>(kw, src, word, kind, kwpos, k);
+    } else {
+        kw_verify_batch::<false>(kw, src, word, kind, kwpos, k);
+    }
 }
-#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
-#[inline(always)]
-fn bzhi(x: u64, n: u32) -> u64 {
-    x & (u64::MAX >> (64 - n))
-}
+
 /// Resolve a batch of keyword candidates (positions collected by
 /// `coalesce`): exact match against the perfect-hash tables, patching
 /// `kind` from IDENT to the keyword kind on hit. `TS_KEY` selects the
@@ -21,7 +31,7 @@ fn bzhi(x: u64, n: u32) -> u64 {
 /// Kept out of line: inlining would double both variants into each of
 /// coalesce's flush sites, and one call per KWB words is free.
 #[inline(never)]
-pub(super) unsafe fn kw_verify_batch<const TS_KEY: bool>(
+unsafe fn kw_verify_batch<const TS_KEY: bool>(
     kw: &KwSet,
     src: *const u8,
     word: *const u64,
@@ -56,5 +66,18 @@ pub(super) unsafe fn kw_verify_batch<const TS_KEY: bool>(
         // literal interior and JSX start from the masks), so the incumbent
         // kind is IDENT: select over it instead of a read-modify-write.
         *kind.add(p) = (IDENT & !hm) | (kw.kwh_kind[h] & hm);
+    }
+}
+
+#[inline(always)]
+fn bzhi(x: u64, n: u32) -> u64 {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+    unsafe {
+        core::arch::x86_64::_bzhi_u64(x, n)
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+    {
+        x & (u64::MAX >> (64 - n))
     }
 }

--- a/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
@@ -1,177 +1,22 @@
-use crate::error::diag_code;
-use crate::lanes::Lanes;
-use crate::opmap::{KwSet, OP_QDOT};
-use crate::tables::{Tables, is_digit, is_op_char, is_word, is_ws};
+use crate::{
+    error::diag_code,
+    lanes::Lanes,
+    opmap::{KwSet, OP_QDOT},
+    tables::{Tables, is_digit, is_op_char, is_word, is_ws},
+};
 
-use super::NUM;
-use super::bitmap::{bm_clear_range, bm_next0, bm_set1};
-use super::find::scan_number;
-use super::keywords::{KWB, kw_verify_batch};
+use super::{
+    NUM,
+    bitmap::{bm_clear_range, bm_next0, bm_set1},
+    find::scan_number,
+    regex_div::{gt_run_split, lt_run_split},
+};
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
-#[inline(always)]
-fn prefetch(p: *const u8) {
-    unsafe { core::arch::x86_64::_mm_prefetch(p as *const i8, core::arch::x86_64::_MM_HINT_T0) }
-}
-#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
-#[inline(always)]
-fn prefetch(_p: *const u8) {}
+mod keywords;
+pub use keywords::KWB;
+use keywords::kw_flush;
 
-unsafe fn munch_walk(
-    t: &Tables,
-    src: *const u8,
-    n: usize,
-    st: *mut u64,
-    opch: *const u64,
-    kind: *mut u8,
-    mut pos: usize,
-) -> usize {
-    let end = bm_next0(opch, pos, n);
-    while end - pos >= 2 {
-        bm_set1(st, pos);
-        let rem = end - pos;
-        let lmax: u32 = if rem < 4 { rem as u32 } else { 4 };
-        let b0 = *src.add(pos);
-        let b1 = *src.add(pos + 1);
-        let b2 = *src.add(pos + 2);
-        let b3 = *src.add(pos + 3);
-        let mut opk: u32 = 0;
-        let mut opl: u32 = 0;
-        let mut l = lmax;
-        while l >= 2 {
-            let k = t.op.opmap_lookup(b0, b1, b2, b3, l);
-            if k != 0 && !(k == OP_QDOT as u32 && pos + 2 < n && is_digit(*src.add(pos + 2))) {
-                opk = k;
-                opl = l;
-                break;
-            }
-            l -= 1;
-        }
-        if opk != 0 {
-            *kind.add(pos) = opk as u8;
-            let mut j = 1usize;
-            while j < opl as usize {
-                *st.add((pos + j) >> 6) &= !(1u64 << ((pos + j) & 63));
-                j += 1;
-            }
-            pos += opl as usize;
-        } else {
-            pos += 1;
-        }
-    }
-    if end - pos == 1 {
-        bm_set1(st, pos);
-    }
-    pos
-}
-unsafe fn glue_number(
-    t: &Tables,
-    kw: &KwSet,
-    src: *const u8,
-    n: usize,
-    st: *mut u64,
-    opch: *mut u64,
-    word: *const u64,
-    kind: *mut u8,
-    mut p: usize,
-    lanes: &mut Lanes,
-) -> usize {
-    loop {
-        let e2 = scan_number(src, n, p);
-        *kind.add(p) = NUM + (*src.add(e2 - 1) == b'n') as u8;
-        if e2 > p + 1 {
-            bm_clear_range(st, p + 1, e2 - 1);
-            bm_clear_range(opch, p, e2 - 1);
-        }
-        if e2 >= n {
-            return n;
-        }
-        bm_set1(st, e2);
-        let c = *src.add(e2);
-        // A word char abutting the number end (`1.5n`, `3in`, `0b12`, `1π`)
-        // is a spec-invalid adjacency. Never true on valid input, so the
-        // whole arm is cold.
-        if is_word(c) {
-            let srcs = core::slice::from_raw_parts(src, n);
-            if c < 0x80 {
-                // A surviving `n` is a misplaced bigint suffix; scan_number
-                // consumes legal ones. Token spans are unchanged either way.
-                let code = if c == b'n' {
-                    diag_code::INVALID_BIGINT
-                } else {
-                    diag_code::INVALID_NUMERIC_LITERAL
-                };
-                lanes.push_num_end_diag(srcs, e2, code);
-                if is_digit(c) {
-                    // Digit invalid for the radix (`0b12`) or after a bigint
-                    // suffix (`1n2`): keep gluing from it.
-                    p = e2;
-                    continue;
-                }
-                // This token start postdates the kwc mask built in the word
-                // prelude, so resolve any keyword kind inline (`3in` is `3`
-                // + KW_IN). Same inputs as kw_verify_batch: length from the
-                // word bitmap, no match right after a member `.` (a number
-                // ending in `.` is that dot-run's first dot).
-                if *src.add(e2 - 1) != b'.' {
-                    let wb = word as *const u8;
-                    let x = core::ptr::read_unaligned(wb.add(e2 >> 3) as *const u64) >> (e2 & 7);
-                    let kk = kw.lookup(src.add(e2), (!x).trailing_zeros() as usize);
-                    if kk != 0 {
-                        *kind.add(e2) = kk as u8;
-                    }
-                }
-            } else {
-                // Cold decode; flags only a real Unicode IdentifierStart.
-                lanes.push_num_end_diag_unicode(srcs, e2);
-            }
-            return e2; // token start already set at e2
-        }
-        if e2 + 1 < n && is_op_char(c) && (*opch.add((e2 + 1) >> 6) >> ((e2 + 1) & 63)) & 1 != 0 {
-            // A numeric literal type ends its type argument list here (`Map<A, 1.5>>`); without this the number's own munch
-            // reaches the `>` run before `coalesce` ever raises it as an event.
-            if c == b'>' && kw.ts_key && matches!(*src.add(e2 + 1), b'>' | b'=') {
-                let end = bm_next0(opch, e2, n);
-                let g = super::regex_div::gt_run_split(t, src, st, opch, kind, n, e2, end - e2);
-                if g != 0 {
-                    // The split `>`s stay single tokens, but whatever borders on them is still an operator run and has to be
-                    // munched, or a following `&&` / `??` / `**` is emitted a byte at a time.
-                    return munch_walk(t, src, n, st, opch, kind, e2 + g);
-                }
-            }
-            let q = munch_walk(t, src, n, st, opch, kind, e2);
-            if q < n
-                && *src.add(q) == b'.'
-                && is_digit(*src.add(q + 1))
-                && (*st.add(q >> 6) >> (q & 63)) & 1 != 0
-            {
-                p = q;
-                continue;
-            }
-            return q;
-        }
-        return e2;
-    }
-}
-/// Dispatch to the key-monomorphized verify without duplicating `coalesce`
-/// itself: one predictable branch per flush, not per candidate, keyed off
-/// the set itself so the walk carries no extra mode scalar.
-#[inline(always)]
-unsafe fn kw_flush(
-    kw: &KwSet,
-    src: *const u8,
-    word: *const u64,
-    kind: *mut u8,
-    kwpos: *const u32,
-    k: usize,
-) {
-    if kw.ts_key {
-        kw_verify_batch::<true>(kw, src, word, kind, kwpos, k);
-    } else {
-        kw_verify_batch::<false>(kw, src, word, kind, kwpos, k);
-    }
-}
-pub(super) unsafe fn coalesce(
+pub unsafe fn coalesce(
     t: &Tables,
     kw: &KwSet,
     src: *const u8,
@@ -287,7 +132,7 @@ pub(super) unsafe fn coalesce(
                     && kw.ts_key
                     && (b1 == b'>' || (b1 == b'=' && p > 0 && !is_ws(*src.add(p - 1))))
                 {
-                    let g = super::regex_div::gt_run_split(t, src, st, opch, kind, n, p, run);
+                    let g = gt_run_split(t, src, st, opch, kind, n, p, run);
                     if g != 0 {
                         // Only `>`s stay split; the rest still munches, or `>>&&` would emit two `&`s.
                         cursor = munch_walk(t, src, n, st, opch, kind, p + g);
@@ -296,7 +141,7 @@ pub(super) unsafe fn coalesce(
                 }
                 // Mirror case: `Array<<T>(x: T) => T>` opens two lists, not `<<` shift-left.
                 if b0 == b'<' && b1 == b'<' && kw.ts_key {
-                    if super::regex_div::lt_run_split(src, st, opch, kind, n, p) {
+                    if lt_run_split(src, st, opch, kind, n, p) {
                         cursor = munch_walk(t, src, n, st, opch, kind, p + 2);
                         continue;
                     }
@@ -360,4 +205,156 @@ pub(super) unsafe fn coalesce(
         }
     }
     kw_flush(kw, src, word, kind, kwpos, k);
+}
+
+unsafe fn glue_number(
+    t: &Tables,
+    kw: &KwSet,
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    opch: *mut u64,
+    word: *const u64,
+    kind: *mut u8,
+    mut p: usize,
+    lanes: &mut Lanes,
+) -> usize {
+    loop {
+        let e2 = scan_number(src, n, p);
+        *kind.add(p) = NUM + (*src.add(e2 - 1) == b'n') as u8;
+        if e2 > p + 1 {
+            bm_clear_range(st, p + 1, e2 - 1);
+            bm_clear_range(opch, p, e2 - 1);
+        }
+        if e2 >= n {
+            return n;
+        }
+        bm_set1(st, e2);
+        let c = *src.add(e2);
+        // A word char abutting the number end (`1.5n`, `3in`, `0b12`, `1π`)
+        // is a spec-invalid adjacency. Never true on valid input, so the
+        // whole arm is cold.
+        if is_word(c) {
+            let srcs = core::slice::from_raw_parts(src, n);
+            if c < 0x80 {
+                // A surviving `n` is a misplaced bigint suffix; scan_number
+                // consumes legal ones. Token spans are unchanged either way.
+                let code = if c == b'n' {
+                    diag_code::INVALID_BIGINT
+                } else {
+                    diag_code::INVALID_NUMERIC_LITERAL
+                };
+                lanes.push_num_end_diag(srcs, e2, code);
+                if is_digit(c) {
+                    // Digit invalid for the radix (`0b12`) or after a bigint
+                    // suffix (`1n2`): keep gluing from it.
+                    p = e2;
+                    continue;
+                }
+                // This token start postdates the kwc mask built in the word
+                // prelude, so resolve any keyword kind inline (`3in` is `3`
+                // + KW_IN). Same inputs as kw_verify_batch: length from the
+                // word bitmap, no match right after a member `.` (a number
+                // ending in `.` is that dot-run's first dot).
+                if *src.add(e2 - 1) != b'.' {
+                    let wb = word as *const u8;
+                    let x = core::ptr::read_unaligned(wb.add(e2 >> 3) as *const u64) >> (e2 & 7);
+                    let kk = kw.lookup(src.add(e2), (!x).trailing_zeros() as usize);
+                    if kk != 0 {
+                        *kind.add(e2) = kk as u8;
+                    }
+                }
+            } else {
+                // Cold decode; flags only a real Unicode IdentifierStart.
+                lanes.push_num_end_diag_unicode(srcs, e2);
+            }
+            return e2; // token start already set at e2
+        }
+        if e2 + 1 < n && is_op_char(c) && (*opch.add((e2 + 1) >> 6) >> ((e2 + 1) & 63)) & 1 != 0 {
+            // A numeric literal type ends its type argument list here (`Map<A, 1.5>>`); without this the number's own munch
+            // reaches the `>` run before `coalesce` ever raises it as an event.
+            if c == b'>' && kw.ts_key && matches!(*src.add(e2 + 1), b'>' | b'=') {
+                let end = bm_next0(opch, e2, n);
+                let g = gt_run_split(t, src, st, opch, kind, n, e2, end - e2);
+                if g != 0 {
+                    // The split `>`s stay single tokens, but whatever borders on them is still an operator run and has to be
+                    // munched, or a following `&&` / `??` / `**` is emitted a byte at a time.
+                    return munch_walk(t, src, n, st, opch, kind, e2 + g);
+                }
+            }
+            let q = munch_walk(t, src, n, st, opch, kind, e2);
+            if q < n
+                && *src.add(q) == b'.'
+                && is_digit(*src.add(q + 1))
+                && (*st.add(q >> 6) >> (q & 63)) & 1 != 0
+            {
+                p = q;
+                continue;
+            }
+            return q;
+        }
+        return e2;
+    }
+}
+
+unsafe fn munch_walk(
+    t: &Tables,
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    opch: *const u64,
+    kind: *mut u8,
+    mut pos: usize,
+) -> usize {
+    let end = bm_next0(opch, pos, n);
+    while end - pos >= 2 {
+        bm_set1(st, pos);
+        let rem = end - pos;
+        let lmax: u32 = if rem < 4 { rem as u32 } else { 4 };
+        let b0 = *src.add(pos);
+        let b1 = *src.add(pos + 1);
+        let b2 = *src.add(pos + 2);
+        let b3 = *src.add(pos + 3);
+        let mut opk: u32 = 0;
+        let mut opl: u32 = 0;
+        let mut l = lmax;
+        while l >= 2 {
+            let k = t.op.opmap_lookup(b0, b1, b2, b3, l);
+            if k != 0 && !(k == OP_QDOT as u32 && pos + 2 < n && is_digit(*src.add(pos + 2))) {
+                opk = k;
+                opl = l;
+                break;
+            }
+            l -= 1;
+        }
+        if opk != 0 {
+            *kind.add(pos) = opk as u8;
+            let mut j = 1usize;
+            while j < opl as usize {
+                *st.add((pos + j) >> 6) &= !(1u64 << ((pos + j) & 63));
+                j += 1;
+            }
+            pos += opl as usize;
+        } else {
+            pos += 1;
+        }
+    }
+    if end - pos == 1 {
+        bm_set1(st, pos);
+    }
+    pos
+}
+
+#[inline(always)]
+fn prefetch(p: *const u8) {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+    unsafe {
+        core::arch::x86_64::_mm_prefetch(p as *const i8, core::arch::x86_64::_MM_HINT_T0)
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
+    {
+        // No-op
+        let _ = p;
+    }
 }

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -16,7 +16,6 @@ mod classify;
 mod coalesce;
 mod compress;
 mod find;
-mod keywords;
 mod regex_div;
 mod replay;
 
@@ -31,9 +30,8 @@ use crate::token::SPAN_SENTINELS;
 use bitmap::bm_any;
 use carve::carve;
 use classify::{classify, misc_post, misc_pre};
-use coalesce::coalesce;
+use coalesce::{KWB, coalesce};
 use compress::{build_spans, compress, lanes_post, write_sentinels};
-use keywords::KWB;
 
 use crate::token::TokenKind;
 


### PR DESCRIPTION
Pure refactor. No code changes, just moving code around.

Move all code for `coalesce` pipeline stage into a directory together.

`coalesce/mod.rs` contains same code as `coalesce.rs` did previously. `keyword.rs` moves into the same directory, since `kw_verify_batch` is only used in `coalesce` stage. `kw_flush` moves into `keyword.rs` as it's keyword-related.

Additionally, apply the same kinds of stylistic changes as #26390.