### PR TITLE
fix(formatter): keep cast-target assignment and commented parameter patterns

### DIFF
--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_formatter_core::Format;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator, AstNodes},
@@ -356,9 +356,13 @@ pub fn can_avoid_parentheses(arrow: &ArrowFunctionExpression<'_>, f: &JsFormatte
                 && param.initializer.is_none()
                 && param.pattern.is_binding_identifier()
         }
-        && !f.comments().has_comment_in_span(arrow.params.span)
+        // Position-based: queried again inside `FormalParameter::write`, after its leading comments are printed
+        && !f.comments().has_any_comment_in_range(arrow.params.span.start, arrow.params.span.end)
 }
 
+/// Queried from three print phases for the same list
+/// (`FormalParameters` before printing, `FormalParameter` after its leading comments, the type literal while printing),
+/// so every comment check here must be position-based to give all of them the same answer.
 pub fn should_hug_function_parameters<'a>(
     parameters: &AstNode<'a, FormalParameters<'a>>,
     this_param: Option<&AstNode<'a, TSThisParameter<'a>>>,
@@ -371,21 +375,19 @@ pub fn should_hug_function_parameters<'a>(
         return false;
     }
 
+    // `(/* comment before */ only_parameter /* comment after */)`
+    let has_comment_around = |span: Span| {
+        f.comments().has_any_comment_in_range(parameters.span.start, span.start)
+            || f.comments().has_any_comment_in_range(span.end, parameters.span.end)
+    };
+
     if let Some(this_param) = this_param {
-        // `(/* comment before */ this /* comment after */)`
-        // Checker whether there are comments around the only parameter.
-
-        if f.comments().has_comment_in_range(parameters.span.start, this_param.span.start)
-            || f.comments().has_comment_in_range(this_param.span.end, parameters.span.end)
-        {
-            return false;
-        }
-
         return list.is_empty()
             && this_param
                 .type_annotation
                 .as_ref()
-                .is_none_or(|ty| matches!(ty.type_annotation, TSType::TSTypeLiteral(_)));
+                .is_none_or(|ty| matches!(ty.type_annotation, TSType::TSTypeLiteral(_)))
+            && !has_comment_around(this_param.span);
     }
 
     // Safe because of the length check above
@@ -395,15 +397,7 @@ pub fn should_hug_function_parameters<'a>(
         return false;
     }
 
-    // `(/* comment before */ only_parameter /* comment after */)`
-    // Checker whether there are comments around the only parameter.
-    if f.comments().has_comment_in_range(parameters.span.start, only_parameter.span.start)
-        || f.comments().has_comment_in_range(only_parameter.span.end, parameters.span.end)
-    {
-        return false;
-    }
-
-    match &only_parameter.pattern {
+    let shape_allows_hug = match &only_parameter.pattern {
         BindingPattern::AssignmentPattern(assignment) => {
             // AssignmentPattern in catch clauses or other contexts
             assignment.left.is_destructuring_pattern() && is_huggable_expression(&assignment.right)
@@ -421,7 +415,9 @@ pub fn should_hug_function_parameters<'a>(
                         )
                     }))
         }
-    }
+    };
+
+    shape_allows_hug && !has_comment_around(only_parameter.span)
 }
 
 /// Tests if all of the parameters of `expression` are simple enough to allow

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -453,18 +453,20 @@ impl<'a> AssignmentLike<'a, '_> {
             return AssignmentLikeLayout::NeverBreakAfterOperator;
         }
 
+        // A cast-parenthesized RHS is Prettier's kept `ParenthesizedExpression`,
+        // opaque to the shape check (same as in `should_break_after_operator`)
         if !left_may_break
             && (is_left_short
-                || matches!(
-                    right_expression.map(AsRef::as_ref),
-                    Some(
+                || right_expression.is_some_and(|expr| {
+                    matches!(
+                        expr.as_ref(),
                         Expression::ClassExpression(_)
                             | Expression::TemplateLiteral(_)
                             | Expression::TaggedTemplateExpression(_)
                             | Expression::BooleanLiteral(_)
                             | Expression::NumericLiteral(_)
-                    )
-                ))
+                    ) && !is_cast_target(expr.span(), f)
+                }))
         {
             return AssignmentLikeLayout::NeverBreakAfterOperator;
         }

