### PR TITLE
feat(oxlint): add experimental parallel execution for JS plugins

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -59,6 +59,10 @@ export type JsCreateWorkspaceCb =
 export type JsDestroyWorkspaceCb =
   ((arg: string) => void)
 
+/** JS callback which creates worker isolates for external plugins. */
+export type JsInitializePluginWorkersCb =
+  ((arg0: number, arg1: number, arg2: string) => Promise<undefined>)
+
 /** JS callback to lint a file. */
 export type JsLintFileCb =
   ((arg0: string, arg1: number, arg2: Uint8Array | undefined | null, arg3: Array<number>, arg4: Array<number>, arg5: string, arg6: string, arg7?: string | undefined | null) => string | null)
@@ -86,10 +90,11 @@ export type JsSetupRuleConfigsCb =
  * 5. `create_workspace`: Create a workspace.
  * 6. `destroy_workspace`: Destroy a workspace.
  * 7. `load_js_configs`: Load JavaScript config files.
+ * 8. `initialize_plugin_workers`: Create worker isolates for JS plugins.
  *
  * Returns `true` if linting succeeded without errors, `false` otherwise.
  */
-export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb, createWorkspace: JsCreateWorkspaceCb, destroyWorkspace: JsDestroyWorkspaceCb, loadJsConfigs: JsLoadJsConfigsCb): Promise<boolean>
+export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb, createWorkspace: JsCreateWorkspaceCb, destroyWorkspace: JsDestroyWorkspaceCb, loadJsConfigs: JsLoadJsConfigsCb, initializePluginWorkers: JsInitializePluginWorkersCb): Promise<boolean>
 
 /**
  * Parse AST into provided `Uint8Array` buffer, synchronously.
@@ -132,3 +137,14 @@ export interface ParserOptions {
 
 /** Returns `true` if raw transfer is supported on this platform. */
 export declare function rawTransferSupported(): boolean
+
+/**
+ * Register a JS-plugin worker isolate with the currently initializing worker pool.
+ *
+ * # Errors
+ * Returns an error if the pool or worker index is invalid, or the worker already registered.
+ */
+export declare function registerJsPluginWorker(poolId: number, workerIndex: number, lintFile: JsLintFileCb): void
+
+/** Report that a JS-plugin worker isolate failed after it was created. */
+export declare function reportJsPluginWorkerFailure(poolId: number, workerIndex: number, error: string): void

--- a/apps/oxlint/src-js/bindings.js
+++ b/apps/oxlint/src-js/bindings.js
@@ -702,10 +702,12 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Severity, applyFixes, getBufferOffset, lint, parseRawSync, rawTransferSupported } = nativeBinding
+const { Severity, applyFixes, getBufferOffset, lint, parseRawSync, rawTransferSupported, registerJsPluginWorker, reportJsPluginWorkerFailure } = nativeBinding
 export { Severity }
 export { applyFixes }
 export { getBufferOffset }
 export { lint }
 export { parseRawSync }
 export { rawTransferSupported }
+export { registerJsPluginWorker }
+export { reportJsPluginWorkerFailure }

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -1,5 +1,7 @@
-import { lint } from "./bindings.js";
+import { Worker } from "node:worker_threads";
+import { lint, reportJsPluginWorkerFailure } from "./bindings.js";
 import { debugAssertIsNonNull, debugAssertIsNotUndefined } from "./utils/asserts.ts";
+import { getErrorMessage } from "./utils/utils.ts";
 
 // Lazy-loaded JS plugin-related functions.
 // The type annotations below use `typeof import("./plugins/index.ts").<fn>` so that the lazy-loaded variables
@@ -11,6 +13,77 @@ let createWorkspace: typeof import("./workspace/index.ts").createWorkspace | nul
 let destroyWorkspace: typeof import("./workspace/index.ts").destroyWorkspace | null = null;
 // Lazy-loaded JS/TS config loader (experimental)
 let resolvedConfigLoader: import("./js_config.ts").ConfigLoader | null = null;
