### PR TITLE
refactor(formatter): make `is_cast_target` position-based

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -177,7 +177,8 @@ impl<'a> Comments<'a> {
         self.unprinted_comments().iter().take_while(move |c| c.span.end <= pos)
     }
 
-    /// Returns all comments that end before or at the given position.
+    /// Returns the unprinted comments that end before or at the given position
+    /// (cursor-based, see [`Self::all_comments_in_range`] for the position-based queries).
     pub fn comments_before(&self, pos: u32) -> &'a [Comment] {
         let index = self.comments_before_iter(pos).count();
         &self.unprinted_comments()[..index]
@@ -220,7 +221,32 @@ impl<'a> Comments<'a> {
         &comments[start_index..]
     }
 
-    /// Returns comments that fall between the given start and end positions.
+    /// Position-based variant of [`Self::comments_in_range`]:
+    /// ALL comments contained in `[start, end]`, printed and hidden ones included.
+    ///
+    /// Layout decisions evaluated more than once for the same node must use the position-based queries:
+    /// grouped call arguments re-format the grouped function with its body reused from cache
+    /// after the first pass has already consumed the comments,
+    /// so a cursor-based query would give the two passes different answers.
+    pub fn all_comments_in_range(&self, start: u32, end: u32) -> impl Iterator<Item = &'a Comment> {
+        let first = self.inner.partition_point(|comment| comment.span.start < start);
+        self.inner[first..].iter().take_while(move |comment| comment.span.end <= end)
+    }
+
+    /// Position-based variant of [`Self::comments_before`]:
+    /// ALL comments ending at or before `pos`, printed and hidden ones included.
+    pub fn all_comments_before(&self, pos: u32) -> &'a [Comment] {
+        &self.inner[..self.inner.partition_point(|comment| comment.span.end <= pos)]
+    }
+
+    /// Position-based variant of [`Self::comments_after`]:
+    /// ALL comments ending after `pos`, printed and hidden ones included.
+    fn all_comments_after(&self, pos: u32) -> &'a [Comment] {
+        &self.inner[self.inner.partition_point(|comment| comment.span.end <= pos)..]
+    }
+
+    /// Returns the unprinted comments between the given positions (cursor-based, see [`Self::all_comments_in_range`]).
+    /// Unlike the position-based variant, a comment ending exactly at `start` is included.
     pub fn comments_in_range(&self, start: u32, end: u32) -> &'a [Comment] {
         let comments = self.comments_after(start);
         let end_index = comments.iter().take_while(|c| c.span.end <= end).count();
@@ -305,8 +331,7 @@ impl<'a> Comments<'a> {
             Some(b'/') => {}
             _ => return false,
         }
-        let first = self.inner.partition_point(|comment| comment.span.end <= pos);
-        let run = self.comment_run_after(&self.inner[first..], pos);
+        let run = self.comment_run_after(self.all_comments_after(pos), pos);
         let end = run.last().map_or(pos, |comment| comment.span.end);
         self.source_text.next_non_whitespace_byte_is(end, b')')
     }
@@ -384,7 +409,8 @@ impl<'a> Comments<'a> {
         end
     }
 
-    /// Checks if there are any comments between the given positions.
+    /// Checks if there are any unprinted comments between the given positions
+    /// (cursor-based, see [`Self::has_any_comment_in_range`]).
     pub fn has_comment_in_range(&self, start: u32, end: u32) -> bool {
         self.comments_before_iter(end).any(|comment| comment.span.end > start)
     }
@@ -406,28 +432,14 @@ impl<'a> Comments<'a> {
         self.comments_before_iter(start).any(|comment| comment.followed_by_newline())
     }
 
-    /// Position-based variant of [`Self::has_leading_own_line_comment`]:
-    /// checks ALL comments within `(start, end)`, including already-printed ones.
-    ///
-    /// Layout decisions evaluated more than once for the same node must use this:
-    /// grouped call arguments re-format the grouped function with its body reused from cache
-    /// after the first pass has already consumed the comments,
-    /// so a cursor-based query would give the two passes different answers.
+    /// Position-based variant of [`Self::has_leading_own_line_comment`] (see [`Self::all_comments_in_range`]).
     pub fn has_own_line_comment_in_range(&self, start: u32, end: u32) -> bool {
-        let first = self.inner.partition_point(|comment| comment.span.start < start);
-        self.inner[first..]
-            .iter()
-            .take_while(|comment| comment.span.end <= end)
-            .any(|comment| comment.followed_by_newline())
+        self.all_comments_in_range(start, end).any(|comment| comment.followed_by_newline())
     }
 