--- a/crates/oxc_formatter/tests/fixtures/js/comments/parameter-leading-comment-no-hug.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/parameter-leading-comment-no-hug.js
@@ -1,0 +1,26 @@
+// A comment around the only parameter disables hugging, and the pattern keeps its own group:
+// an own-line comment breaks the parameter list, not `{ item }`.
+const resolveItemValue = useCallback(
+  (
+    /** @type {{ item: { id: number } }} */
+    { item },
+  ) => String(item?.id),
+  [],
+);
+const line_comment = (
+  // c
+  { item },
+) => String(item?.id);
+const array_pattern = (
+  // c
+  [a, b],
+) => a + b;
+function decl(
+  /** @type {{ item: { id: number } }} */
+  { item },
+) {}
+// Same-line comments still don't hug, and the pattern stays inline.
+const before = (/* c */ { item }) => String(item?.id);
+const after = ({ item } /* c */) => String(item?.id);
+// No comment: hugs as before.
+const hugged = ({ item, other, more, evenMore, andMore, stillMore, last }) => String(item?.id);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/parameter-leading-comment-no-hug.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/parameter-leading-comment-no-hug.js.snap
@@ -1,0 +1,94 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment around the only parameter disables hugging, and the pattern keeps its own group:
+// an own-line comment breaks the parameter list, not `{ item }`.
+const resolveItemValue = useCallback(
+  (
+    /** @type {{ item: { id: number } }} */
+    { item },
+  ) => String(item?.id),
+  [],
+);
+const line_comment = (
+  // c
+  { item },
+) => String(item?.id);
+const array_pattern = (
+  // c
+  [a, b],
+) => a + b;
+function decl(
+  /** @type {{ item: { id: number } }} */
+  { item },
+) {}
+// Same-line comments still don't hug, and the pattern stays inline.
+const before = (/* c */ { item }) => String(item?.id);
+const after = ({ item } /* c */) => String(item?.id);
+// No comment: hugs as before.
+const hugged = ({ item, other, more, evenMore, andMore, stillMore, last }) => String(item?.id);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment around the only parameter disables hugging, and the pattern keeps its own group:
+// an own-line comment breaks the parameter list, not `{ item }`.
+const resolveItemValue = useCallback(
+  (
+    /** @type {{ item: { id: number } }} */
+    { item },
+  ) => String(item?.id),
+  [],
+);
+const line_comment = (
+  // c
+  { item },
+) => String(item?.id);
+const array_pattern = (
+  // c
+  [a, b],
+) => a + b;
+function decl(
+  /** @type {{ item: { id: number } }} */
+  { item },
+) {}
+// Same-line comments still don't hug, and the pattern stays inline.
+const before = (/* c */ { item }) => String(item?.id);
+const after = ({ item } /* c */) => String(item?.id);
+// No comment: hugs as before.
+const hugged = ({ item, other, more, evenMore, andMore, stillMore, last }) =>
+  String(item?.id);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment around the only parameter disables hugging, and the pattern keeps its own group:
+// an own-line comment breaks the parameter list, not `{ item }`.
+const resolveItemValue = useCallback(
+  (
+    /** @type {{ item: { id: number } }} */
+    { item },
+  ) => String(item?.id),
+  [],
+);
+const line_comment = (
+  // c
+  { item },
+) => String(item?.id);
+const array_pattern = (
+  // c
+  [a, b],
+) => a + b;
+function decl(
+  /** @type {{ item: { id: number } }} */
+  { item },
+) {}
+// Same-line comments still don't hug, and the pattern stays inline.
+const before = (/* c */ { item }) => String(item?.id);
+const after = ({ item } /* c */) => String(item?.id);
+// No comment: hugs as before.
+const hugged = ({ item, other, more, evenMore, andMore, stillMore, last }) => String(item?.id);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
@@ -14,3 +14,12 @@ const complex_selectors_bbbbbbbb = selector.args.children_xxxxxxxxxxxxxxxxxxxxxx
 // Last-argument arrow: a cast inside the call body keeps the hug, a cast-wrapped body does not.
 const needs_version_increase = !s.reactions?.every((r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions).has(r));
 const needs_version_increase2 = !s.reactions?.every((r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions.has(r)));
