### PR TITLE
perf(react-compiler): check component parameters before scanning bodies

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -934,8 +934,8 @@ fn get_component_or_hook_like(
     if let Some(fn_name) = name {
         if is_component_name(fn_name) {
             // Check if it actually looks like a component
-            let is_component = calls_hooks_or_creates_jsx(params, body)
-                && is_valid_component_params(params)
+            let is_component = is_valid_component_params(params)
+                && calls_hooks_or_creates_jsx(params, body)
                 && !returns_non_node_fn(body);
             return if is_component { Some(ReactFunctionType::Component) } else { None };
         } else if is_hook_name(fn_name) {


### PR DESCRIPTION
Check component parameter validity before scanning for hooks or JSX. Invalid parameter lists now short-circuit the body scan without changing component classification.
