### PR TITLE
perf(linter/eslint/no-restricted-imports): avoid redundant import scans

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -24,7 +24,7 @@ use oxc_str::CompactStr;
 
 use crate::{
     ModuleRecord,
-    context::LintContext,
+    context::{ContextHost, LintContext},
     module_record::{ExportEntry, ExportImportName, ImportEntry, ImportImportName, NameSpan},
     rule::Rule,
     utils::deserialize_required_regex_option,
@@ -1018,6 +1018,10 @@ impl Rule for NoRestrictedImports {
         Ok(Self(Box::new(NoRestrictedImportsConfig { paths, patterns })))
     }
 
+    fn should_run(&self, _ctx: &ContextHost) -> bool {
+        !self.paths.is_empty() || !self.patterns.is_empty()
+    }
+
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSImportEqualsDeclaration(declaration) => {
@@ -1081,17 +1085,17 @@ impl Rule for NoRestrictedImports {
 
 impl NoRestrictedImports {
     fn report_side_effects(&self, ctx: &LintContext<'_>, module_record: &ModuleRecord) {
+        if module_record.requested_modules.is_empty() {
+            return;
+        }
+
+        let import_statement_spans: FxHashSet<Span> =
+            module_record.import_entries.iter().map(|entry| entry.statement_span).collect();
         let mut side_effect_import_map: FxHashMap<&CompactStr, Vec<Span>> = FxHashMap::default();
 
         for (source, requests) in &module_record.requested_modules {
             for request in requests {
-                if request.is_import
-                    && (module_record.import_entries.is_empty()
-                        || module_record
-                            .import_entries
-                            .iter()
-                            .all(|entry| entry.statement_span != request.statement_span))
-                {
+                if request.is_import && !import_statement_spans.contains(&request.statement_span) {
                     side_effect_import_map.entry(source).or_default().push(request.statement_span);
                 }
             }
@@ -3600,6 +3604,33 @@ fn test() {
 
     pass.extend(pass_typescript);
     fail.extend(fail_typescript);
+
+    pass.extend([
+        (
+            r"import 'foo'; import { bar } from 'foo'; export { baz } from 'foo'; import('foo');",
+            None,
+        ),
+        (r"import 'foo'; import foo = require('foo');", Some(serde_json::json!([]))),
+        (
+            r"import 'foo'; import { bar } from 'foo'; export * from 'foo'; import('foo');",
+            Some(serde_json::json!([{ "paths": [], "patterns": [] }])),
+        ),
+    ]);
+
+    fail.extend([
+        (
+            r"import { allowed } from 'foo'; import 'foo'; import {} from 'foo';",
+            Some(
+                serde_json::json!([{ "paths": [{ "name": "foo", "allowImportNames": ["allowed"] }] }]),
+            ),
+        ),
+        (
+            r"import 'foo'; import { allowed } from 'foo'; import {} from 'foo';",
+            Some(
+                serde_json::json!([{ "patterns": [{ "regex": "^foo$", "allowImportNames": ["allowed"] }] }]),
+            ),
+        ),
+    ]);
 
     Tester::new(NoRestrictedImports::NAME, NoRestrictedImports::PLUGIN, pass, fail)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -1025,3 +1025,15 @@ source: crates/oxc_linter/src/tester.rs
    ·          ───
    ╰────
   help: Please use Bar and Baz from /import-bar/baz/ instead.
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:32]
+ 1 │ import { allowed } from 'foo'; import 'foo'; import {} from 'foo';
+   ·                                ─────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import 'foo'; import { allowed } from 'foo'; import {} from 'foo';
+   · ─────────────
+   ╰────

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -109,7 +109,6 @@ eslint/no-redeclare                                        |      7
 eslint/no-regex-spaces                                     |  64236
 eslint/no-restricted-exports                               |     70
 eslint/no-restricted-globals                               |      7
-eslint/no-restricted-imports                               |     26
 eslint/no-restricted-properties                            |  94494
 eslint/no-return-assign                                    |  13005
 eslint/no-script-url                                       |  63073


### PR DESCRIPTION
Skip the rule when neither paths nor patterns are configured. For side-effect import detection, build a set of import statement spans once instead of scanning every import entry for each request, and return early when the file has no requested modules.
