### PR TITLE
perf(parser): reject non-arrow single-parameter heads earlier

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -165,8 +165,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 }
                                 Tristate::False
                             }
-                            // If we have "(a," or "(a=" or "(a)" this *could* be an arrow function
-                            Kind::Comma | Kind::Eq | Kind::RParen => Tristate::Maybe,
+                            // If we have "(a," or "(a=" this *could* be an arrow function
+                            Kind::Comma | Kind::Eq => Tristate::Maybe,
+                            Kind::RParen => {
+                                // A single parenthesized parameter must be followed by `=>` or
+                                // a TypeScript return annotation. Otherwise the speculative head
+                                // would fail. Skip that parse and its temporary parameter allocation.
+                                let deferred_errors_len = self.lexer.deferred_module_errors.len();
+                                let fourth = self.lexer.peek_token().kind();
+                                if fourth == Kind::Arrow || (self.is_ts && fourth == Kind::Colon) {
+                                    // The head will read this token again. Lexer checkpoints do not
+                                    // restore deferred module errors, so discard this extra peek's
+                                    // errors and let the head record them once.
+                                    self.lexer.deferred_module_errors.truncate(deferred_errors_len);
+                                    Tristate::Maybe
+                                } else {
+                                    Tristate::False
+                                }
+                            }
                             // It is definitely not an arrow function
                             _ => Tristate::False,
                         }

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -173,11 +173,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 // would fail. Skip that parse and its temporary parameter allocation.
                                 let deferred_errors_len = self.lexer.deferred_module_errors.len();
                                 let fourth = self.lexer.peek_token().kind();
