### PR TITLE
perf(linter/unicorn/prefer-object-from-entries): avoid allocating configured paths

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
@@ -89,7 +89,10 @@ fn check_array_prototype_methods(call_expr: &CallExpression, ctx: &LintContext) 
             .first()
             .is_some_and(|arg| arg.as_expression().is_none_or(|expr| is_node_not_function(expr)))
         || call_expr.arguments.get(1).is_some_and(|arg| matches!(arg, Argument::SpreadElement(_)))
-        || does_expr_match_any_path(&call_expr.callee, IGNORED)
+        || does_expr_match_any_path(
+            &call_expr.callee,
+            IGNORED.iter().map(|path| path.iter().copied()),
+        )
     {
         return;
     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -97,7 +97,7 @@ impl Rule for PreferObjectFromEntries {
             && call_expr.arguments[0].is_expression()
             && does_expr_match_any_path(
                 &call_expr.callee,
-                self.functions.iter().map(|fun| fun.split('.').collect::<Vec<_>>()),
+                self.functions.iter().map(|fun| fun.split('.')),
             )
         {
             ctx.diagnostic(prefer_object_from_entries_diagnostic(call_expr.callee.span()));
@@ -341,6 +341,13 @@ fn test() {
         ("_.foo(pairs)", Some(serde_json::json!([{"functions": ["foo"]}]))),
         ("foo(pairs)", Some(serde_json::json!([{"functions": ["utils.object.foo"]}]))),
         ("object.foo(pairs)", Some(serde_json::json!([{"functions": ["utils.object.foo"]}]))),
+        ("foo(pairs)", Some(serde_json::json!([{"functions": ["", ".foo", "foo."]}]))),
+        (
+            "utils.foo(pairs)",
+            Some(serde_json::json!([{"functions": ["utils..foo", "utils.foo.extra"]}])),
+        ),
+        ("utils.foo.extra(pairs)", Some(serde_json::json!([{"functions": ["utils.foo"]}]))),
+        ("utils['foo'](pairs)", Some(serde_json::json!([{"functions": ["utils.foo"]}]))),
     ];
 
     let fail = vec![
@@ -421,6 +428,10 @@ fn test() {
             Some(serde_json::json!([{"functions": ["myFromPairsFunction"]}])),
         ),
         ("utils.object.foo(pairs)", Some(serde_json::json!([{"functions": ["utils.object.foo"]}]))),
+        (
+            "utils.foo(pairs)",
+            Some(serde_json::json!([{"functions": ["utils", "utils.foo", "utils.foo.extra"]}])),
+        ),
     ];
 
     Tester::new(PreferObjectFromEntries::NAME, PreferObjectFromEntries::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
@@ -304,3 +304,10 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────
    ╰────
   help: Use `Object.fromEntries(pairs)` instead of manually building objects with `reduce` or `forEach`.
+
+  ⚠ unicorn(prefer-object-from-entries): Prefer `Object.fromEntries` over manual object construction from entries.
+   ╭─[prefer_object_from_entries.tsx:1:1]
+ 1 │ utils.foo(pairs)
+   · ─────────
+   ╰────
+  help: Use `Object.fromEntries(pairs)` instead of manually building objects with `reduce` or `forEach`.

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -443,7 +443,7 @@ pub fn call_expr_member_expr_property_span(call_expr: &CallExpression) -> Span {
 pub fn does_expr_match_any_path<'a, P, S>(mut expr: &Expression, paths: P) -> bool
 where
     P: IntoIterator<Item = S>,
-    S: AsRef<[&'a str]>,
+    S: IntoIterator<Item = &'a str>,
 {
     // Member chains are short in practice; keep the segments on the stack.
     let mut path: SmallVec<[&str; 4]> = SmallVec::new();
@@ -459,18 +459,9 @@ where
 
     let Expression::Identifier(ident) = expr else { return false };
     path.push(ident.name.as_str());
-    let path = path.iter().rev();
+    let path = path.iter().rev().copied();
 
-    for e in paths {
-        let expected_path = e.as_ref();
-        if expected_path.len() == path.len()
-            && expected_path.iter().zip(path.clone()).all(|(x, y)| x == y)
-        {
-            return true;
-        }
-    }
-
-    false
+    paths.into_iter().any(|expected_path| expected_path.into_iter().eq(path.clone()))
 }
 
 /// Returns the precedence of an expression if it has one.


### PR DESCRIPTION
Compare configured function paths directly through their split iterators instead of collecting a temporary vector for each candidate call. The shared matcher accepts iterators while preserving exact segment and length matching; its other caller, `no-array-method-this-argument`, is adapted to the new signature.
