### PR TITLE
fix(codegen): compare hex against shortened decimal literals

### DIFF
--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -31,6 +31,13 @@ fn test_number() {
     test_minify("x = 1e2", "x=100;");
     test_minify("x = 1e3", "x=1e3;");
     test_minify("x = 1e4", "x=1e4;");
+    test_minify("x = 1e12", "x=1e12;");
+    test_minify("x = 1e18", "x=1e18;");
+    test_minify("x = 1e19", "x=1e19;");
+    test_minify("x = 1e20", "x=1e20;");
+    test_minify("x = 0xde0b6b3a7640000", "x=1e18;");
+    test_minify("x = -1e18", "x=-1e18;");
+    test("x = 1e18", "x = 1e18;\n");
     test_minify("x = 1e100", "x=1e100;");
 
     // Check "12eN"
@@ -59,6 +66,7 @@ fn test_number() {
     test_minify("x = 12e2", "x=1200;");
     test_minify("x = 12e3", "x=12e3;");
     test_minify("x = 12e4", "x=12e4;");
+    test_minify("x = 12e18", "x=12e18;");
     test_minify("x = 12e100", "x=12e100;");
 
     // Check cases for "A.BeX" => "ABeY" simplification
@@ -97,20 +105,20 @@ fn test_number() {
     test_minify("x = -0x1_0000_0001", "x=-4294967297;");
 
     // int64
-    test_minify("x = 0x7fff_ffff_ffff_fdff", "x=0x7ffffffffffffc00;");
-    test_minify("x = 0x8000_0000_0000_0000", "x=0x8000000000000000;");
-    test_minify("x = 0x8000_0000_0000_3000", "x=0x8000000000003000;");
-    test_minify("x = -0x7fff_ffff_ffff_fdff", "x=-0x7ffffffffffffc00;");
-    test_minify("x = -0x8000_0000_0000_0000", "x=-0x8000000000000000;");
-    test_minify("x = -0x8000_0000_0000_3000", "x=-0x8000000000003000;");
+    test_minify("x = 0x7fff_ffff_ffff_fdff", "x=9223372036854775e3;");
+    test_minify("x = 0x8000_0000_0000_0000", "x=9223372036854776e3;");
+    test_minify("x = 0x8000_0000_0000_3000", "x=9223372036854788e3;");
+    test_minify("x = -0x7fff_ffff_ffff_fdff", "x=-9223372036854775e3;");
+    test_minify("x = -0x8000_0000_0000_0000", "x=-9223372036854776e3;");
+    test_minify("x = -0x8000_0000_0000_3000", "x=-9223372036854788e3;");
 
     // uint64
-    test_minify("x = 0xffff_ffff_ffff_fbff", "x=0xfffffffffffff800;");
-    test_minify("x = 0x1_0000_0000_0000_0000", "x=0x10000000000000000;");
-    test_minify("x = 0x1_0000_0000_0000_1000", "x=0x10000000000001000;");
-    test_minify("x = -0xffff_ffff_ffff_fbff", "x=-0xfffffffffffff800;");
-    test_minify("x = -0x1_0000_0000_0000_0000", "x=-0x10000000000000000;");
-    test_minify("x = -0x1_0000_0000_0000_1000", "x=-0x10000000000001000;");
+    test_minify("x = 0xffff_ffff_ffff_fbff", "x=1844674407370955e4;");
+    test_minify("x = 0x1_0000_0000_0000_0000", "x=18446744073709552e3;");
+    test_minify("x = 0x1_0000_0000_0000_1000", "x=18446744073709556e3;");
+    test_minify("x = -0xffff_ffff_ffff_fbff", "x=-1844674407370955e4;");
+    test_minify("x = -0x1_0000_0000_0000_0000", "x=-18446744073709552e3;");
+    test_minify("x = -0x1_0000_0000_0000_1000", "x=-18446744073709556e3;");
 
     // Check the hex vs. decimal decision boundary when minifying
     // TODO FIXME
@@ -124,10 +132,10 @@ fn test_number() {
     test_minify("x = 999999999999", "x=999999999999;");
     test_minify("x = 1000000000001", "x=0xe8d4a51001;");
     test_minify("x = 0x0FFF_FFFF_FFFF_FF80", "x=0xfffffffffffff80;");
-    test_minify("x = 0x1000_0000_0000_0000", "x=0x1000000000000000;");
+    test_minify("x = 0x1000_0000_0000_0000", "x=1152921504606847e3;");
     test_minify("x = 0xFFFF_FFFF_FFFF_F000", "x=0xfffffffffffff000;");
-    test_minify("x = 0xFFFF_FFFF_FFFF_F800", "x=0xfffffffffffff800;");
-    test_minify("x = 0xFFFF_FFFF_FFFF_FFFF", "x=0x10000000000000000;");
+    test_minify("x = 0xFFFF_FFFF_FFFF_F800", "x=1844674407370955e4;");
+    test_minify("x = 0xFFFF_FFFF_FFFF_FFFF", "x=18446744073709552e3;");
 
     // Check printing a space in between a number and a subsequent "."
     test_minify("x = 0.0001 .y", "x=1e-4.y;");
@@ -138,6 +146,7 @@ fn test_number() {
     test_minify("x = 10 .y", "x=10 .y;");
     test_minify("x = 100 .y", "x=100 .y;");
     test_minify("x = 1000 .y", "x=1e3.y;");
+    test_minify("x = 1e18 .y", "x=1e18.y;");
     test_minify("x = 12345 .y", "x=12345 .y;");
     test_minify("x = 0xFFFF_0000_FFFF_0000 .y", "x=0xffff0000ffff0000.y;");
 }

--- a/crates/oxc_ecmascript/src/number_literal.rs
+++ b/crates/oxc_ecmascript/src/number_literal.rs
@@ -28,20 +28,7 @@ fn number_literal(value: f64) -> LiteralString {
         best_candidate.push(byte);
     }
 
-    let mut is_hex = false;
-    if value.fract() == 0.0 {
-        let integer = value as u128;
-        let hex_digits = (128 - integer.leading_zeros() as usize).div_ceil(4);
-        let hex_len = 2 + hex_digits;
-        if hex_len < best_candidate.len_usize() {
-            let mut candidate = LiteralString::new();
-            candidate.push(b'0');
-            candidate.push(b'x');
-            push_hex(integer, &mut candidate);
-            best_candidate = candidate;
-            is_hex = true;
-        }
-    } else if best_candidate.starts_with(".0")
+    if best_candidate.starts_with(".0")
         && let Some(index) = best_candidate.bytes().skip(2).position(|byte| byte != b'0')
     {
         let digits_start = index + 2;
@@ -59,8 +46,7 @@ fn number_literal(value: f64) -> LiteralString {
         }
     }
 
-    if !is_hex
-        && best_candidate.ends_with('0')
+    if best_candidate.ends_with('0')
         && let Some(exponent) = best_candidate.bytes().rev().position(|byte| byte != b'0')
     {
         let base_len = best_candidate.len_usize() - exponent;
@@ -105,6 +91,20 @@ fn number_literal(value: f64) -> LiteralString {
         }
     }
 
+    // Compare hex against the shortest decimal form, including exponent notation.
+    if value.fract() == 0.0 {
+        let integer = value as u128;
+        let hex_digits = (128 - integer.leading_zeros() as usize).div_ceil(4);
+        let hex_len = 2 + hex_digits;
+        if hex_len < best_candidate.len_usize() {
+            let mut candidate = LiteralString::new();
+            candidate.push(b'0');
+            candidate.push(b'x');
+            push_hex(integer, &mut candidate);
+            best_candidate = candidate;
+        }
+    }
+
     best_candidate
 }
 
@@ -136,6 +136,11 @@ mod tests {
             (0.05, ".05"),
             (0.000_001, "1e-6"),
             (1000.0, "1e3"),
+            (1e12, "1e12"),
+            (1e18, "1e18"),
+            (1e19, "1e19"),
+            (1e20, "1e20"),
+            (12e18, "12e18"),
             (281_474_976_710_655.0, "0xffffffffffff"),
             (1.2e101, "12e100"),
             (f64::MAX, "17976931348623157e292"),

--- a/packages/codegen/src-js/print/number.ts
+++ b/packages/codegen/src-js/print/number.ts
@@ -49,22 +49,20 @@ export function printNonNegativeFloat(
  * Print an integer of 1000 or more in its shortest form.
  *
  * `String` gives plain digits below 1e21 and exponent notation from there up, which have different forms
- * available to them, so they are separate cases. Both can go hexadecimal.
+ * available to them, so they are separate cases. Only plain digits need comparing with hexadecimal.
  */
 function printShortestInteger(state: State, value: number): void {
   const formatted = String(value);
 
   if (value >= 1e21) {
     debugAssert(formatted.includes("e+"), "`String` gives `e+` notation from 1e21 up");
-    // The `+` always goes, so the text is one shorter than `formatted`
-    if (printHexIfShorter(state, value, formatted.length - 1)) return;
+    // Below 1e25, shortened exponent notation takes at most 19 characters, versus at least 20 for hex.
+    // From 1e25 up, hex takes at least 23 characters, while exponent notation needs at most 21.
     printExponent(state, formatted, formatted.indexOf("e"));
     return;
   }
 
   const { length } = formatted;
-  if (printHexIfShorter(state, value, length)) return;
-
   // A run of trailing zeros as an exponent: `1000` -> `1e3`
   if (formatted.charCodeAt(length - 1) === 48 /* 0 */) {
     // The first digit is never a zero, so the run always stops
@@ -74,6 +72,7 @@ function printShortestInteger(state: State, value: number): void {
     // Worth it when the `e` and the exponent cost less than the zeros they replace
     const exponent = String(zeros);
     if (exponent.length + 1 < zeros) {
+      if (printHexIfShorter(state, value, length - zeros + 1 + exponent.length)) return;
       writeNoLast(state, formatted.slice(0, length - zeros));
       writeNoLast(state, "e");
       writeIdent(state, exponent);
@@ -81,7 +80,7 @@ function printShortestInteger(state: State, value: number): void {
     }
   }
 
-  write(state, formatted, CAT_INT_DIGIT);
+  if (!printHexIfShorter(state, value, length)) write(state, formatted, CAT_INT_DIGIT);
 }
 
 /**
@@ -182,9 +181,8 @@ function printExponent(state: State, formatted: string, exponentIndex: number): 
  * Hexadecimal has to win back the `0x` in front of it, which takes 13 digits at the very least,
  * so below that the conversion is not attempted at all.
  *
- * That bound is in decimal digits, and the caller with a number in exponent notation passes the length
- * of that instead, which is shorter - but such a number is at least 1e21, whose 18 hex digits make 20 characters,
- * so anything the early return skips there could not have won either.
+ * The caller may pass the length of a shortened exponent form instead of plain digits.
+ * That is no longer than the plain digits, so the early return remains valid.
  *
  * `BigInt` rather than `value.toString(16)`, whose result the specification leaves implementation-approximated
  * for every radix but 10, where the output here has to be exact.

--- a/packages/codegen/test/print.test.ts
+++ b/packages/codegen/test/print.test.ts
@@ -196,6 +196,7 @@ describe("member access on numbers", () => {
     ["int-large", e(member(num(255), id("x"))), "255 .x;\n"],
     ["int-999", e(member(num(999), id("x"))), "999 .x;\n"],
     ["int-1000", e(member(num(1000), id("x"))), "1e3.x;\n"],
+    ["int-1e18", e(member(num(1e18), id("x"))), "1e18.x;\n"],
     ["decimal", e(member(num(0.5), id("x"))), ".5.x;\n"],
     ["decimal-leading", e(member(num(1.5), id("x"))), "1.5.x;\n"],
     ["exponent-large", e(member(num(1e21), id("x"))), "1e21.x;\n"],
@@ -249,15 +250,18 @@ describe("numbers", () => {
     ["int-max-safe", e(num(9007199254740991)), "9007199254740991;\n"],
     ["hex", e(num(281474976710655)), "0xffffffffffff;\n"],
     ["hex-negative", e(num(-281474976710655)), "-0xffffffffffff;\n"],
-    // hexadecimal is tried first and wins, though `1e12` is shorter
-    ["hex-over-exponent", e(num(1e12)), "0xe8d4a51000;\n"],
-    // The two cases above reach the hexadecimal test from plain digits. These reach it from
-    // exponent notation, where the length it is judged against is one less than the text `String`
-    // gave, because the `+` of the exponent always goes. The second is the boundary: hexadecimal is
-    // exactly as long as the exponent form, so it must lose - and would wrongly win, as
-    // `0x21e2073de72ea800000`, if that one character were not taken off.
-    ["hex-from-exponent", e(num(1.0000990573316814e21)), "0x36372999e429e40000;\n"],
-    ["hex-from-exponent-boundary", e(num(1.0000473745167254e22)), "10000473745167254e6;\n"],
+    // Compare hex against the shortened exponent form, with decimal winning ties.
+    ["exponent-over-hex", e(num(1e12)), "1e12;\n"],
+    ["exponent-1e18", e(num(1e18)), "1e18;\n"],
+    ["exponent-1e19", e(num(1e19)), "1e19;\n"],
+    ["exponent-1e20", e(num(1e20)), "1e20;\n"],
+    ["exponent-negative", e(num(-1e18)), "-1e18;\n"],
+    ["exponent-multiple-digits", e(num(12e18)), "12e18;\n"],
+    ["exponent-hex-tie", e(num(0x8000000000000000)), "9223372036854776e3;\n"],
+    ["hex-over-shortened-exponent", e(num(0xfffffffffffff000)), "0xfffffffffffff000;\n"],
+    // Folding the point and removing the `+` both count toward the decimal candidate's length.
+    ["folded-exponent-over-hex", e(num(1.0000990573316814e21)), "10000990573316814e5;\n"],
+    ["folded-exponent-boundary", e(num(1.0000473745167254e22)), "10000473745167254e6;\n"],
     ["exponent-fold", e(num(1.2e101)), "12e100;\n"], // the point folds into the exponent
     ["max-value", e(num(1.7976931348623157e308)), "17976931348623157e292;\n"],
     ["min-value", e(num(5e-324)), "5e-324;\n"],


### PR DESCRIPTION
Codegen currently prints `1e18` as `0xde0b6b3a7640000` because the shared number formatter chooses hex before shortening decimal literals. Compare hex against the fully shortened decimal candidate so exponent notation wins when shorter; decimal also wins ties.

