### PR TITLE
docs(linter/typescript/await-thenable): add missing lang for markdown doc comment

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/await_thenable.rs
+++ b/crates/oxc_linter/src/rules/typescript/await_thenable.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```
+    /// ```ts
     /// await 12;
     /// await (() => {});
     ///
@@ -31,7 +31,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```
+    /// ```ts
     /// await Promise.resolve('value');
     /// await Promise.reject(new Error());
     ///


### PR DESCRIPTION
Noticed that examples in https://oxc.rs/docs/guide/usage/linter/rules/typescript/await-thenable.html#examples don't have syntax highlighting.