### PR TITLE
fix(parser): allow `in` expressions in class static blocks

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -400,7 +400,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_class_static_block(&mut self, start: u32) -> ClassElement<'a> {
         self.bump_any(); // bump `static`
         let block = self.context(
-            Context::Await | Context::NewTarget,
+            Context::In | Context::Await | Context::NewTarget,
             Context::Yield | Context::Return,
             Self::parse_block,
         );

--- a/tasks/coverage/misc/pass/class-static-block-in.js
+++ b/tasks/coverage/misc/pass/class-static-block-in.js
@@ -1,0 +1,5 @@
+for (class { static { a in b; } };;);
+for (let C = class { static { a in b; } };;);
+
+// Restore the outer initializer's disabled `in` context after the static block.
+for (class { static { a in b; } }.x in c);

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 90/90 (100.00%)
-Positive Passed: 90/90 (100.00%)
+AST Parsed     : 91/91 (100.00%)
+Positive Passed: 91/91 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 90/90 (100.00%)
-Positive Passed: 90/90 (100.00%)
+AST Parsed     : 91/91 (100.00%)
+Positive Passed: 91/91 (100.00%)

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 280/280 (100.00%)
-Positive Passed: 280/280 (100.00%)
+AST Parsed     : 281/281 (100.00%)
+Positive Passed: 281/281 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 90/90 (100.00%)
-Positive Passed: 90/90 (100.00%)
+AST Parsed     : 91/91 (100.00%)
+Positive Passed: 91/91 (100.00%)
 Negative Passed: 190/190 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 90/90 (100.00%)
-Positive Passed: 86/90 (95.56%)
+AST Parsed     : 91/91 (100.00%)
+Positive Passed: 87/91 (95.60%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 90/90 (100.00%)
-Positive Passed: 90/90 (100.00%)
+AST Parsed     : 91/91 (100.00%)
+Positive Passed: 91/91 (100.00%)


### PR DESCRIPTION
Class static blocks inherit the disabled `in` context of a surrounding `for` initializer, causing valid code such as `for (class { static { a in b; } };;);` to report a missing semicolon at `in`. Enable `Context::In` while parsing the static block, with the existing context helper restoring the surrounding flags afterward.
