### PR TITLE
perf(parser): avoid allocation for single grouped expressions

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -276,14 +276,46 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.lexer.trivia_builder.previous_token_no_side_effects_comments();
         self.bump_any(); // `bump` `(`
         let expr_start = self.cur_start();
-        let (mut expressions, comma_start) = self.context(Context::In, Context::Decorator, |p| {
-            p.parse_delimited_list(
-                Kind::RParen,
-                Kind::Comma,
-                opening_span,
-                Self::parse_assignment_expression_or_higher,
-            )
-        });
+        let (expression, mut expressions, comma_start) =
+            self.context(Context::In, Context::Decorator, |p| {
+                let mut expressions = ArenaVec::new_in(p);
+                if p.at(Kind::RParen) || p.has_fatal_error() {
+                    return (None, expressions, None);
+                }
+
+                // Most parentheses contain one expression. Keep it outside a vector until a
+                // comma requires a sequence expression, avoiding an otherwise unused allocation.
+                let expression = p.parse_assignment_expression_or_higher();
+                let kind = p.cur_kind();
+                if kind == Kind::RParen || p.has_fatal_error() {
+                    return (Some(expression), expressions, None);
+                }
+                if kind != Kind::Comma {
+                    p.set_fatal_error(diagnostics::expect_closing_or_separator(
+                        Kind::RParen.to_str(),
+                        Kind::Comma.to_str(),
+                        kind.to_str(),
+                        p.cur_token().span(),
+                        opening_span,
+                    ));
+                    return (Some(expression), expressions, None);
+                }
+
+                expressions.push(expression);
+                p.advance(Kind::Comma);
+                let comma_start = if p.at(Kind::RParen) {
+                    Some(p.prev_token_end - 1)
+                } else {
+                    p.parse_delimited_list_into(
+                        &mut expressions,
+                        Kind::RParen,
+                        Kind::Comma,
+                        opening_span,
+                        Self::parse_assignment_expression_or_higher,
+                    )
+                };
+                (None, expressions, comma_start)
+            });
 
         if let Some(comma_start) = comma_start {
             let error = diagnostics::unexpected_trailing_comma(
@@ -293,7 +325,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.fatal_error(error);
         }
 
-        if expressions.is_empty() {
+        if expression.is_none() && expressions.is_empty() {
             self.expect(Kind::RParen);
             let error = diagnostics::empty_parenthesized_expression(self.end_span(start));
             return self.fatal_error(error);
@@ -303,7 +335,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::RParen);
 
         // ParenthesizedExpression is from acorn --preserveParens
-        let mut expression = if expressions.len() == 1 {
+        let mut expression = if let Some(expression) = expression {
+            expression
+        } else if expressions.len() == 1 {
             expressions.remove(0)
         } else {
             Expression::new_sequence_expression(expr_span, expressions, self)

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 2973674 # 2.97 MB
   arena allocs: 1070155
   arena reallocs: 927
-  arena size: 90259056 # 90.26 MB
+  arena size: 90215328 # 90.22 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 435358 # 435.36 kB
   arena allocs: 211361
   arena reallocs: 364
-  arena size: 16936624 # 16.94 MB
+  arena size: 16933280 # 16.93 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1156432 # 1.16 MB
   arena allocs: 432553
   arena reallocs: 428
-  arena size: 29572816 # 29.57 MB
+  arena size: 29566080 # 29.57 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 50737424 # 50.74 MB
   arena allocs: 2558370
   arena reallocs: 1889
-  arena size: 246661408 # 246.66 MB
+  arena size: 246576512 # 246.58 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 195149 # 195.15 kB
   arena allocs: 63591
   arena reallocs: 38
-  arena size: 5685072 # 5.69 MB
+  arena size: 5683120 # 5.68 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 1491796 # 1.49 MB
   arena allocs: 561600
   arena reallocs: 1041
-  arena size: 38563072 # 38.56 MB
+  arena size: 38551680 # 38.55 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 10169560 # 10.17 MB
   arena allocs: 72029
   arena reallocs: 28269
-  arena size: 17401952 # 17.40 MB
+  arena size: 17358168 # 17.36 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 1612427 # 1.61 MB
   arena allocs: 8372
   arena reallocs: 2709
-  arena size: 2719488 # 2.72 MB
+  arena size: 2716016 # 2.72 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 3693363 # 3.69 MB
   arena allocs: 21027
   arena reallocs: 7699
-  arena size: 5783984 # 5.78 MB
+  arena size: 5777200 # 5.78 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 19934749 # 19.93 MB
   arena allocs: 207576
   arena reallocs: 75941
-  arena size: 45456840 # 45.46 MB
+  arena size: 45371944 # 45.37 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 657404 # 657.40 kB
   arena allocs: 3311
   arena reallocs: 834
-  arena size: 1083312 # 1.08 MB
+  arena size: 1081312 # 1.08 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 3707457 # 3.71 MB
   arena allocs: 32092
   arena reallocs: 12187
-  arena size: 8691304 # 8.69 MB
+  arena size: 8679808 # 8.68 MB

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19
   sys alloc bytes: 4820 # 4.82 kB
   sys peak growth: 2432 # 2.43 kB
-  arena allocs: 262590
+  arena allocs: 259857
   arena reallocs: 22858
-  arena size: 12923744 # 12.92 MB
+  arena size: 12879992 # 12.88 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 18
   sys alloc bytes: 4348 # 4.35 kB
   sys peak growth: 1868 # 1.87 kB
-  arena allocs: 44037
+  arena allocs: 43828
   arena reallocs: 3537
-  arena size: 2230856 # 2.23 MB
+  arena size: 2227416 # 2.23 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 1
   sys alloc bytes: 108 # 108 B
   sys peak growth: 108 # 108 B
-  arena allocs: 367
+  arena allocs: 366
   arena reallocs: 66
   arena size: 21200 # 21.20 kB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 67
   sys alloc bytes: 24020 # 24.02 kB
   sys peak growth: 12140 # 12.14 kB
-  arena allocs: 89857
+  arena allocs: 89436
   arena reallocs: 8136
-  arena size: 4536712 # 4.54 MB
+  arena size: 4529904 # 4.53 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 185
   sys alloc bytes: 109952 # 109.95 kB
   sys peak growth: 48264 # 48.26 kB
-  arena allocs: 528577
+  arena allocs: 523271
   arena reallocs: 55355
-  arena size: 29421920 # 29.42 MB
+  arena size: 29337024 # 29.34 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 0
   sys alloc bytes: 3016 # 3.02 kB
   sys peak growth: 251 # 251 B
-  arena allocs: 16587
+  arena allocs: 16465
   arena reallocs: 1476
-  arena size: 916328 # 916.33 kB
+  arena size: 913896 # 913.90 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 183
   sys alloc bytes: 34053 # 34.05 kB
   sys peak growth: 3892 # 3.89 kB
-  arena allocs: 136453
+  arena allocs: 135741
   arena reallocs: 11898
-  arena size: 6440104 # 6.44 MB
+  arena size: 6428712 # 6.43 MB

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 3858362 # 3.86 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 12923744 # 12.92 MB
+  arena size: 12879992 # 12.88 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 360848 # 360.85 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 2230856 # 2.23 MB
+  arena size: 2227416 # 2.23 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 832762 # 832.76 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 4536712 # 4.54 MB
+  arena size: 4529904 # 4.53 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 5441278 # 5.44 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 29421920 # 29.42 MB
+  arena size: 29337024 # 29.34 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 246886 # 246.89 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 916328 # 916.33 kB
+  arena size: 913896 # 913.90 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 1101954 # 1.10 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 6440104 # 6.44 MB
+  arena size: 6428712 # 6.43 MB

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 2243 # 2.24 kB
   arena allocs: 1959
   arena reallocs: 5
-  arena size: 13012200 # 13.01 MB
+  arena size: 12968448 # 12.97 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 2584 # 2.58 kB
   arena allocs: 618
   arena reallocs: 17
-  arena size: 2264144 # 2.26 MB
+  arena size: 2260704 # 2.26 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1610 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 4536736 # 4.54 MB
+  arena size: 4529928 # 4.53 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 1611 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 29421944 # 29.42 MB
+  arena size: 29337048 # 29.34 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 1625 # 1.62 kB
   arena allocs: 154
   arena reallocs: 0
-  arena size: 923168 # 923.17 kB
+  arena size: 920576 # 920.58 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,4 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 3218 # 3.22 kB
   arena allocs: 6132
   arena reallocs: 280
-  arena size: 6774200 # 6.77 MB
+  arena size: 6762808 # 6.76 MB


### PR DESCRIPTION
Keep the first parenthesized expression outside the arena vector, allocating its backing storage only when a comma requires a sequence expression. Sequence tails continue through the existing list parser, preserving delimiter diagnostics and parenthesis/comment handling.
