### PR TITLE
refactor(formatter): route every assignment RHS shape rule through a cast-aware accessor

### DIFF
--- a/crates/oxc_formatter/src/print/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/print/object_pattern_like.rs
@@ -39,6 +39,8 @@ impl<'a> ObjectPatternLike<'a, '_> {
         }
     }
 
+    /// A parameter pattern never groups: `FormalParameter` groups the pattern with its type annotation (as Prettier's `printObject` does),
+    /// so a source-broken type literal must break the pattern too (`{ log, logger }: {\n ... }`); a group here would cut that.
     fn is_inline(&self, _f: &JsFormatter<'_, 'a>) -> bool {
         match self {
             Self::ObjectPattern(node) => match node.parent() {

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -413,28 +413,26 @@ impl<'a> AssignmentLike<'a, '_> {
         left_may_break: bool,
         f: &mut JsFormatter<'_, 'a>,
     ) -> AssignmentLikeLayout {
-        let right_expression = self.get_right_expression();
-        if let Some(expr) = right_expression {
-            if let Some(layout) = self.chain_formatting_layout(expr) {
-                return layout;
-            }
-
-            if let Expression::CallExpression(call_expression) = expr.as_ref()
-                && call_expression
-                    .callee
-                    .get_identifier_reference()
-                    .is_some_and(|ident| ident.name == "require")
-                && !f.comments().has_leading_own_line_comment(call_expression.span.start)
-            {
-                return AssignmentLikeLayout::NeverBreakAfterOperator;
-            }
+        let right_shape = self.right_expression_shape(f);
+        if let Some(layout) = self.chain_formatting_layout(right_shape, f) {
+            return layout;
         }
 
-        if self.should_break_left_hand_side(left_may_break) {
+        if let Some(Expression::CallExpression(call_expression)) = right_shape
+            && call_expression
+                .callee
+                .get_identifier_reference()
+                .is_some_and(|ident| ident.name == "require")
+            && !f.comments().has_leading_own_line_comment(call_expression.span.start)
+        {
+            return AssignmentLikeLayout::NeverBreakAfterOperator;
+        }
+
+        if self.should_break_left_hand_side(right_shape, left_may_break) {
             return AssignmentLikeLayout::BreakLeftHandSide;
         }
 
-        if self.should_break_after_operator(right_expression, is_left_short, f) {
+        if self.should_break_after_operator(self.get_right_expression(), is_left_short, f) {
             return AssignmentLikeLayout::BreakAfterOperator;
         }
 
@@ -453,25 +451,31 @@ impl<'a> AssignmentLike<'a, '_> {
             return AssignmentLikeLayout::NeverBreakAfterOperator;
         }
 
-        // A cast-parenthesized RHS is Prettier's kept `ParenthesizedExpression`,
-        // opaque to the shape check (same as in `should_break_after_operator`)
         if !left_may_break
             && (is_left_short
-                || right_expression.is_some_and(|expr| {
-                    matches!(
-                        expr.as_ref(),
+                || matches!(
+                    right_shape,
+                    Some(
                         Expression::ClassExpression(_)
                             | Expression::TemplateLiteral(_)
                             | Expression::TaggedTemplateExpression(_)
                             | Expression::BooleanLiteral(_)
                             | Expression::NumericLiteral(_)
-                    ) && !is_cast_target(expr.span(), f)
-                }))
+                    )
+                ))
         {
             return AssignmentLikeLayout::NeverBreakAfterOperator;
         }
 
         AssignmentLikeLayout::Fluid
+    }
+
+    /// The right expression as the shape-based layout rules see it.
+    /// `None` for a cast target ([`is_cast_target`]): Prettier's `chooseLayout` sees a `ParenthesizedExpression` there.
+    fn right_expression_shape(&self, f: &JsFormatter<'_, 'a>) -> Option<&Expression<'a>> {
+        self.get_right_expression()
+            .filter(|expr| !is_cast_target(expr.span(), f))
+            .map(AsRef::as_ref)
     }
 
     fn get_right_expression(&self) -> Option<&AstNode<'a, Expression<'a>>> {
@@ -547,15 +551,20 @@ impl<'a> AssignmentLike<'a, '_> {
     /// and if so, it return the layout type
     fn chain_formatting_layout(
         &self,
-        right_expression: &Expression,
+        right_shape: Option<&Expression>,
+        f: &JsFormatter<'_, 'a>,
     ) -> Option<AssignmentLikeLayout> {
-        let right_is_tail = !matches!(right_expression, Expression::AssignmentExpression(_));
+        let right_is_tail = !matches!(right_shape, Some(Expression::AssignmentExpression(_)));
 
         // The chain goes up two levels, by checking up to the great parent if all the conditions
         // are correctly met.
         let upper_chain_is_eligible =
             // First, we check if the current node is an assignment expression
-            if let Self::AssignmentExpression(assignment) = self {
+            // and not a cast target (the mark, not `is_cast_target`: the target is mid-format here):
+            // its parent would be Prettier's `ParenthesizedExpression`, which breaks the chain.
+            if let Self::AssignmentExpression(assignment) = self
+                && !f.comments().is_marked_as_type_cast_node(assignment)
+            {
                 // Then we check if the parent is assignment expression or variable declarator
                 let parent = assignment.parent();
                 // Determine if the chain is eligible based on the following checks:
@@ -575,8 +584,8 @@ impl<'a> AssignmentLike<'a, '_> {
 
         if upper_chain_is_eligible {
             if right_is_tail {
-                match right_expression {
-                    Expression::ArrowFunctionExpression(arrow) => {
+                match right_shape {
+                    Some(Expression::ArrowFunctionExpression(arrow)) => {
                         if matches!(
                             arrow.get_expression(),
                             Some(Expression::ArrowFunctionExpression(_))
@@ -597,7 +606,11 @@ impl<'a> AssignmentLike<'a, '_> {
 
     /// Particular function that checks if the left hand side of a [AssignmentLike] should
     /// be broken on multiple lines
-    fn should_break_left_hand_side(&self, left_may_break: bool) -> bool {
+    fn should_break_left_hand_side(
+        &self,
+        right_shape: Option<&Expression>,
+        left_may_break: bool,
+    ) -> bool {
         if self.is_complex_destructuring() {
             return true;
         }
@@ -610,10 +623,7 @@ impl<'a> AssignmentLike<'a, '_> {
 
         type_annotation.is_some_and(|ann| is_complex_type_annotation(ann))
             || (left_may_break
-                && declarator
-                    .init
-                    .as_ref()
-                    .is_some_and(|expr| matches!(expr, Expression::ArrowFunctionExpression(_))))
+                && matches!(right_shape, Some(Expression::ArrowFunctionExpression(_))))
     }
 
     /// Checks if the current assignment is eligible for [AssignmentLikeLayout::BreakAfterOperator]
@@ -766,17 +776,17 @@ fn should_break_after_operator<'a>(
         }
     }
 
-    // Prettier keeps the `ParenthesizedExpression` node when it is a closure type cast target,
-    // which makes a fully cast RHS opaque to the shape checks below (`x = /** @type {T} */ (a || b);` stays inline).
-    // We have no paren nodes, so reproduce that with the cast classification.
+    // A cast-wrapped RHS has no shape (`x = /** @type {T} */ (a || b);` stays inline)
     if is_cast_target(right.span(), f) {
         return false;
     }
 
     match right.as_ref() {
         // head is a long chain, meaning that right -> right are both assignment expressions
+        // (a cast-wrapped right is opaque, not an assignment)
         Expression::AssignmentExpression(assignment) => {
             matches!(assignment.right, Expression::AssignmentExpression(_))
+                && !is_cast_target(assignment.right.span(), f)
         }
         Expression::BinaryExpression(_) | Expression::SequenceExpression(_) => true,
         Expression::LogicalExpression(logical) => {
@@ -794,45 +804,41 @@ fn should_break_after_operator<'a>(
         Expression::ClassExpression(class) => !class.decorators.is_empty(),
         // Based on https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/assignment.js#L235-L263
         _ if is_left_short => false,
-        _ => {
-            let inner_expression = get_innermost_expression(right);
-            matches!(inner_expression.as_ref(), Expression::StringLiteral(_))
-                || is_poorly_breakable_member_or_call_chain(inner_expression, f)
-        }
+        _ => get_innermost_expression(right, f).is_some_and(|inner| {
+            matches!(inner.as_ref(), Expression::StringLiteral(_))
+                || is_poorly_breakable_member_or_call_chain(inner, f)
+        }),
     }
 }
 
 /// Traverses nested unary-like expressions to find the innermost one.
 ///
 /// Example: `void !!(await test())` returns the `await test()` expression.
+///
+/// `None` when the walk reaches a cast target (`!/** @type {T} */ ("s")`): a cast target has no shape.
+/// The caller has already checked the entry node.
 fn get_innermost_expression<'a, 'b>(
     mut current: &'b AstNode<'a, Expression<'a>>,
-) -> &'b AstNode<'a, Expression<'a>> {
+    f: &JsFormatter<'_, 'a>,
+) -> Option<&'b AstNode<'a, Expression<'a>>> {
     loop {
-        match current.as_ast_nodes() {
-            AstNodes::UnaryExpression(unary) => {
-                current = unary.argument();
-            }
-            AstNodes::TSNonNullExpression(non_null) => {
-                current = non_null.expression();
-            }
-            AstNodes::AwaitExpression(expr) => {
-                current = expr.argument();
-            }
-            AstNodes::YieldExpression(expr) => {
-                if let Some(argument) = expr.argument() {
-                    current = argument;
-                } else {
-                    break;
-                }
-            }
-            _ => {
-                break;
-            }
+        let argument = match current.as_ast_nodes() {
+            AstNodes::UnaryExpression(unary) => unary.argument(),
+            AstNodes::TSNonNullExpression(non_null) => non_null.expression(),
+            AstNodes::AwaitExpression(expr) => expr.argument(),
+            AstNodes::YieldExpression(expr) => match expr.argument() {
+                Some(argument) => argument,
+                None => break,
+            },
+            _ => break,
+        };
+        if is_cast_target(argument.span(), f) {
+            return None;
         }
+        current = argument;
     }
 
-    current
+    Some(current)
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AssignmentLike<'a, '_> {
@@ -971,8 +977,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for WithAssignmentLayout<'a, '_> {
         // An arrow needs the layout inside its `write`,
         // which is reached through the shared generated `fmt` (suppression, type casts, parentheses, comments);
         // the span-keyed context slot hands it across that frame.
+        // A cast target has no shape; the layout never reaches the arrow inside.
         if let (Some(layout), AstNodes::ArrowFunctionExpression(arrow)) =
             (self.layout, self.expression.as_ast_nodes())
+            && !is_cast_target(arrow.span(), f)
         {
             f.context_mut().set_arrow_assignment_layout(arrow.span(), layout);
             arrow.fmt(f);

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
@@ -23,3 +23,11 @@ const cast_bool = /** @type {import("react-hook-form").Path<TFormValues>} */ (tr
 const cast_num = /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} */ (123456);
 const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (tag`${key}.${locale}`);
 const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});
+
+// The other RHS shape rules stop at the cast too: `require`, assignment chains, arrows, the unary walk.
+const someLongVariableNameForRequire = /** @type {typeof import("some-module")} */ (require("some-module"));
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (cccccccccccccccc = dddddddddddddddd);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = /** @type {T} */ (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc.ddddddddddddddd);
+aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ ((xxxxxxxxxxxxxxxx) => xxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy);
+const someLongVariableNameForArrow3 = /** @type {Handler} */ ((a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee));
+const someLongVariableNameHereForNot = !/** @type {Promise<string>} */ ("some long string literal here ok yes");

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
@@ -28,6 +28,14 @@ const cast_num = /** @type {import("react-hook-form").Path<TFormValuesXXXXXXX>} 
 const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (tag`${key}.${locale}`);
 const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});
 
+// The other RHS shape rules stop at the cast too: `require`, assignment chains, arrows, the unary walk.
+const someLongVariableNameForRequire = /** @type {typeof import("some-module")} */ (require("some-module"));
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (cccccccccccccccc = dddddddddddddddd);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = /** @type {T} */ (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc.ddddddddddddddd);
+aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ ((xxxxxxxxxxxxxxxx) => xxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy);
+const someLongVariableNameForArrow3 = /** @type {Handler} */ ((a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee));
+const someLongVariableNameHereForNot = !/** @type {Promise<string>} */ ("some long string literal here ok yes");
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -79,6 +87,24 @@ const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (
   class {}
 );
 
+// The other RHS shape rules stop at the cast too: `require`, assignment chains, arrows, the unary walk.
+const someLongVariableNameForRequire =
+  /** @type {typeof import("some-module")} */ (require("some-module"));
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+  /** @type {T} */ (cccccccccccccccc = dddddddddddddddd);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = /** @type {T} */ (
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc.ddddddddddddddd
+);
+aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (
+  (xxxxxxxxxxxxxxxx) => xxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+);
+const someLongVariableNameForArrow3 = /** @type {Handler} */ (
+  (a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee)
+);
+const someLongVariableNameHereForNot = !(
+  /** @type {Promise<string>} */ ("some long string literal here ok yes")
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -117,5 +143,25 @@ const cast_tagged = /** @type {import("react-hook-form").Path<TFormValues>} */ (
   tag`${key}.${locale}`
 );
 const cast_class = /** @type {import("react-hook-form").Path<TFormValues>} */ (class {});
+
+// The other RHS shape rules stop at the cast too: `require`, assignment chains, arrows, the unary walk.
+const someLongVariableNameForRequire = /** @type {typeof import("some-module")} */ (
+  require("some-module")
+);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (
+  cccccccccccccccc = dddddddddddddddd
+);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = /** @type {T} */ (
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc.ddddddddddddddd
+);
+aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (
+  (xxxxxxxxxxxxxxxx) => xxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+);
+const someLongVariableNameForArrow3 = /** @type {Handler} */ (
+  (a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee)
+);
+const someLongVariableNameHereForNot = !(
+  /** @type {Promise<string>} */ ("some long string literal here ok yes")
+);
 
 ===================== End =====================

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1061813
+  arena allocs: 1070155
   arena reallocs: 927
-  arena size: 89925376 # 89.93 MB
+  arena size: 90259056 # 90.26 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
-  arena allocs: 208750
+  arena allocs: 211361
   arena reallocs: 364
-  arena size: 16832304 # 16.83 MB
+  arena size: 16936624 # 16.94 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 89
   sys alloc bytes: 36132 # 36.13 kB
   sys peak growth: 12192 # 12.19 kB
-  arena allocs: 1128
+  arena allocs: 1149
   arena reallocs: 0
   arena size: 117760 # 117.76 kB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
-  arena allocs: 426837
+  arena allocs: 432553
   arena reallocs: 428
-  arena size: 29344176 # 29.34 MB
+  arena size: 29572816 # 29.57 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2502477
+  arena allocs: 2558370
   arena reallocs: 1889
-  arena size: 244425688 # 244.43 MB
+  arena size: 246661408 # 246.66 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
-  arena allocs: 63077
+  arena allocs: 63591
   arena reallocs: 38
-  arena size: 5664512 # 5.66 MB
+  arena size: 5685072 # 5.69 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 554419
+  arena allocs: 561600
   arena reallocs: 1041
-  arena size: 38275832 # 38.28 MB
+  arena size: 38563072 # 38.56 MB


### PR DESCRIPTION
Follow up on #26429, apply cast-aware behavior to assignment call sites.