### PR TITLE
refactor(lexer): move compress logic out of `lex_raw`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/compress/avx2.rs
+++ b/crates/oxc_lexer/src/pipeline/compress/avx2.rs
@@ -51,7 +51,7 @@ const fn bcompact() -> [[u8; 16]; 256] {
 }
 
 #[inline(never)]
-pub unsafe fn compress(
+pub(super) unsafe fn compress_blocks(
     t: &Tables,
     st: *const u64,
     kind: *const u8,
@@ -106,7 +106,7 @@ pub unsafe fn compress(
     m
 }
 
-pub unsafe fn build_spans(
+pub(super) unsafe fn build_spans(
     stage_kind: *const u8,
     stage_pos: *const u32,
     m: usize,
@@ -169,7 +169,7 @@ pub unsafe fn build_spans(
     w
 }
 
-pub unsafe fn lanes_post(
+pub(super) unsafe fn lanes_post(
     src: &[u8],
     out_kinds: *const u8,
     out_spans: *const Span,

--- a/crates/oxc_lexer/src/pipeline/compress/generic.rs
+++ b/crates/oxc_lexer/src/pipeline/compress/generic.rs
@@ -9,7 +9,7 @@ use super::super::{
 
 use super::common::{emit_value, invalid_diags};
 
-pub unsafe fn compress(
+pub(super) unsafe fn compress_blocks(
     _t: &Tables,
     st: *const u64,
     kind: *const u8,
@@ -37,7 +37,7 @@ pub unsafe fn compress(
 }
 
 /// Contents of this function is in common with AVX2 implementation.
-pub unsafe fn build_spans(
+pub(super) unsafe fn build_spans(
     stage_kind: *const u8,
     stage_pos: *const u32,
     m: usize,
@@ -59,7 +59,7 @@ pub unsafe fn build_spans(
     w
 }
 
-pub unsafe fn lanes_post(
+pub(super) unsafe fn lanes_post(
     src: &[u8],
     out_kinds: *const u8,
     out_spans: *const Span,

--- a/crates/oxc_lexer/src/pipeline/compress/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/compress/mod.rs
@@ -1,15 +1,58 @@
+use oxc_span::Span;
+
+use crate::{lanes::Lanes, tables::Tables};
+
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 mod avx2;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
-pub use avx2::{build_spans, compress, lanes_post};
+use avx2::{build_spans, compress_blocks, lanes_post};
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 mod generic;
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
-pub use generic::{build_spans, compress, lanes_post};
+use generic::{build_spans, compress_blocks, lanes_post};
 
 mod common;
 pub use common::write_sentinels;
+
+const STAGE_BLOCKS: usize = 32;
+pub const STAGE_CAP: usize = STAGE_BLOCKS * 64 + 128;
+
+pub unsafe fn compress(
+    t: &Tables,
+    src: &[u8],
+    n: usize,
+    nb: usize,
+    st: *const u64,
+    kind: *const u8,
+    stage_pos: *mut u32,
+    stage_kind: *mut u8,
+    out_kinds: *mut u8,
+    out_spans: *mut Span,
+    lanes: &mut Lanes,
+) -> usize {
+    let mut c = 0usize;
+    let mut w = 0usize;
+    let mut b = 0usize;
+    while b < nb {
+        let b1 = (b + STAGE_BLOCKS).min(nb);
+        c += compress_blocks(t, st, kind, b, b1, stage_pos.add(c), stage_kind.add(c));
+        b = b1;
+        if c > 1 {
+            w += build_spans(stage_kind, stage_pos, c - 1, out_spans.add(w), out_kinds.add(w));
+            *stage_pos = *stage_pos.add(c - 1);
+            *stage_kind = *stage_kind.add(c - 1);
+            c = 1;
+        }
+    }
+    if c == 1 {
+        *stage_pos.add(1) = n as u32;
+        w += build_spans(stage_kind, stage_pos, 1, out_spans.add(w), out_kinds.add(w));
+    }
+    write_sentinels(n as u32, out_spans.add(w), out_kinds.add(w));
+    lanes_post(src, out_kinds, out_spans, w, n as u32, lanes);
+    w
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/oxc_lexer/src/pipeline/compress/tests.rs
+++ b/crates/oxc_lexer/src/pipeline/compress/tests.rs
@@ -1,9 +1,9 @@
 use crate::tables::Tables;
 
-use super::compress;
+use super::compress_blocks;
 
 #[test]
-fn compress_matches_scalar_reference() {
+fn compress_blocks_matches_scalar_reference() {
     let t = Tables::new();
     let mut cases: Vec<Vec<u64>> = Vec::new();
     let all_pairs: Vec<u64> = (0..65536u64)
@@ -43,7 +43,15 @@ fn compress_matches_scalar_reference() {
         let mut starts = vec![0u32; n + 64];
         let mut kinds = vec![0u8; n + 64];
         let m = unsafe {
-            compress(&t, st.as_ptr(), kind.as_ptr(), 0, nb, starts.as_mut_ptr(), kinds.as_mut_ptr())
+            compress_blocks(
+                &t,
+                st.as_ptr(),
+                kind.as_ptr(),
+                0,
+                nb,
+                starts.as_mut_ptr(),
+                kinds.as_mut_ptr(),
+            )
         };
         let mut rs: Vec<u32> = Vec::new();
         let mut rk: Vec<u8> = Vec::new();

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -31,12 +31,9 @@ use bitmap::bm_any;
 use carve::carve;
 use classify::{classify, misc_post, misc_pre};
 use coalesce::{KWB, coalesce};
-use compress::{build_spans, compress, lanes_post, write_sentinels};
+use compress::{STAGE_CAP, compress, write_sentinels};
 
 use crate::token::TokenKind;
-
-const STAGE_BLOCKS: usize = 32;
-const STAGE_CAP: usize = STAGE_BLOCKS * 64 + 128;
 
 // Short kind aliases for the pipeline, tied to `token_kind` so they can't drift.
 pub(crate) const WS: u8 = TokenKind::Whitespace as u8;
@@ -225,28 +222,19 @@ impl Lexer {
         if nesc != 0 {
             misc_post(sp, n, st, word, misc, kind);
         }
-        let stage_pos = self.stage_pos.as_mut_ptr();
-        let stage_kind = self.stage_kind.as_mut_ptr();
-        let mut c = 0usize;
-        let mut w = 0usize;
-        let mut b = 0usize;
-        while b < nb {
-            let b1 = (b + STAGE_BLOCKS).min(nb);
-            c += compress(t, st, kind, b, b1, stage_pos.add(c), stage_kind.add(c));
-            b = b1;
-            if c > 1 {
-                w += build_spans(stage_kind, stage_pos, c - 1, out_spans.add(w), out_kinds.add(w));
-                *stage_pos = *stage_pos.add(c - 1);
-                *stage_kind = *stage_kind.add(c - 1);
-                c = 1;
-            }
-        }
-        if c == 1 {
-            *stage_pos.add(1) = n as u32;
-            w += build_spans(stage_kind, stage_pos, 1, out_spans.add(w), out_kinds.add(w));
-        }
-        write_sentinels(n as u32, out_spans.add(w), out_kinds.add(w));
-        lanes_post(src, out_kinds, out_spans, w, n as u32, &mut self.lanes);
+        let w = compress(
+            t,
+            src,
+            n,
+            nb,
+            st,
+            kind,
+            self.stage_pos.as_mut_ptr(),
+            self.stage_kind.as_mut_ptr(),
+            out_kinds,
+            out_spans,
+            &mut self.lanes,
+        );
         self.sig_len = w;
         w
     }


### PR DESCRIPTION
Pure refactor. No code changes, just moving code around.

`compress` stage of pipeline involves several separate steps. Previously this compress-specific logic was in `lex_raw`, mixed with the logic for other stages.

This PR moves it into the `compress` module, so all that remains in `lex_raw` is a single call to `compress`.

The function that was previously called `compress` is renamed to `compress_blocks` to avoid duplicated names.