-    /// Position-based variant of [`Self::has_comment_in_range`],
-    /// considering ALL comments, including already-printed ones:
-    /// whether the first comment at or after `start` ends within `end`.
-    /// Same discipline as [`Self::has_own_line_comment_in_range`].
+    /// Position-based variant of [`Self::has_comment_in_range`] (see [`Self::all_comments_in_range`]).
     pub fn has_any_comment_in_range(&self, start: u32, end: u32) -> bool {
-        let first = self.inner.partition_point(|comment| comment.span.start < start);
-        self.inner.get(first).is_some_and(|comment| comment.span.end <= end)
+        self.all_comments_in_range(start, end).next().is_some()
     }
 
     pub fn has_end_of_line_comment_after(&self, pos: u32) -> bool {

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -559,11 +559,10 @@ impl<'a> AssignmentLike<'a, '_> {
         // The chain goes up two levels, by checking up to the great parent if all the conditions
         // are correctly met.
         let upper_chain_is_eligible =
-            // First, we check if the current node is an assignment expression
-            // and not a cast target (the mark, not `is_cast_target`: the target is mid-format here):
+            // First, we check if the current node is an assignment expression and not a cast target:
             // its parent would be Prettier's `ParenthesizedExpression`, which breaks the chain.
             if let Self::AssignmentExpression(assignment) = self
-                && !f.comments().is_marked_as_type_cast_node(assignment)
+                && !is_cast_target(assignment.span, f)
             {
                 // Then we check if the parent is assignment expression or variable declarator
                 let parent = assignment.parent();

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -1,3 +1,29 @@
+//! JSDoc type casts: `/** @type {T} */ (expr)`.
+//!
+//! The cast comment types the parenthesized expression right after it,
+//! so the parens must survive formatting and the comment must stay in front of them.
+//! The AST has no paren node (`preserve_parens: false`); the cast is recovered from the source (see `CastCommentGap`):
+//! a cast comment, then only `(`s and trivia, then the node, then `)` makes the node a [`TypeCast::Target`].
+//!
+//! # Printing protocol
+//!
+//! The generated `fmt` of every node with `NeedsParentheses` first offers the node to [`format_type_cast_comment_node`]:
+//! 1. [`classify_type_cast`] finds the node's binding cast comment among its UNPRINTED leading comments
+//!    (the first one: nested casts `/** U */ (/** T */ (x))` are peeled from the outside, one per pass);
+//! 2. [`format_type_cast_comment_node`] prints them, marks the node, and re-enters its `fmt` inside `(`...`)`;
+//! 3. the re-entered `fmt` offers the node again;
+//!    the cast comment just printed counts as handled (`Comments::is_handled_type_cast_comment`),
+//!    so only a further unprinted cast can bind now (the inner one of a nest, which repeats step 2);
+//!    with none, the offer is declined and the node prints itself.
+//!
+//! A cast whose paren closes inside the node ([`TypeCast::BindsInner`]) is kept adjacent to its target
+//! by [`format_leading_comments_and_open_paren`].
+//!
+//! # Layout decisions
+//!
+//! Shape-based layout rules see a cast target as Prettier's kept `ParenthesizedExpression` and ask [`is_cast_target`].
+//! `classify_type_cast` and the mark are for printing only.
+
 use oxc_ast::Comment;
 use oxc_span::{GetSpan, Span};
 
@@ -14,9 +40,6 @@ use crate::{
 };
 
 /// How a JSDoc type cast comment relates to a node.
-///
-/// A cast is a `/** @type */`-like comment immediately followed by a
-/// parenthesized expression; where that parenthesis closes decides the binding.
 pub enum TypeCast<'a> {
     /// The node itself is the cast target
     /// (the parenthesis right after the comment closes right after the node):
@@ -51,15 +74,10 @@ pub enum TypeCast<'a> {
     None,
 }
 
-impl TypeCast<'_> {
-    pub fn is_target(&self) -> bool {
-        matches!(self, TypeCast::Target { .. })
-    }
-}
-
-/// Classifies how a type cast comment relates to the node at `span`.
-/// This is the single source of truth for cast binding;
-/// both [`format_type_cast_comment_node`] and [`format_leading_comments_and_open_paren`] consume it.
+/// Classifies how a type cast comment relates to the node at `span`, for printing:
+/// which comments are still pending is a cursor question,
+/// so this reads the printed state (the first unprinted cast comment, or the last printed one).
+/// Both [`format_type_cast_comment_node`] and [`format_leading_comments_and_open_paren`] consume it.
 pub fn classify_type_cast<'a>(span: Span, f: &JsFormatter<'_, 'a>) -> TypeCast<'a> {
     let comments = f.context().comments();
 
@@ -105,20 +123,48 @@ pub fn classify_type_cast<'a>(span: Span, f: &JsFormatter<'_, 'a>) -> TypeCast<'
     TypeCast::None
 }
 