+                                // The real parse reads this token again on either path. Lexer
+                                // checkpoints do not restore deferred module errors, so discard
+                                // this extra peek's errors and let normal parsing record them once.
+                                self.lexer.deferred_module_errors.truncate(deferred_errors_len);
                                 if fourth == Kind::Arrow || (self.is_ts && fourth == Kind::Colon) {
-                                    // The head will read this token again. Lexer checkpoints do not
-                                    // restore deferred module errors, so discard this extra peek's
-                                    // errors and let the head record them once.
-                                    self.lexer.deferred_module_errors.truncate(deferred_errors_len);
                                     Tristate::Maybe
                                 } else {
                                     Tristate::False

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -1173,9 +1173,12 @@ mod test {
     #[test]
     fn unambiguous_arrow_lookahead_diagnostics() {
         let allocator = Allocator::default();
-        for (source, source_type, diagnostic_count) in [
-            ("(x)\n<!-- comment\n=> x; export {};", SourceType::unambiguous(), 2),
-            ("(x)\n<!-- comment\n: number => x; export {};", SourceType::ts(), 1),
+        for (source, source_type, diagnostic_count, html_comment_count) in [
+            ("(x)\n<!-- comment\n=> x; export {};", SourceType::unambiguous(), 2, 1),
+            ("(x)\n<!-- comment\n: number => x; export {};", SourceType::ts(), 1, 1),
+            ("(x)\n<!-- comment\n; export {};", SourceType::unambiguous(), 1, 1),
+            ("(x)\n--> comment\n; export {};", SourceType::unambiguous(), 1, 1),
+            ("<!-- first\n(x)\n<!-- second\n; export {};", SourceType::unambiguous(), 2, 2),
         ] {
             for tokens in [false, true] {
                 let ret = Parser::new(&allocator, source, source_type)
@@ -1183,7 +1186,7 @@ mod test {
                     .parse();
                 assert!(!ret.fatal_error);
                 assert!(ret.program.source_type.is_module());
-                assert_eq!(ret.diagnostics.len(), diagnostic_count);
+                assert_eq!(ret.diagnostics.len(), diagnostic_count, "{source:?}, tokens={tokens}");
                 assert_eq!(
                     ret.diagnostics
                         .iter()
@@ -1191,7 +1194,8 @@ mod test {
                             diagnostic.to_string() == "HTML comments are not allowed in modules"
                         })
                         .count(),
-                    1,
+                    html_comment_count,
+                    "{source:?}, tokens={tokens}",
                 );
             }
         }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -1171,6 +1171,33 @@ mod test {
     }
 
     #[test]
+    fn unambiguous_arrow_lookahead_diagnostics() {
+        let allocator = Allocator::default();
+        for (source, source_type, diagnostic_count) in [
+            ("(x)\n<!-- comment\n=> x; export {};", SourceType::unambiguous(), 2),
+            ("(x)\n<!-- comment\n: number => x; export {};", SourceType::ts(), 1),
+        ] {
+            for tokens in [false, true] {
+                let ret = Parser::new(&allocator, source, source_type)
+                    .with_config(RuntimeParserConfig::new(tokens))
+                    .parse();
+                assert!(!ret.fatal_error);
+                assert!(ret.program.source_type.is_module());
+                assert_eq!(ret.diagnostics.len(), diagnostic_count);
+                assert_eq!(
+                    ret.diagnostics
+                        .iter()
+                        .filter(|diagnostic| {
+                            diagnostic.to_string() == "HTML comments are not allowed in modules"
+                        })
+                        .count(),
+                    1,
+                );
+            }
+        }
+    }
+
+    #[test]
     fn binary_file() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1156432 # 1.16 MB
   arena allocs: 432553
   arena reallocs: 428
-  arena size: 29572816 # 29.57 MB
+  arena size: 29554728 # 29.55 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 50737424 # 50.74 MB
   arena allocs: 2558370
   arena reallocs: 1889
-  arena size: 246661408 # 246.66 MB
+  arena size: 246494968 # 246.49 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 3693363 # 3.69 MB
   arena allocs: 21027
   arena reallocs: 7699
-  arena size: 5783984 # 5.78 MB
+  arena size: 5765848 # 5.77 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 19934749 # 19.93 MB
   arena allocs: 207576
   arena reallocs: 75941
-  arena size: 45456840 # 45.46 MB
+  arena size: 45290400 # 45.29 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -33,25 +33,25 @@ RadixUIAdoptionSection.jsx:
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
-  sys allocs: 67
+  sys allocs: 61
   sys reallocs: 67
-  sys deallocs: 67
+  sys deallocs: 61
   sys alloc bytes: 24020 # 24.02 kB
   sys peak growth: 12140 # 12.14 kB
-  arena allocs: 89857
+  arena allocs: 89500
   arena reallocs: 8136
-  arena size: 4536712 # 4.54 MB
+  arena size: 4518552 # 4.52 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 185
+  sys allocs: 183
   sys reallocs: 221
-  sys deallocs: 185
-  sys alloc bytes: 109952 # 109.95 kB
-  sys peak growth: 48264 # 48.26 kB
-  arena allocs: 528577
+  sys deallocs: 183
+  sys alloc bytes: 92428 # 92.43 kB
+  sys peak growth: 38848 # 38.85 kB
+  arena allocs: 525292
   arena reallocs: 55355
-  arena size: 29421920 # 29.42 MB
+  arena size: 29255480 # 29.26 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 832762 # 832.76 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 4536712 # 4.54 MB
+  arena size: 4518552 # 4.52 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 5441278 # 5.44 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 29421920 # 29.42 MB
+  arena size: 29255480 # 29.26 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1610 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 4536736 # 4.54 MB
+  arena size: 4518576 # 4.52 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 1611 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 29421944 # 29.42 MB
+  arena size: 29255504 # 29.26 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB


### PR DESCRIPTION
After `(identifier)`, skip speculative arrow-head parsing unless the next token is `=>` or a TypeScript return annotation. This avoids temporary parameter allocations for ordinary grouped identifiers.

Roll back deferred HTML-comment errors from the extra peek on both paths so normal parsing records them once. Skipping the failed head parse also avoids some existing duplicate HTML-comment diagnostics.