+
+// Assignment: a cast-wrapped RHS is opaque to the never-break shapes too (template literal, literals, class).
+// The line breaks after the `=` when the cast comment does not fit; a short one stays inline.
+const fieldPath = /** @type {import("react-hook-form").Path<TFormValues>} */ (`${key}.${locale}`);
+const short_cast = /** @type {T} */ (`short`);
+const cast_bool = /** @type {import("react-hook-form").Path<TFormValues>} */ (true);
+const cast_num = /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} */ (123456);
+const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (tag`${key}.${locale}`);
+const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
@@ -19,6 +19,15 @@ const complex_selectors_bbbbbbbb = selector.args.children_xxxxxxxxxxxxxxxxxxxxxx
 const needs_version_increase = !s.reactions?.every((r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions).has(r));
 const needs_version_increase2 = !s.reactions?.every((r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions.has(r)));
 
+// Assignment: a cast-wrapped RHS is opaque to the never-break shapes too (template literal, literals, class).
+// The line breaks after the `=` when the cast comment does not fit; a short one stays inline.
+const fieldPath = /** @type {import("react-hook-form").Path<TFormValues>} */ (`${key}.${locale}`);
+const short_cast = /** @type {T} */ (`short`);
+const cast_bool = /** @type {import("react-hook-form").Path<TFormValues>} */ (true);
+const cast_num = /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} */ (123456);
+const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (tag`${key}.${locale}`);
+const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -52,6 +61,24 @@ const needs_version_increase2 = !s.reactions?.every(
   (r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions.has(r)),
 );
 
+// Assignment: a cast-wrapped RHS is opaque to the never-break shapes too (template literal, literals, class).
+// The line breaks after the `=` when the cast comment does not fit; a short one stays inline.
+const fieldPath = /** @type {import("react-hook-form").Path<TFormValues>} */ (
+  `${key}.${locale}`
+);
+const short_cast = /** @type {T} */ (`short`);
+const cast_bool = /** @type {import("react-hook-form").Path<TFormValues>} */ (
+  true
+);
+const cast_num =
+  /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} */ (123456);
+const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (
+  tag`${key}.${locale}`
+);
+const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (
+  class {}
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -79,5 +106,16 @@ const needs_version_increase = !s.reactions?.every((r) =>
 const needs_version_increase2 = !s.reactions?.every(
   (r) => /** @type {NonNullable<typeof v_reactions>} */ (v_reactions.has(r)),
 );
+
+// Assignment: a cast-wrapped RHS is opaque to the never-break shapes too (template literal, literals, class).
+// The line breaks after the `=` when the cast comment does not fit; a short one stays inline.
+const fieldPath = /** @type {import("react-hook-form").Path<TFormValues>} */ (`${key}.${locale}`);
+const short_cast = /** @type {T} */ (`short`);
+const cast_bool = /** @type {import("react-hook-form").Path<TFormValues>} */ (true);
+const cast_num = /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} */ (123456);
+const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (
+  tag`${key}.${locale}`
+);
+const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});
 
 ===================== End =====================


### PR DESCRIPTION
Fixes #26425, #26426.

- Exclude cast target from never-break check
- Use position based comment check