-/// Whether the node at `span` is a cast target (see [`TypeCast::Target`]).
-///
-/// A cast target keeps its parens, so to shape-based layout checks it is a parenthesized expression, not the node inside;
-/// the AST has no paren node, so those checks ask this instead.
+/// Whether the node at `span` is a cast target (see [`TypeCast::Target`]), for layout decisions.
+/// Position-based (source only, no printed state), so every frame agrees, the target mid-format included.
 /// Every cast target closes with `)`: the byte peek rejects the common case before any comment lookup.
 pub fn is_cast_target(span: Span, f: &JsFormatter<'_, '_>) -> bool {
-    f.context().comments().is_followed_by_closing_paren(span.end)
-        && classify_type_cast(span, f).is_target()
+    let source = f.source_text();
+    // A target is preceded by its `(` or by the `/` closing a comment:
+    // one byte peek rejects most nodes before the `)` peek (true for every last argument and parenthesized test)
+    // and the comment lookup.
+    if !matches!(
+        source.bytes_to(span.start).find(|byte| !byte.is_ascii_whitespace()),
+        Some(b'(' | b'/')
+    ) {
+        return false;
+    }
+    let comments = f.context().comments();
+    if !comments.is_followed_by_closing_paren(span.end) {
+        return false;
+    }
+    // Walk back over the comments before the node, one gap segment at a time, stopping at the first code byte.
+    // A cast comment with no `(` between it and the node binds to an inner node, and the walk continues:
+    // an earlier cast may still wrap this one (`/** @type {U} */ (/** @type {T} */ (a).b)`).
+    let mut cursor = span.start;
+    let mut has_paren = false;
+    for comment in comments.all_comments_before(span.start).iter().rev() {
+        let Some(segment_has_paren) =
+            classify_gap_segment(source.bytes_range(comment.span.end, cursor))
+        else {
+            return false;
+        };
+        has_paren |= segment_has_paren;
+        if has_paren && comments.is_type_cast_comment_followed_by_paren(comment) {
+            return true;
+        }
+        cursor = comment.span.start;
+    }
+    false
 }
 
 /// A cast target's pending comments and the span of its cast parentheses
 /// (from the first `(` after the cast comment to after the matching `)`), `None` for any other node.
 fn cast_target_parens<'a>(span: Span, f: &JsFormatter<'_, 'a>) -> Option<(&'a [Comment], Span)> {
-    // The same rejection as `is_cast_target`
+    // Fast path: every target closes with `)`
     if !f.context().comments().is_followed_by_closing_paren(span.end) {
         return None;
     }
@@ -146,6 +192,7 @@ pub fn cast_target_end(span: Span, f: &JsFormatter<'_, '_>) -> Option<u32> {
 /// prints the pending cast comments, marks the node
 /// (so `NeedsParentheses` rules skip their own parentheses), and wraps it in parentheses,
 /// like `/** @type {string} */ (value)` or `/** @type {number} */ ((expression))`.
+/// Step 2 of the module's printing protocol: the node's `fmt` is re-entered inside the parens and declines the second offer.
 ///
 /// Returns `true` if the node was formatted as a cast target, `false` otherwise;
 /// callers apply their own formatting on `false`.
@@ -256,14 +303,14 @@ fn cast_parens_span(cast_comment_end: u32, span: Span, f: &JsFormatter<'_, '_>) 
 
 /// Byte segments between `start` and `bound` lying outside the given comment spans:
 /// one `(gap_start, gap_end)` pair per gap, ending with the tail segment up to `bound`.
-fn gap_segments(
-    comment_spans: &[Comment],
+fn gap_segments<'c>(
+    comments: impl IntoIterator<Item = &'c Comment> + 'c,
     start: u32,
     bound: u32,
-) -> impl Iterator<Item = (u32, u32)> + '_ {
+) -> impl Iterator<Item = (u32, u32)> + 'c {
     let mut pos = start;
-    comment_spans
-        .iter()
+    comments
+        .into_iter()
         .map(|comment| comment.span)
         .chain(std::iter::once(Span::empty(bound)))
         .filter_map(move |span| {
@@ -407,32 +454,33 @@ enum CastCommentGap {
 }
 
 /// Classifies the source between a cast comment end (`start`) and the node start (`end`).
-/// Comments in the gap are skipped via their known spans
-/// (they are unprinted at both call sites: they come after the cast comment,
-/// which is the newest printed comment in the printed branch);
-/// between them only whitespace and `(` are grammatically possible,
-/// so anything else is conservatively [`CastCommentGap::Code`].
+/// Comments in the gap are skipped via their known spans (printed or not, the bytes are the same).
 fn classify_cast_comment_gap(start: u32, end: u32, f: &JsFormatter<'_, '_>) -> CastCommentGap {
     let source = f.source_text();
-    let is_gap_byte = |b: u8| b.is_ascii_whitespace() || b == b'(';
+    let comments = f.context().comments().all_comments_in_range(start, end);
 
     let mut has_paren = false;
-    let mut pos = start;
-    for comment in f.context().comments().comments_in_range(start, end) {
-        // A comment ending exactly at `start` lies before the range
-        if comment.span.start < pos {
-            continue;
-        }
-        if !source.all_bytes_match(pos, comment.span.start, is_gap_byte) {
+    for (from, to) in gap_segments(comments, start, end) {
+        let Some(segment_has_paren) = classify_gap_segment(source.bytes_range(from, to)) else {
             return CastCommentGap::Code;
-        }
-        has_paren = has_paren || source.bytes_contain(pos, comment.span.start, b'(');
-        pos = comment.span.end;
+        };
+        has_paren |= segment_has_paren;
     }
-    if !source.all_bytes_match(pos, end, is_gap_byte) {
-        return CastCommentGap::Code;
-    }
-    has_paren = has_paren || source.bytes_contain(pos, end, b'(');
 
     if has_paren { CastCommentGap::ParensAndTrivia } else { CastCommentGap::Trivia }
+}
+
+/// One comment-free segment of a cast gap: `Some(has_paren)` when it holds only whitespace and `(`s
+/// (the only bytes grammatically possible between a cast comment and its target),
+/// `None` on anything else, which conservatively ends the cast ([`CastCommentGap::Code`]).
+fn classify_gap_segment(bytes: &[u8]) -> Option<bool> {
+    let mut has_paren = false;
+    for &byte in bytes {
+        match byte {
+            b'(' => has_paren = true,
+            _ if byte.is_ascii_whitespace() => {}
+            _ => return None,
+        }
+    }
+    Some(has_paren)
 }

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js
@@ -31,3 +31,9 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = /** @type {T} */ (bbbbbbbbbbbbbbbbbbbbbbb
 aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ ((xxxxxxxxxxxxxxxx) => xxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy);
 const someLongVariableNameForArrow3 = /** @type {Handler} */ ((a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee));
 const someLongVariableNameHereForNot = !/** @type {Promise<string>} */ ("some long string literal here ok yes");
+
+// Nested casts: each cast keeps its own parens.
+const outer = /** @type {U} */ (/** @type {T} */ (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).bbbbbbbbbbbbbbbb);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (cccccccccccccccc = /** @type {S} */ (dddddddddddddddd = eeeeeeeeeeeeeeee));
+// A chain inside a call-argument cast with doubled source parens.
+foo(/** @type {T} */ ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc)));

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/cast-target-opaque-layout.js.snap
@@ -36,6 +36,12 @@ aaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ ((xxxxxxxxxxxxxx
 const someLongVariableNameForArrow3 = /** @type {Handler} */ ((a) => (b) => (c) => (d) => someLongFunctionCall(a, b, c, d, eeeeeeeeeee));
 const someLongVariableNameHereForNot = !/** @type {Promise<string>} */ ("some long string literal here ok yes");
 
+// Nested casts: each cast keeps its own parens.
+const outer = /** @type {U} */ (/** @type {T} */ (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).bbbbbbbbbbbbbbbb);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (cccccccccccccccc = /** @type {S} */ (dddddddddddddddd = eeeeeeeeeeeeeeee));
+// A chain inside a call-argument cast with doubled source parens.
+foo(/** @type {T} */ ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc)));
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -105,6 +111,24 @@ const someLongVariableNameHereForNot = !(
   /** @type {Promise<string>} */ ("some long string literal here ok yes")
 );
 
+// Nested casts: each cast keeps its own parens.
+const outer = /** @type {U} */ (
+  /** @type {T} */ (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  ).bbbbbbbbbbbbbbbb
+);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+  /** @type {T} */ (
+    cccccccccccccccc = /** @type {S} */ (dddddddddddddddd = eeeeeeeeeeeeeeee)
+  );
+// A chain inside a call-argument cast with doubled source parens.
+foo(
+  /** @type {T} */ (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+      cccccccccccccccc
+  ),
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -162,6 +186,20 @@ const someLongVariableNameForArrow3 = /** @type {Handler} */ (
 );
 const someLongVariableNameHereForNot = !(
   /** @type {Promise<string>} */ ("some long string literal here ok yes")
+);
+
+// Nested casts: each cast keeps its own parens.
+const outer = /** @type {U} */ (
+  /** @type {T} */ (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).bbbbbbbbbbbbbbbb
+);
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = /** @type {T} */ (
+  cccccccccccccccc = /** @type {S} */ (dddddddddddddddd = eeeeeeeeeeeeeeee)
+);
+// A chain inside a call-argument cast with doubled source parens.
+foo(
+  /** @type {T} */ (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = cccccccccccccccc
+  ),
 );
 
 ===================== End =====================


### PR DESCRIPTION
We use `preserve_parens: false`, need to detect typecast `()` from source, always.