+
+const PLUGIN_WORKER_URL = new URL("./plugin-worker.js", import.meta.url);
+const pluginWorkers: Worker[] = [];
+let pluginWorkersShuttingDown = false;
+
+interface PluginWorkerMessage {
+  ready?: true;
+  error?: string;
+}
+
+/**
+ * Create JS-plugin workers after Rust has finished resolving the canonical plugin configuration.
+ */
+async function initializePluginWorkersWrapper(
+  poolId: number,
+  workerCount: number,
+  bootstrapJSON: string,
+): Promise<undefined> {
+  const startupPromises: Promise<void>[] = [];
+
+  for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+    const worker = new Worker(PLUGIN_WORKER_URL, {
+      workerData: { poolId, workerIndex, bootstrapJSON },
+    });
+    pluginWorkers.push(worker);
+
+    startupPromises.push(
+      new Promise((resolve, reject) => {
+        let ready = false;
+        let startupSettled = false;
+
+        const fail = (error: unknown) => {
+          const message = typeof error === "string" ? error : getErrorMessage(error);
+          reportJsPluginWorkerFailure(poolId, workerIndex, message);
+          if (!startupSettled) {
+            startupSettled = true;
+            reject(new Error(`JS plugin worker ${workerIndex} failed: ${message}`));
+          }
+        };
+
+        worker.once("message", (message: PluginWorkerMessage) => {
+          if (message?.ready === true) {
+            ready = true;
+            startupSettled = true;
+            resolve();
+          } else {
+            fail(message?.error ?? "Worker sent an invalid startup response");
+          }
+        });
+        worker.on("error", fail);
+        worker.on("exit", (code) => {
+          if (pluginWorkersShuttingDown) return;
+          const message = ready
+            ? `JS plugin worker ${workerIndex} exited unexpectedly with code ${code}`
+            : `JS plugin worker ${workerIndex} exited during startup with code ${code}`;
+          reportJsPluginWorkerFailure(poolId, workerIndex, message);
+          if (!startupSettled) {
+            startupSettled = true;
+            reject(new Error(message));
+          }
+        });
+      }),
+    );
+  }
+
+  // Handle every startup promise concurrently, then propagate any failure after all workers settle.
+  for (const result of await Promise.allSettled(startupPromises)) {
+    if (result.status === "rejected") throw result.reason;
+  }
+  return undefined;
+}
 
 /**
  * Load a plugin.
@@ -182,15 +255,24 @@ if (!process.stdout.isTTY) {
 if (args.includes("--lsp")) process.stdout.write = process.stderr.write.bind(process.stderr);
 
 // Call Rust, passing callbacks and CLI arguments
-const success = await lint(
-  args,
-  loadPluginWrapper,
-  setupRuleConfigsWrapper,
-  lintFileWrapper,
-  createWorkspaceWrapper,
-  destroyWorkspaceWrapper,
-  loadJsConfigsWrapper,
-);
+let success = false;
+try {
+  success = await lint(
+    args,
+    loadPluginWrapper,
+    setupRuleConfigsWrapper,
+    lintFileWrapper,
+    createWorkspaceWrapper,
+    destroyWorkspaceWrapper,
+    loadJsConfigsWrapper,
+    initializePluginWorkersWrapper,
+  );
+} finally {
+  pluginWorkersShuttingDown = true;
+  const terminations = pluginWorkers.map((worker) => worker.terminate());
+  // Wait for every worker to terminate without masking a linting error with a shutdown failure.
+  await Promise.allSettled(terminations);
+}
 
 // Note: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
 // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxlint/src-js/plugin-worker.ts
+++ b/apps/oxlint/src-js/plugin-worker.ts
@@ -1,0 +1,93 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { registerJsPluginWorker } from "./bindings.js";
+import { lintFile, loadPlugin, setupRuleConfigs } from "./plugins/index.ts";
+import { getErrorMessage } from "./utils/utils.ts";
+
+interface PluginLoadRecord {
+  pluginUrl: string;
+  pluginName: string | null;
+  pluginNameIsAlias: boolean;
+  workspaceUri: string | null;
+  expected: {
+    name: string;
+    offset: number;
+    ruleNames: string[];
+  };
+}
+
+interface WorkerBootstrap {
+  plugins: PluginLoadRecord[];
+  optionsJson: string;
+}
+
+type LoadPluginReturnValue = { Success: PluginLoadRecord["expected"] } | { Failure: string };
+
+interface PluginWorkerData {
+  poolId: number;
+  workerIndex: number;
+  bootstrapJSON: string;
+}
+
+const { poolId, workerIndex, bootstrapJSON } = workerData as PluginWorkerData;
+
+async function initialize(): Promise<void> {
+  const bootstrap = JSON.parse(bootstrapJSON) as WorkerBootstrap;
+
+  // Plugin imports are deliberately sequential. Rule IDs and module side effects must occur in
+  // exactly the same order as on the canonical main isolate.
+  for (const plugin of bootstrap.plugins) {
+    // oxlint-disable-next-line no-await-in-loop -- Preserve the canonical plugin registration order.
+    const resultJSON = await loadPlugin(
+      plugin.pluginUrl,
+      plugin.pluginName,
+      plugin.pluginNameIsAlias,
+      plugin.workspaceUri,
+    );
+    const result = JSON.parse(resultJSON) as LoadPluginReturnValue;
+    if ("Failure" in result) throw new Error(result.Failure);
+
+    if (JSON.stringify(result.Success) !== JSON.stringify(plugin.expected)) {
+      throw new Error(
+        `Plugin registration did not match the main isolate. Expected ${JSON.stringify(plugin.expected)}, received ${JSON.stringify(result.Success)}`,
+      );
+    }
+  }
+
+  const setupError = setupRuleConfigs(bootstrap.optionsJson);
+  if (setupError !== null) throw new Error(setupError);
+
+  registerJsPluginWorker(poolId, workerIndex, lintFileWrapper);
+}
+
+function lintFileWrapper(
+  filePath: string,
+  bufferId: number,
+  buffer: Uint8Array | null | undefined,
+  ruleIds: number[],
+  optionsIds: number[],
+  settingsJSON: string,
+  globalsJSON: string,
+  workspaceUri: string | null | undefined,
+): string | null {
+  if (buffer === undefined) throw new TypeError("`buffer` should not be `undefined`");
+  if (workspaceUri === undefined) {
+    throw new TypeError("`workspaceUri` should not be `undefined`");
+  }
+  return lintFile(
+    filePath,
+    bufferId,
+    buffer,
+    ruleIds,
+    optionsIds,
+    settingsJSON,
+    globalsJSON,
+    workspaceUri,
+  );
+}
+
+try {
+  await initialize();
+  parentPort!.postMessage({ ready: true });
+} catch (error) {
+  parentPort!.postMessage({ error: getErrorMessage(error) });
+}

--- a/apps/oxlint/src/command/mod.rs
+++ b/apps/oxlint/src/command/mod.rs
@@ -31,6 +31,15 @@ pub struct MiscOptions {
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,
 
+    /// Number of JavaScript threads to use for JS plugins, including the main thread.
+    #[bpaf(
+        long("js-plugin-threads"),
+        argument("INT"),
+        guard(|threads| *threads != Some(0), "must be greater than 0"),
+        hide
+    )]
+    pub js_plugin_threads: Option<usize>,
+
     /// This option outputs the configuration to be used.
     /// When present, no linting is performed and only config-related options are valid.
     #[bpaf(switch, hide_usage)]
@@ -62,6 +71,7 @@ mod misc_options {
         let options = get_misc_options(".");
         assert!(!options.no_error_on_unmatched_pattern);
         assert!(options.threads.is_none());
+        assert!(options.js_plugin_threads.is_none());
     }
 
     #[test]
@@ -74,5 +84,17 @@ mod misc_options {
     fn threads() {
         let options = get_misc_options("--threads 4 .");
         assert_eq!(options.threads, Some(4));
+    }
+
+    #[test]
+    fn js_plugin_threads() {
+        let options = get_misc_options("--js-plugin-threads 4 .");
+        assert_eq!(options.js_plugin_threads, Some(4));
+    }
+
+    #[test]
+    fn js_plugin_threads_cannot_be_zero() {
+        let args = ["--js-plugin-threads", "0", "."].map(std::string::ToString::to_string);
+        assert!(lint_command().run_inner(args.as_slice()).is_err());
     }
 }

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -1,5 +1,9 @@
 use std::{
-    sync::{Arc, atomic::Ordering, mpsc::channel},
+    sync::{
+        Arc, Condvar, LazyLock, Mutex, OnceLock,
+        atomic::{AtomicU32, Ordering},
+        mpsc::{Receiver, RecvTimeoutError, channel},
+    },
     time::Duration,
 };
 
@@ -8,34 +12,189 @@ use napi::{
     bindgen_prelude::{FnArgs, Uint8Array},
     threadsafe_function::ThreadsafeFunctionCallMode,
 };
-use serde::Deserialize;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 
 use oxc_allocator::{Allocator, free_fixed_size_allocator};
 use oxc_linter::{
     ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
-    ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,
-    LintFileResult, LoadPluginResult,
+    ExternalLinterInitializeWorkersCb, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
+    ExternalLinterSetupRuleConfigsCb, LintFileResult, LoadPluginResult,
 };
 
 use crate::{
     generated::raw_transfer_constants::{BLOCK_ALIGN, BUFFER_SIZE},
     run::{
-        JsCreateWorkspaceCb, JsDestroyWorkspaceCb, JsLintFileCb, JsLoadPluginCb,
-        JsSetupRuleConfigsCb,
+        JsCreateWorkspaceCb, JsDestroyWorkspaceCb, JsInitializePluginWorkersCb, JsLintFileCb,
+        JsLoadPluginCb, JsSetupRuleConfigsCb,
     },
 };
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginLoadRecord {
+    plugin_url: String,
+    plugin_name: Option<String>,
+    plugin_name_is_alias: bool,
+    workspace_uri: Option<String>,
+    expected: LoadPluginResult,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerBootstrap {
+    plugins: Vec<PluginLoadRecord>,
+    options_json: String,
+}
+
+#[derive(Default)]
+struct BootstrapState {
+    plugins: Mutex<Vec<PluginLoadRecord>>,
+    options_json: Mutex<Option<String>>,
+}
+
+#[derive(Default)]
+struct WorkerHealth {
+    failure: Mutex<Option<String>>,
+    failure_reported: Condvar,
+}
+
+impl WorkerHealth {
+    fn fail(&self, error: String) {
+        let mut failure = self.failure.lock().unwrap();
+        if failure.is_none() {
+            *failure = Some(error);
+            self.failure_reported.notify_all();
+        }
+    }
+
+    fn get_failure(&self) -> Option<String> {
+        self.failure.lock().unwrap().clone()
+    }
+
+    fn wait_for_failure(&self) -> Option<String> {
+        let failure = self.failure.lock().unwrap();
+        let (failure, _) = self
+            .failure_reported
+            .wait_timeout_while(failure, Duration::from_millis(500), |failure| failure.is_none())
+            .unwrap();
+        failure.clone()
+    }
+}
+
+struct RegisteredWorker {
+    lint_file: JsLintFileCb,
+    health: Arc<WorkerHealth>,
+}
+
+struct PendingWorkerPool {
+    workers: Vec<Option<RegisteredWorker>>,
+    failures: Vec<Option<String>>,
+}
+
+impl PendingWorkerPool {
+    fn new(worker_count: usize) -> Self {
+        Self {
+            workers: std::iter::repeat_with(|| None).take(worker_count).collect(),
+            failures: vec![None; worker_count],
+        }
+    }
+}
+
+type PendingWorkerPools = FxHashMap<u32, PendingWorkerPool>;
+type WorkerHealths = FxHashMap<(u32, u32), Arc<WorkerHealth>>;
+
+static NEXT_WORKER_POOL_ID: AtomicU32 = AtomicU32::new(1);
+static PENDING_WORKER_POOLS: LazyLock<Mutex<PendingWorkerPools>> =
+    LazyLock::new(|| Mutex::new(FxHashMap::default()));
+static WORKER_HEALTHS: LazyLock<Mutex<WorkerHealths>> =
+    LazyLock::new(|| Mutex::new(FxHashMap::default()));
+
+struct WorkerPoolGuard {
+    pool_id: u32,
+    worker_count: u32,
+}
+
+impl Drop for WorkerPoolGuard {
+    fn drop(&mut self) {
+        cleanup_worker_healths(self.pool_id, self.worker_count);
+    }
+}
+
+struct InitializedLintHosts {
+    callbacks: Box<[ExternalLinterLintFileCb]>,
+    _worker_pool: WorkerPoolGuard,
+}
+
+type LintHosts = OnceLock<InitializedLintHosts>;
+
+pub fn register_worker(
+    pool_id: u32,
+    worker_index: u32,
+    lint_file: JsLintFileCb,
+) -> Result<(), String> {
+    let mut pools = PENDING_WORKER_POOLS.lock().unwrap();
+    let pool = pools
+        .get_mut(&pool_id)
+        .ok_or_else(|| format!("JS plugin worker pool {pool_id} is not being initialized"))?;
+    let worker_index_usize = usize::try_from(worker_index)
+        .map_err(|_| format!("JS plugin worker index {worker_index} is out of range"))?;
+    let worker = pool
+        .workers
+        .get_mut(worker_index_usize)
+        .ok_or_else(|| format!("JS plugin worker index {worker_index_usize} is out of range"))?;
+    if worker.is_some() {
+        return Err(format!("JS plugin worker {worker_index_usize} registered more than once"));
+    }
+
+    let health = Arc::new(WorkerHealth::default());
+    if let Some(error) = pool.failures[worker_index_usize].take() {
+        health.fail(error);
+    }
+    WORKER_HEALTHS.lock().unwrap().insert((pool_id, worker_index), Arc::clone(&health));
+    *worker = Some(RegisteredWorker { lint_file, health });
+    Ok(())
+}
+
+pub fn report_worker_failure(pool_id: u32, worker_index: u32, error: String) {
+    let mut pools = PENDING_WORKER_POOLS.lock().unwrap();
+    if let Some(pool) = pools.get_mut(&pool_id)
+        && let Some(failure) = pool.failures.get_mut(worker_index as usize)
+    {
+        if failure.is_none() {
+            *failure = Some(error.clone());
+        }
+        if let Some(Some(worker)) = pool.workers.get(worker_index as usize) {
+            worker.health.fail(error);
+        }
+        return;
+    }
+    drop(pools);
+
+    if let Some(health) = WORKER_HEALTHS.lock().unwrap().get(&(pool_id, worker_index)) {
+        health.fail(error);
+    }
+}
 
 /// Wrap JS callbacks as normal Rust functions, and create [`ExternalLinter`].
 pub fn create_external_linter(
     load_plugin: JsLoadPluginCb,
     setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
+    initialize_workers: JsInitializePluginWorkersCb,
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
 ) -> ExternalLinter {
-    let rust_load_plugin = wrap_load_plugin(load_plugin);
-    let rust_setup_rule_configs = wrap_setup_rule_configs(setup_rule_configs);
-    let rust_lint_file = wrap_lint_file(lint_file);
+    let bootstrap_state = Arc::new(BootstrapState::default());
+    let lint_hosts = Arc::new(OnceLock::new());
+
+    let rust_load_plugin = wrap_load_plugin(load_plugin, Arc::clone(&bootstrap_state));
+    let rust_setup_rule_configs =
+        wrap_setup_rule_configs(setup_rule_configs, Arc::clone(&bootstrap_state));
+    let main_lint_file = wrap_lint_file(lint_file, None);
+    let rust_lint_file = dispatch_lint_file(Arc::clone(&main_lint_file), Arc::clone(&lint_hosts));
+    let rust_initialize_workers =
+        wrap_initialize_workers(initialize_workers, bootstrap_state, main_lint_file, lint_hosts);
     let rust_create_workspace = wrap_create_workspace(create_workspace);
     let rust_destroy_workspace = wrap_destroy_workspace(destroy_workspace);
 
@@ -43,6 +202,7 @@ pub fn create_external_linter(
         rust_load_plugin,
         rust_setup_rule_configs,
         rust_lint_file,
+        rust_initialize_workers,
         rust_create_workspace,
         rust_destroy_workspace,
     )
@@ -61,8 +221,18 @@ pub enum LoadPluginReturnValue {
 /// until the `Promise` returned by the JS function resolves.
 ///
 /// The returned function will panic if called outside of a Tokio runtime.
-fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
+fn wrap_load_plugin(
+    cb: JsLoadPluginCb,
+    bootstrap_state: Arc<BootstrapState>,
+) -> ExternalLinterLoadPluginCb {
     Arc::new(Box::new(move |plugin_url, plugin_name, plugin_name_is_alias, workspace_uri| {
+        let record = PluginLoadRecord {
+            plugin_url: plugin_url.clone(),
+            plugin_name: plugin_name.clone(),
+            plugin_name_is_alias,
+            workspace_uri: workspace_uri.clone(),
+            expected: LoadPluginResult { name: String::new(), offset: 0, rule_names: Vec::new() },
+        };
         let cb = &cb;
         let res = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
@@ -82,7 +252,12 @@ fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
             // `loadPlugin` returns JSON string if plugin loaded successfully, or an error occurred
             Ok(json) => match serde_json::from_str(&json) {
                 // Plugin loaded successfully
-                Ok(LoadPluginReturnValue::Success(result)) => Ok(result),
+                Ok(LoadPluginReturnValue::Success(result)) => {
+                    let mut record = record;
+                    record.expected = result.clone();
+                    bootstrap_state.plugins.lock().unwrap().push(record);
+                    Ok(result)
+                }
                 // Error occurred on JS side
                 Ok(LoadPluginReturnValue::Failure(err)) => Err(err),
                 // Invalid JSON - should be impossible, because we control serialization on JS side
@@ -101,9 +276,13 @@ fn wrap_load_plugin(cb: JsLoadPluginCb) -> ExternalLinterLoadPluginCb {
 /// The JS-side `setupRuleConfigs` function is synchronous, but it's wrapped in a `ThreadsafeFunction`,
 /// so cannot be called synchronously. Use an `mpsc::channel` to wait for the result from JS side,
 /// and block current thread until `setupRuleConfigs` completes execution.
-fn wrap_setup_rule_configs(cb: JsSetupRuleConfigsCb) -> ExternalLinterSetupRuleConfigsCb {
+fn wrap_setup_rule_configs(
+    cb: JsSetupRuleConfigsCb,
+    bootstrap_state: Arc<BootstrapState>,
+) -> ExternalLinterSetupRuleConfigsCb {
     Arc::new(Box::new(move |options_json: String| {
         let (tx, rx) = channel();
+        let bootstrap_options_json = options_json.clone();
 
         // Send data to JS
         let status = cb.call_with_return_value(
@@ -122,7 +301,10 @@ fn wrap_setup_rule_configs(cb: JsSetupRuleConfigsCb) -> ExternalLinterSetupRuleC
         if status == Status::Ok {
             match rx.recv() {
                 // Setup succeeded
-                Ok(Ok(None)) => Ok(()),
+                Ok(Ok(None)) => {
+                    *bootstrap_state.options_json.lock().unwrap() = Some(bootstrap_options_json);
+                    Ok(())
+                }
                 // Setup failed
                 Ok(Ok(Some(err))) => Err(err),
                 // `setupRuleConfigs` threw an error - should be impossible because it should be infallible
@@ -136,6 +318,142 @@ fn wrap_setup_rule_configs(cb: JsSetupRuleConfigsCb) -> ExternalLinterSetupRuleC
             Err(format!("Failed to schedule `setupRuleConfigs` callback: {status:?}"))
         }
     }))
+}
+
+fn wrap_initialize_workers(
+    cb: JsInitializePluginWorkersCb,
+    bootstrap_state: Arc<BootstrapState>,
+    main_lint_file: ExternalLinterLintFileCb,
+    lint_hosts: Arc<LintHosts>,
+) -> ExternalLinterInitializeWorkersCb {
+    Arc::new(Box::new(move |host_count| {
+        if host_count <= 1 {
+            return Ok(());
+        }
+        if lint_hosts.get().is_some() {
+            return Err("JS plugin workers have already been initialized".to_string());
+        }
+
+        let worker_count = host_count - 1;
+        let worker_count_u32 = u32::try_from(worker_count)
+            .map_err(|_| format!("Too many JS plugin workers requested: {worker_count}"))?;
+        let options_json =
+            bootstrap_state.options_json.lock().unwrap().clone().ok_or_else(|| {
+                "JS plugin rule configuration has not been initialized".to_string()
+            })?;
+        let bootstrap = WorkerBootstrap {
+            plugins: bootstrap_state.plugins.lock().unwrap().clone(),
+            options_json,
+        };
+        let bootstrap_json = serde_json::to_string(&bootstrap)
+            .map_err(|err| format!("Failed to serialize JS plugin worker state: {err}"))?;
+
+        let pool_id = NEXT_WORKER_POOL_ID.fetch_add(1, Ordering::Relaxed);
+        if pool_id == 0 {
+            return Err("JS plugin worker pool ID space exhausted".to_string());
+        }
+        {
+            let mut pools = PENDING_WORKER_POOLS.lock().unwrap();
+            if pools.insert(pool_id, PendingWorkerPool::new(worker_count)).is_some() {
+                return Err(format!("JS plugin worker pool ID {pool_id} is already in use"));
+            }
+        }
+
+        let res = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                cb.call_async(FnArgs::from((pool_id, worker_count_u32, bootstrap_json)))
+                    .await?
+                    .into_future()
+                    .await
+            })
+        });
+
+        if let Err(err) = res {
+            cleanup_worker_pool(pool_id, worker_count_u32);
+            return Err(format!("Failed to initialize JS plugin workers: {err}"));
+        }
+
+        let pool =
+            PENDING_WORKER_POOLS.lock().unwrap().remove(&pool_id).ok_or_else(|| {
+                format!("JS plugin worker pool {pool_id} disappeared during startup")
+            })?;
+
+        if let Some((worker_index, error)) = pool
+            .failures
+            .iter()
+            .enumerate()
+            .find_map(|(index, error)| error.as_ref().map(|error| (index, error.clone())))
+        {
+            cleanup_worker_healths(pool_id, worker_count_u32);
+            return Err(format!("JS plugin worker {worker_index} failed during startup: {error}"));
+        }
+
+        let mut hosts = Vec::with_capacity(host_count);
+        hosts.push(Arc::clone(&main_lint_file));
+        for (worker_index, worker) in pool.workers.into_iter().enumerate() {
+            let Some(worker) = worker else {
+                cleanup_worker_healths(pool_id, worker_count_u32);
+                return Err(format!(
+                    "JS plugin worker {worker_index} did not register during startup"
+                ));
+            };
+            hosts.push(wrap_lint_file(worker.lint_file, Some(worker.health)));
+        }
+
+        lint_hosts
+            .set(InitializedLintHosts {
+                callbacks: hosts.into_boxed_slice(),
+                _worker_pool: WorkerPoolGuard { pool_id, worker_count: worker_count_u32 },
+            })
+            .map_err(|_| "JS plugin workers have already been initialized".to_string())
+    }))
+}
+
+fn cleanup_worker_pool(pool_id: u32, worker_count: u32) {
+    PENDING_WORKER_POOLS.lock().unwrap().remove(&pool_id);
+    cleanup_worker_healths(pool_id, worker_count);
+}
+
+fn cleanup_worker_healths(pool_id: u32, worker_count: u32) {
+    let mut healths = WORKER_HEALTHS.lock().unwrap();
+    for worker_index in 0..worker_count {
+        healths.remove(&(pool_id, worker_index));
+    }
+}
+
+fn dispatch_lint_file(
+    main_lint_file: ExternalLinterLintFileCb,
+    lint_hosts: Arc<LintHosts>,
+) -> ExternalLinterLintFileCb {
+    Arc::new(Box::new(
+        move |file_path,
+              rule_ids,
+              options_ids,
+              settings_json,
+              globals_json,
+              workspace_uri,
+              allocator| {
+            let host = if let Some(hosts) = lint_hosts.get() {
+                // SAFETY: External rules are only run with allocators obtained from a fixed-size
+                // allocator pool. The worker pool is initialized before any file is linted, and its
+                // size never changes, so a buffer always maps to the same JavaScript isolate.
+                let buffer_id = unsafe { allocator.fixed_size_metadata_ptr().as_ref().id };
+                &hosts.callbacks[buffer_id as usize % hosts.callbacks.len()]
+            } else {
+                &main_lint_file
+            };
+
+            host(
+                file_path,
+                rule_ids,
+                options_ids,
+                settings_json,
+                globals_json,
+                workspace_uri,
+                allocator,
+            )
+        },
+    ))
 }
 
 /// Result returned by `lintFile` JS callback.
@@ -154,7 +472,7 @@ pub enum LintFileReturnValue {
 /// on main JS thread, and therefore it may have to wait for a previous `lintFile` call to complete.
 /// Use an `mpsc::channel` to wait for the result from JS side, and block current thread until `lintFile`
 /// completes execution.
-fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
+fn wrap_lint_file(cb: JsLintFileCb, health: Option<Arc<WorkerHealth>>) -> ExternalLinterLintFileCb {
     Arc::new(Box::new(
         move |file_path: String,
               rule_ids: Vec<u32>,
@@ -197,11 +515,11 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
             );
 
             if status == Status::Ok {
-                match rx.recv() {
+                match receive_lint_result(&rx, health.as_deref()) {
                     // `lintFile` returns `null` if no diagnostics reported, and no error occurred
-                    Ok(Ok(None)) => Ok(Vec::new()),
+                    Ok(None) => Ok(Vec::new()),
                     // `lintFile` returns JSON string if diagnostics reported, or an error occurred
-                    Ok(Ok(Some(json))) => {
+                    Ok(Some(json)) => {
                         match serde_json::from_str(&json) {
                             // Diagnostics reported
                             Ok(LintFileReturnValue::Success(diagnostics)) => Ok(diagnostics),
@@ -215,17 +533,53 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
                         }
                     }
                     // `lintFile` threw an error - should be impossible because `lintFile` is wrapped in try-catch
-                    Ok(Err(err)) => Err(format!("`lintFile` threw an error: {err}")),
-                    // Sender "hung up" - should be impossible because closure passed to `call_with_return_value`
-                    // takes ownership of the sender `tx`. Unless NAPI-RS drops the closure without calling it,
-                    // `tx.send()` always happens before `tx` is dropped.
-                    Err(err) => Err(format!("`lintFile` did not respond: {err}")),
+                    Err(err) => Err(err),
                 }
             } else {
-                Err(format!("Failed to schedule `lintFile` callback: {status:?}"))
+                // When a worker exits, N-API can report `Closing` just before Node delivers the
+                // worker's `exit` event to the main isolate. Wait briefly for that more useful
+                // health error instead of emitting a generic scheduling failure.
+                let worker_error = health.as_ref().and_then(|health| health.wait_for_failure());
+                Err(worker_error.unwrap_or_else(|| {
+                    format!("Failed to schedule `lintFile` callback: {status:?}")
+                }))
             }
         },
     ))
+}
+
+fn receive_lint_result(
+    rx: &Receiver<napi::Result<Option<String>>>,
+    health: Option<&WorkerHealth>,
+) -> Result<Option<String>, String> {
+    if let Some(health) = health {
+        loop {
+            match rx.recv_timeout(Duration::from_millis(100)) {
+                Ok(Ok(result)) => return Ok(result),
+                Ok(Err(err)) => {
+                    return Err(health
+                        .wait_for_failure()
+                        .unwrap_or_else(|| format!("`lintFile` threw an error: {err}")));
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(health.wait_for_failure().unwrap_or_else(|| {
+                        "`lintFile` callback disconnected without responding".to_string()
+                    }));
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    if let Some(error) = health.get_failure() {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    }
+
+    match rx.recv() {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(err)) => Err(format!("`lintFile` threw an error: {err}")),
+        Err(err) => Err(format!("`lintFile` did not respond: {err}")),
+    }
 }
 
 /// Get buffer ID of the `Allocator` and, if it hasn't already been sent to JS,

--- a/apps/oxlint/src/js_plugins/mod.rs
+++ b/apps/oxlint/src/js_plugins/mod.rs
@@ -6,4 +6,4 @@ pub mod fix;
 #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
 pub mod parse;
 
-pub use external_linter::create_external_linter;
+pub use external_linter::{create_external_linter, register_worker, report_worker_failure};

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -95,6 +95,18 @@ impl CliRunner {
             ..
         } = self.options;
 
+        let requested_js_plugin_threads = misc_options.js_plugin_threads.unwrap_or(1);
+        let rust_thread_count = rayon::current_num_threads();
+        if requested_js_plugin_threads > rust_thread_count {
+            print_and_flush_stdout(
+                stdout,
+                &format!(
+                    "`--js-plugin-threads` ({requested_js_plugin_threads}) cannot exceed the effective `--threads` count ({rust_thread_count}).\n"
+                ),
+            );
+            return CliRunResult::InvalidOptionJsPluginThreads;
+        }
+
         if basic_options.init {
             return crate::mode::run_init(&self.cwd, stdout);
         }
@@ -376,6 +388,7 @@ impl CliRunner {
             .into_iter()
             .filter(|path| !ignore_matcher.should_ignore(Path::new(path)))
             .collect::<Vec<Arc<OsStr>>>();
+        let number_of_files = files_to_lint.len();
 
         if debug_files {
             return crate::mode::run_debug_files(
@@ -474,13 +487,23 @@ impl CliRunner {
                 );
                 return CliRunResult::InvalidOptionConfig;
             }
+
+            if number_of_files > 0 {
+                let js_plugin_host_count = requested_js_plugin_threads.min(number_of_files);
+                if let Err(err) = external_linter.initialize_workers(js_plugin_host_count) {
+                    print_and_flush_stdout(
+                        stdout,
+                        &format!("Failed to initialize JS plugin workers:\n{err}\n"),
+                    );
+                    return CliRunResult::InvalidOptionJsPluginThreads;
+                }
+            }
         }
 
         let linter = Linter::new(LintOptions::default(), config_store, external_linter)
             .with_fix(fix_options.fix_kind())
             .with_report_unused_directives(report_unused_directives);
 
-        let number_of_files = files_to_lint.len();
         let tsconfig = basic_options.tsconfig;
         if let Some(path) = tsconfig.as_ref() {
             if path.is_file() {

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -19,6 +19,11 @@ fn main() -> CliRunResult {
     // (Rayon-based); `#[tokio::main]` would otherwise spawn one idle Tokio worker thread per core
     // on every lint invocation.
     if command.lsp {
+        if command.misc_options.js_plugin_threads.is_some_and(|threads| threads > 1) {
+            print_js_plugin_threads_lsp_error();
+            return CliRunResult::InvalidOptionJsPluginThreads;
+        }
+
         let runtime =
             tokio::runtime::Runtime::new().expect("Failed to build the Tokio runtime for the LSP");
         return runtime.block_on(async {
@@ -40,4 +45,9 @@ fn main() -> CliRunResult {
 
     // Run without external linter (no JS plugins)
     CliRunner::new(command, None).run(&mut stdout)
+}
+
+#[expect(clippy::print_stderr, reason = "LSP reserves stdout for protocol messages")]
+fn print_js_plugin_threads_lsp_error() {
+    eprintln!("`--js-plugin-threads` greater than 1 is not supported with `--lsp`.");
 }

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -5,6 +5,7 @@ pub enum CliRunResult {
     None,
     JsPluginWorkspaceSetupFailed,
     InvalidOptionConfig,
+    InvalidOptionJsPluginThreads,
     InvalidOptionTsConfig,
     InvalidOptionTypeCheckWithoutTypeAware,
     InvalidOptionTypeCheckOnlyWithFix,
@@ -38,6 +39,7 @@ impl Termination for CliRunResult {
             | Self::LintNoWarningsAllowed
             | Self::LintMaxWarningsExceeded
             | Self::InvalidOptionConfig
+            | Self::InvalidOptionJsPluginThreads
             | Self::InvalidOptionTsConfig
             | Self::InvalidOptionTypeCheckWithoutTypeAware
             | Self::InvalidOptionTypeCheckOnlyWithFix

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -4,13 +4,27 @@ use std::{
 };
 
 use napi::{
-    Status,
+    Error, Status,
     bindgen_prelude::{FnArgs, Promise, Uint8Array},
     threadsafe_function::ThreadsafeFunction,
 };
 use napi_derive::napi;
 
 use crate::{init::init_tracing, lint::CliRunner, result::CliRunResult};
+
+/// JS callback which creates worker isolates for external plugins.
+#[napi]
+pub type JsInitializePluginWorkersCb = ThreadsafeFunction<
+    FnArgs<(
+        u32,    // Worker pool ID
+        u32,    // Number of workers to create (does not include main JS isolate)
+        String, // Serialized plugin bootstrap state
+    )>,
+    Promise<()>,
+    FnArgs<(u32, u32, String)>,
+    Status,
+    false,
+>;
 
 /// JS callback to load a JS plugin.
 #[napi]
@@ -132,6 +146,7 @@ pub type JsLoadJsConfigsCb = ThreadsafeFunction<
 /// 5. `create_workspace`: Create a workspace.
 /// 6. `destroy_workspace`: Destroy a workspace.
 /// 7. `load_js_configs`: Load JavaScript config files.
+/// 8. `initialize_plugin_workers`: Create worker isolates for JS plugins.
 ///
 /// Returns `true` if linting succeeded without errors, `false` otherwise.
 #[expect(clippy::allow_attributes)]
@@ -145,6 +160,7 @@ pub async fn lint(
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
     load_js_configs: JsLoadJsConfigsCb,
+    initialize_plugin_workers: JsInitializePluginWorkersCb,
 ) -> bool {
     lint_impl(
         args,
@@ -154,6 +170,7 @@ pub async fn lint(
         create_workspace,
         destroy_workspace,
         load_js_configs,
+        initialize_plugin_workers,
     )
     .await
     .report()
@@ -169,6 +186,7 @@ async fn lint_impl(
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
     load_js_configs: JsLoadJsConfigsCb,
+    initialize_plugin_workers: JsInitializePluginWorkersCb,
 ) -> CliRunResult {
     // Convert String args to OsString for compatibility with bpaf
     let args: Vec<std::ffi::OsString> = args.into_iter().map(std::ffi::OsString::from).collect();
@@ -199,6 +217,7 @@ async fn lint_impl(
             load_plugin,
             setup_rule_configs,
             lint_file,
+            initialize_plugin_workers,
             create_workspace,
             destroy_workspace,
         ));
@@ -206,10 +225,11 @@ async fn lint_impl(
     };
     #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
     let (external_linter, js_config_loader) = {
-        let (_, _, _, _, _, _) = (
+        let (_, _, _, _, _, _, _) = (
             load_plugin,
             setup_rule_configs,
             lint_file,
+            initialize_plugin_workers,
             create_workspace,
             destroy_workspace,
             load_js_configs,
@@ -219,6 +239,11 @@ async fn lint_impl(
 
     // If --lsp flag is set, run the language server
     if command.lsp {
+        if command.misc_options.js_plugin_threads.is_some_and(|threads| threads > 1) {
+            print_js_plugin_threads_lsp_error();
+            return CliRunResult::InvalidOptionJsPluginThreads;
+        }
+
         crate::lsp::run_lsp(external_linter, js_config_loader).await;
         return CliRunResult::LintSucceeded;
     }
@@ -236,6 +261,42 @@ async fn lint_impl(
     }
 
     cli_runner.run(&mut stdout)
+}
+
+#[expect(clippy::print_stderr, reason = "LSP reserves stdout for protocol messages")]
+fn print_js_plugin_threads_lsp_error() {
+    eprintln!("`--js-plugin-threads` greater than 1 is not supported with `--lsp`.");
+}
+
+/// Register a JS-plugin worker isolate with the currently initializing worker pool.
+///
+/// # Errors
+/// Returns an error if the pool or worker index is invalid, or the worker already registered.
+#[napi]
+pub fn register_js_plugin_worker(
+    pool_id: u32,
+    worker_index: u32,
+    lint_file: JsLintFileCb,
+) -> napi::Result<()> {
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    {
+        crate::js_plugins::register_worker(pool_id, worker_index, lint_file)
+            .map_err(Error::from_reason)
+    }
+    #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+    {
+        let _ = (pool_id, worker_index, lint_file);
+        Err(Error::from_reason("JS plugins are not supported on this platform".to_string()))
+    }
+}
+
+/// Report that a JS-plugin worker isolate failed after it was created.
+#[napi]
+pub fn report_js_plugin_worker_failure(pool_id: u32, worker_index: u32, error: String) {
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    crate::js_plugins::report_worker_failure(pool_id, worker_index, error);
+    #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+    let _ = (pool_id, worker_index, error);
 }
 
 #[cfg(all(target_pointer_width = "64", target_endian = "little"))]

--- a/apps/oxlint/test/plugin_workers.test.ts
+++ b/apps/oxlint/test/plugin_workers.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execa } from "execa";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PACKAGE_ROOT_PATH } from "./utils.ts";
+
+const CLI_PATH = join(PACKAGE_ROOT_PATH, "dist/cli.js");
+
+// Use real child processes: worker startup, N-API callbacks, and shutdown must all work together.
+describe("JS plugin workers", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "oxlint-plugin-workers-"));
+    await mkdir(join(cwd, "files"));
+    await Promise.all(
+      Array.from({ length: 32 }, (_, index) =>
+        writeFile(join(cwd, "files", `${index}.js`), "debugger;\n"),
+      ),
+    );
+    await writeFile(
+      join(cwd, ".oxlintrc.json"),
+      JSON.stringify({
+        plugins: [],
+        categories: { correctness: "off" },
+        jsPlugins: ["./plugin.mjs"],
+        rules: { "workers/check": ["error", { message: "configured message" }] },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  function lint(threads: number, ...args: string[]) {
+    return execa(
+      process.execPath,
+      [CLI_PATH, "--threads", "4", "--js-plugin-threads", String(threads), "files", ...args],
+      { cwd, reject: false, timeout: 10_000 },
+    );
+  }
+
+  async function plugin(source: string) {
+    await writeFile(join(cwd, "plugin.mjs"), source);
+  }
+
+  it("replays options on workers and preserves diagnostics and fixes", async () => {
+    await plugin(`
+      import { threadId } from 'node:worker_threads';
+      export default {
+        meta: { name: 'workers' },
+        rules: {
+          check: {
+            meta: { schema: [{ type: 'object' }], fixable: 'code' },
+            create(context) {
+              return {
+                DebuggerStatement(node) {
+                  context.report({
+                    node,
+                    message: context.options[0].message + ' host=' + threadId,
+                    fix(fixer) { return fixer.remove(node); },
+                  });
+                },
+              };
+            },
+          },
+        },
+      };
+    `);
+    const serial = await lint(1, "--format", "json");
+    const parallel = await lint(4, "--format", "json");
+    for (const result of [serial, parallel]) {
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toBe("");
+    }
+    const serialOutput = JSON.parse(serial.stdout);
+    const parallelOutput = JSON.parse(parallel.stdout);
+    expect(serialOutput.diagnostics).toHaveLength(32);
+    expect(parallelOutput.diagnostics).toHaveLength(32);
+    const normalize = (diagnostics: { message: string }[]) =>
+      diagnostics
+        .map((diagnostic) =>
+          JSON.stringify({
+            ...diagnostic,
+            message: diagnostic.message.replace(/ host=\d+$/, ""),
+          }),
+        )
+        .sort();
+    expect(normalize(parallelOutput.diagnostics)).toEqual(normalize(serialOutput.diagnostics));
+    const messages = parallelOutput.diagnostics.map(
+      (diagnostic: { message: string }) => diagnostic.message,
+    );
+    expect(
+      messages.every((message: string) => message.startsWith("configured message host=")),
+    ).toBe(true);
+    // A serial fallback can produce correct diagnostics too; require actual worker execution.
+    expect(messages.some((message: string) => /host=[1-9]\d*$/.test(message))).toBe(true);
+
+    const fixed = await lint(4, "--fix");
+    expect(fixed.timedOut).toBe(false);
+    expect(fixed.exitCode).toBe(0);
+    const files = await Promise.all(
+      Array.from({ length: 32 }, (_, index) => readFile(join(cwd, "files", `${index}.js`), "utf8")),
+    );
+    expect(files).toEqual(Array.from({ length: 32 }, () => "\n"));
+  });
+
+  it.each([
+    [
+      "import failure",
+      "if (!isMainThread) throw new Error('worker import failed');",
+      "worker import failed",
+    ],
+    ["registration mismatch", "", "Plugin registration did not match the main isolate"],
+  ])("reports worker startup %s and shuts down", async (kind, initialization, message) => {
+    await plugin(`
+      import { isMainThread } from 'node:worker_threads';
+      ${initialization}
+      export default {
+        meta: { name: 'workers' },
+        rules: {
+          [${kind === "registration mismatch" ? "isMainThread ? 'check' : 'different'" : "'check'"}]: {
+            meta: { schema: [{ type: 'object' }] },
+            create() { return {}; },
+          },
+        },
+      };
+    `);
+    const serial = await lint(1);
+    expect(serial.exitCode).toBe(0);
+    const result = await lint(4);
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain(message);
+  });
+
+  it("reports a worker exiting inside a visitor instead of waiting forever", async () => {
+    await plugin(`
+      import { isMainThread } from 'node:worker_threads';
+      export default {
+        meta: { name: 'workers' },
+        rules: {
+          check: {
+            meta: { schema: [{ type: 'object' }] },
+            create() {
+              return { DebuggerStatement() { if (!isMainThread) process.exit(23); } };
+            },
+          },
+        },
+      };
+    `);
+    const serial = await lint(1);
+    expect(serial.exitCode).toBe(0);
+    const result = await lint(4);
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain("exited unexpectedly with code 23");
+  });
+
+  it("does not start extra workers when only one file is selected", async () => {
+    await plugin(`
+      import { isMainThread } from 'node:worker_threads';
+      if (!isMainThread) throw new Error('unnecessary worker');
+      export default {
+        meta: { name: 'workers' },
+        rules: {
+          check: {
+            meta: { schema: [{ type: 'object' }] },
+            create() { return {}; },
+          },
+        },
+      };
+    `);
+    await rm(join(cwd, "files"), { recursive: true });
+    await mkdir(join(cwd, "files"));
+    await writeFile(join(cwd, "files", "only.js"), "debugger;\n");
+    const result = await lint(4, "--format", "json");
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).number_of_files).toBe(1);
+  });
+});

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -95,7 +95,7 @@ export default defineConfig([
   // Main build
   {
     ...commonConfig,
-    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugins-dev.ts"],
+    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugin-worker.ts", "src-js/plugins-dev.ts"],
     format: "esm",
     deps: {
       ...commonConfig.deps,

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -15,6 +15,9 @@ use crate::{
 pub type ExternalLinterCreateWorkspaceCb =
     Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>;
 
+pub type ExternalLinterInitializeWorkersCb =
+    Arc<Box<dyn Fn(usize) -> Result<(), String> + Send + Sync>>;
+
 pub type ExternalLinterDestroyWorkspaceCb =
     Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>;
 
@@ -64,7 +67,7 @@ pub type ExternalLinterLintFileCb = Arc<
     >,
 >;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LoadPluginResult {
     pub name: String,
@@ -250,6 +253,7 @@ pub struct ExternalLinter {
     pub(crate) load_plugin: ExternalLinterLoadPluginCb,
     pub(crate) setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
     pub(crate) lint_file: ExternalLinterLintFileCb,
+    initialize_workers: ExternalLinterInitializeWorkersCb,
     pub create_workspace: ExternalLinterCreateWorkspaceCb,
     pub destroy_workspace: ExternalLinterDestroyWorkspaceCb,
 }
@@ -259,10 +263,29 @@ impl ExternalLinter {
         load_plugin: ExternalLinterLoadPluginCb,
         setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
         lint_file: ExternalLinterLintFileCb,
+        initialize_workers: ExternalLinterInitializeWorkersCb,
         create_workspace: ExternalLinterCreateWorkspaceCb,
         destroy_workspace: ExternalLinterDestroyWorkspaceCb,
     ) -> Self {
-        Self { load_plugin, setup_rule_configs, lint_file, create_workspace, destroy_workspace }
+        Self {
+            load_plugin,
+            setup_rule_configs,
+            lint_file,
+            initialize_workers,
+            create_workspace,
+            destroy_workspace,
+        }
+    }
+
+    /// Initialize JavaScript worker isolates used to execute external rules.
+    ///
+    /// `host_count` includes the main JavaScript isolate. A value of `1` preserves the existing
+    /// single-isolate behavior.
+    ///
+    /// # Errors
+    /// Returns an error if workers cannot be started or initialized.
+    pub fn initialize_workers(&self, host_count: usize) -> Result<(), String> {
+        (self.initialize_workers)(host_count)
     }
 }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -76,8 +76,9 @@ pub use crate::{
     context::{ContextSubHost, ContextSubHostOptions, LintContext},
     external_linter::{
         ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
-        ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,
-        JsFix, LintFileResult, LoadPluginResult, convert_and_merge_js_fixes,
+        ExternalLinterInitializeWorkersCb, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
+        ExternalLinterSetupRuleConfigsCb, JsFix, LintFileResult, LoadPluginResult,
+        convert_and_merge_js_fixes,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
     fixer::{Fix, FixKind, Fixer, Message, PossibleFixes, oxc_code_short_canonical_name},

--- a/npm/oxlint-plugins/README.md
+++ b/npm/oxlint-plugins/README.md
@@ -90,6 +90,16 @@ So a plugin which depends on `@oxlint/plugins` can be:
 - Used with ESLint 8+.
 - Published as either ESM or CommonJS.
 
+## Experimental parallel execution
+
+Oxlint can run JavaScript plugins in parallel with `--js-plugin-threads <N>`. The count includes
+the main JavaScript thread, so `1` preserves the default behavior and values above `1` create
+additional Node.js worker isolates.
+
+Each isolate loads an independent instance of every plugin. Do not rely on module-level mutable
+state for cross-file aggregation when this option is enabled. File execution order is
+nondeterministic, just as it is for Oxlint's normal multithreaded file processing.
+
 ## Docs
 
 For full documentation, see [Oxlint JS Plugins docs](https://oxc.rs/docs/guide/usage/linter/js-plugins).


### PR DESCRIPTION
Add experimental parallel execution for JavaScript plugins with `--js-plugin-threads <N>`. The count includes the main JavaScript thread and defaults to `1`; higher values create Node.js workers so plugin rules can run across files in parallel.

Workers replay the resolved plugin registration and rule options, verify that registration matches the main isolate, and receive lint callbacks from Rayon threads. Worker startup and runtime failures are propagated, and workers are terminated when linting finishes.

## Architecture

Example: `--threads 8 --js-plugin-threads 4` means **8 Rust workers + the main JS isolate + 3 JS workers**, within one Node.js process.

```mermaid
flowchart TB
    subgraph setup["1. Setup - once per run"]
        C["Main JS isolate<br/>Load plugins and canonical configuration"]
        W["Start 3 JS workers<br/>Each imports plugins, verifies rules,<br/>and applies the same configuration"]
        C --> W
    end

    subgraph runtime["2. Lint files concurrently"]
        F["Input files"]
        R["Rust / Rayon pool - 8 workers<br/>Parse each file and run built-in rules"]
        D["Native callback pool<br/>Choose JS host = fixed allocator ID % 4"]

        F --> R
        R -->|"Raw AST buffer + per-file configuration"| D

        subgraph hosts["4 independent JS isolates - each has its own plugin state"]
            H0["Host 0<br/>Main isolate"]
            H1["Host 1<br/>Worker A"]
            H2["Host 2<br/>Worker B"]
            H3["Host 3<br/>Worker C"]
        end

        D -->|"Allocator IDs 0, 4, 8..."| H0
        D -->|"Allocator IDs 1, 5, 9..."| H1
        D -->|"Allocator IDs 2, 6, 10..."| H2
        D -->|"Allocator IDs 3, 7, 11..."| H3

        H0 --> J["Rust receives JS diagnostics and fixes<br/>Finishes the file and reuses its allocator"]
        H1 --> J
        H2 --> J
        H3 --> J
    end

    W -.->|"Register callbacks before linting"| D
    J -->|"After all files finish"| E["Terminate and await JS workers"]
```

## Benchmark

Measured the [blog post’s Vue benchmark](https://oxc.rs/blog/2025-10-09-oxlint-js-plugins#performance), using the unchanged custom plugin and full configuration from [`overlookmotel/vue-core-cam`](https://github.com/overlookmotel/vue-core-cam/tree/539a755fb7ffa2ba8b90a6da6aa880bc39346190). Original Oxlint is this PR’s parent commit, `98a8fe33903463fdd30b828edc4a007ff6fbb843`; the PR build is `6cf505d2536e5c4605d6c549ff98244769ef8b79`.

Both revisions were built in release mode with the allocator feature, Rust 1.98.1, and the same installed JS build dependencies. Test machine: Apple M4 Pro, 14 cores (10 performance and 4 efficiency), 48 GiB RAM, Node.js 24.18.0. Rust threads were fixed at 14 throughout; JS thread counts include the main isolate.

| Configuration | Mean runtime ± SD | Median peak RSS | Speedup vs original |
|---|---:|---:|---:|
| Original + JS plugin | 332.1 ± 3.9 ms | 150.8 MiB | 1.00× |
| This PR: 1 JS thread | 339.7 ± 16.0 ms | 151.1 MiB | 0.98× |
| This PR: 2 JS threads | 278.6 ± 6.6 ms | 187.2 MiB | 1.19× |
| This PR: 4 JS threads | 234.1 ± 6.3 ms | 247.2 MiB | 1.42× |
| This PR: 6 JS threads | **224.4 ± 6.5 ms** | 295.8 MiB | **1.48×** |
| This PR: 8 JS threads | 230.7 ± 6.2 ms | 339.4 MiB | 1.44× |
| This PR: 12 JS threads | 250.3 ± 7.0 ms | 428.9 MiB | 1.33× |
| This PR: 14 JS threads | 268.1 ± 13.2 ms | 464.0 MiB | 1.24× |

Six JS threads had the fastest observed mean, reducing runtime by 32.4% while using 1.96× the original’s peak RSS. Four threads were only 4.3% slower than six and used 16.4% less memory. Higher counts provided no additional benefit for this lightweight plugin. The one-thread result was more variable, so its 2.3% higher mean alone does not establish a regression.


Commands, run from the benchmark fixture directory:

```sh
node /path/to/original/dist/cli.js -c .oxlintrc-with-custom-plugin.json --threads 14 . --silent
node /path/to/pr/dist/cli.js -c .oxlintrc-with-custom-plugin.json --threads 14 --js-plugin-threads N . --silent
# N = 1, 2, 4, 6, 8, 12, 14
```

AI assistance: OpenAI Codex helped write the PR title, description, and commit message, and prepared, ran, and summarized this benchmark.

### Large codebase results

A manual test on our private codebase—123k files, 242 native rules plus one JS plugin rule, using 14 Rust threads—showed a substantial improvement.

| Configuration | Runtime |
|---|---:|
| Without the JS plugin | 14.1 s |
| JS plugin, 1 JS thread | 31.2 s |
| JS plugin, 4 JS threads | 18.8 s |

Four JS threads reduced total runtime by **39.7% (1.66× speedup)** compared with one JS thread. The additional time relative to running without the plugin fell from 17.1 s to 4.7 s—a **72.5% reduction**.

These single-run measurements demonstrate a **substantial improvement** on this large codebase.