### PR TITLE
refactor(lexer): deduplicate bitmap access code

### DIFF
--- a/crates/oxc_lexer/src/pipeline/bitmap.rs
+++ b/crates/oxc_lexer/src/pipeline/bitmap.rs
@@ -1,6 +1,19 @@
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
+/// Get bit `i`.
+///
+/// Returns `true` if the bit is set, `false` if it is clear.
+///
+/// # SAFETY
+///
+/// - `bm` must be aligned for `u64`.
+/// - `bm` must be valid for reads of `(i / 64) + 1` words.
+#[inline(always)]
+pub(super) unsafe fn bm_get(bm: *const u64, i: usize) -> bool {
+    (*bm.add(i >> 6) >> (i & 63)) & 1 != 0
+}
+
 /// Get index of the first clear bit at or after `i`.
 ///
 /// If every bit in `i..n` is set, returns `n`.

--- a/crates/oxc_lexer/src/pipeline/carve/common.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/common.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::super::{
     BCOM, LCOM, REGEX, STR,
-    bitmap::{bm_clear_range, bm_next0, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set1},
     find::{scan_block_comment, scan_line_comment, scan_quoted, scan_regex, scan_tmpl_text},
     regex_div::prev_is_regex,
 };
@@ -207,7 +207,7 @@ unsafe fn lex_regex(
         lanes.push_diag(s as u32, (n - s) as u32, diag_code::UNTERMINATED_REGEXP);
     }
     let mut end = fs;
-    if end < n && (*word.add(end >> 6) >> (end & 63)) & 1 != 0 {
+    if end < n && bm_get(word, end) {
         end = bm_next0(word, end, n);
     }
     *kind.add(s) = REGEX;

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/angle_brackets.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/angle_brackets.rs
@@ -5,12 +5,11 @@ use crate::{
 };
 
 use super::super::super::{
+    bitmap::bm_get,
     classify::unicode_ws_len,
     find::{find_line_terminator, scan_block_comment},
     regex_div::{jsx_site_is_expression, ts_type_region_open, type_parameter_list_head},
 };
-
-use super::common::wordbit;
 
 const FN_TYPE_SCAN_CAP: usize = 1 << 16;
 const FN_TYPE_TMPL_DEPTH: u32 = 8;
@@ -74,7 +73,7 @@ unsafe fn ts_angle_verdict(src: &[u8], n: usize, t: usize, word: *const u64) -> 
             p = qq; // `const` was a modifier; advance to the real param
         }
     }
-    while p < n && wordbit(word, p) {
+    while p < n && bm_get(word, p) {
         p += 1; // first type-parameter identifier
     }
     while p < n {
@@ -110,7 +109,7 @@ unsafe fn ts_angle_verdict(src: &[u8], n: usize, t: usize, word: *const u64) -> 
     }
     // `extends` is also a legal JSX attribute name; it signals a generic only
     // as a full word not followed by `=` (attr value) or `>` (boolean attr).
-    if n - p >= 7 && &src[p..p + 7] == b"extends" && !wordbit(word, p + 7) {
+    if n - p >= 7 && &src[p..p + 7] == b"extends" && !bm_get(word, p + 7) {
         let mut qq = p + 7;
         while qq < n && is_ws(src[qq]) {
             qq += 1;

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/common.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/common.rs
@@ -1,4 +1,0 @@
-#[inline(always)]
-pub(super) unsafe fn wordbit(word: *const u64, p: usize) -> bool {
-    (*word.add(p >> 6) >> (p & 63)) & 1 != 0
-}

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/hyphens.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/hyphens.rs
@@ -1,7 +1,7 @@
+use super::super::super::bitmap::bm_get;
+
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use super::super::super::find::{load256, mm, veq};
-
-use super::common::wordbit;
 
 /// JSXIdentifier admits `-`, so `data-x` and `aria-label` are one name token
 /// where JS would read three. Fuse every hyphen in `[a, b)` into the run
@@ -69,12 +69,12 @@ unsafe fn glue_hyphen_at(
     h: usize,
     last: &mut usize,
 ) {
-    if h == 0 || !(wordbit(word, h - 1) || *last == h - 1) {
+    if h == 0 || !(bm_get(word, h - 1) || *last == h - 1) {
         return;
     }
     *st.add(h >> 6) &= !(1u64 << (h & 63));
     *opch.add(h >> 6) &= !(1u64 << (h & 63));
-    if h + 1 < n && wordbit(word, h + 1) {
+    if h + 1 < n && bm_get(word, h + 1) {
         *st.add((h + 1) >> 6) &= !(1u64 << ((h + 1) & 63));
     }
     *last = h;

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
@@ -21,7 +21,6 @@ use super::common::{
 };
 
 mod angle_brackets;
-mod common;
 mod hyphens;
 mod names;
 use angle_brackets::jsx_over_type_params;

--- a/crates/oxc_lexer/src/pipeline/classify/common.rs
+++ b/crates/oxc_lexer/src/pipeline/classify/common.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::super::{
     IDENT, IDENT_ESC, PRIV_IDENT, PRIV_IDENT_ESC, WS,
-    bitmap::{bm_clear_range, bm_next0, bm_prev1, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_prev1, bm_set1},
     find::scan_ident_esc,
 };
 
@@ -81,7 +81,7 @@ pub unsafe fn misc_pre<const VUTF8: bool>(
                 }
                 continue;
             }
-            if (*st.add(p >> 6) >> (p & 63)) & 1 == 0 {
+            if !bm_get(st, p) {
                 continue;
             }
             if c == b'#' {
@@ -136,10 +136,10 @@ pub unsafe fn misc_post(
             if *src.add(p) != b'\\' || *src.add(p + 1) != b'u' {
                 continue;
             }
-            if (*st.add(p >> 6) >> (p & 63)) & 1 == 0 {
+            if !bm_get(st, p) {
                 continue;
             }
-            if p == 0 || (*word.add((p - 1) >> 6) >> ((p - 1) & 63)) & 1 == 0 {
+            if p == 0 || !bm_get(word, p - 1) {
                 continue;
             }
             let tt = bm_prev1(st, p);

--- a/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     NUM,
-    bitmap::{bm_clear_range, bm_next0, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set1},
     find::scan_number,
     regex_div::{gt_run_split, lt_run_split},
 };
@@ -270,7 +270,7 @@ unsafe fn glue_number(
             }
             return e2; // token start already set at e2
         }
-        if e2 + 1 < n && is_op_char(c) && (*opch.add((e2 + 1) >> 6) >> ((e2 + 1) & 63)) & 1 != 0 {
+        if e2 + 1 < n && is_op_char(c) && bm_get(opch, e2 + 1) {
             // A numeric literal type ends its type argument list here (`Map<A, 1.5>>`); without this the number's own munch
             // reaches the `>` run before `coalesce` ever raises it as an event.
             if c == b'>' && kw.ts_key && matches!(*src.add(e2 + 1), b'>' | b'=') {
@@ -283,11 +283,7 @@ unsafe fn glue_number(
                 }
             }
             let q = munch_walk(t, src, n, st, opch, kind, e2);
-            if q < n
-                && *src.add(q) == b'.'
-                && is_digit(*src.add(q + 1))
-                && (*st.add(q >> 6) >> (q & 63)) & 1 != 0
-            {
+            if q < n && *src.add(q) == b'.' && is_digit(*src.add(q + 1)) && bm_get(st, q) {
                 p = q;
                 continue;
             }

--- a/crates/oxc_lexer/src/pipeline/regex_div.rs
+++ b/crates/oxc_lexer/src/pipeline/regex_div.rs
@@ -4,7 +4,7 @@ use crate::opmap::{OP_KIND_BASE, OP_QDOT};
 use crate::tables::{Tables, is_digit, is_glue_join, is_id_start, is_word, is_ws};
 use crate::token::{KW_BASE, KW_MAX, TokenKind};
 
-use super::bitmap::{bm_next0, bm_next1, bm_prev1};
+use super::bitmap::{bm_get, bm_next0, bm_next1, bm_prev1};
 use super::find::{find_line_terminator, scan_block_comment, scan_number};
 use super::{
     BCOM, BIGINT, HASHBANG, IDENT, IDENT_ESC, JEND, JSX_LT, JTEXT, LCOM, NUM, PRIV_IDENT,
@@ -41,10 +41,7 @@ unsafe fn kind_at(kind: *const u8, w: usize) -> u8 {
     }
     k
 }
-#[inline(always)]
-unsafe fn bit_at(bm: *const u64, i: usize) -> bool {
-    (*bm.add(i >> 6) >> (i & 63)) & 1 != 0
-}
+
 enum RunEnd {
     Seg(usize, usize, bool),
     Blank(bool),
@@ -2244,29 +2241,29 @@ unsafe fn gt_run_closes_type_args(
         if !GT_SCAN_DELIM[c as usize] {
             continue;
         }
-        if !bit_at(st, i) {
+        if !bm_get(st, i) {
             continue;
         }
         match c {
             b'>' => {
-                if !bit_at(opch, i) {
+                if !bm_get(opch, i) {
                     continue;
                 }
                 if i > 0 && *src.add(i - 1) == b'=' {
                     continue;
                 }
                 let nx = *src.add(i + 1);
-                if (nx == b'>' || nx == b'=') && !bit_at(st, i + 1) {
+                if (nx == b'>' || nx == b'=') && !bm_get(st, i + 1) {
                     return None;
                 }
                 depth += 1;
             }
             b'<' => {
-                if !bit_at(opch, i) {
+                if !bm_get(opch, i) {
                     continue;
                 }
                 let nx = *src.add(i + 1);
-                if nx == b'=' || (nx == b'<' && !bit_at(st, i + 1)) {
+                if nx == b'=' || (nx == b'<' && !bm_get(st, i + 1)) {
                     return None;
                 }
                 depth -= 1;
@@ -2528,7 +2525,7 @@ unsafe fn type_list_legal(
                 }
                 b'<' => {
                     let nx = *src.add(w + 1);
-                    if was_this || nx == b'=' || (nx == b'<' && !bit_at(st, w + 1)) {
+                    if was_this || nx == b'=' || (nx == b'<' && !bm_get(st, w + 1)) {
                         return false;
                     }
                     angle_bits = (angle_bits << 1) | u64::from(start);
@@ -2537,7 +2534,7 @@ unsafe fn type_list_legal(
                 }
                 b'>' => {
                     let nx = *src.add(w + 1);
-                    if (nx == b'=' || nx == b'>') && !bit_at(st, w + 1) {
+                    if (nx == b'=' || nx == b'>') && !bm_get(st, w + 1) {
                         return false;
                     }
                     if angle_depth > 0 {
@@ -2551,7 +2548,7 @@ unsafe fn type_list_legal(
                     if *src.add(w + 1) != b'>' {
                         return false;
                     }
-                    if bit_at(st, w + 1) {
+                    if bm_get(st, w + 1) {
                         skip = w + 1;
                     }
                     start = true;
@@ -2911,24 +2908,24 @@ unsafe fn enclosing_opener(
     while i > lo {
         i -= 1;
         let c = *src.add(i);
-        if !GT_SCAN_DELIM[c as usize] || !bit_at(st, i) {
+        if !GT_SCAN_DELIM[c as usize] || !bm_get(st, i) {
             continue;
         }
         match c {
             b'>' => {
-                if bit_at(opch, i) && !(i > 0 && *src.add(i - 1) == b'=') {
+                if bm_get(opch, i) && !(i > 0 && *src.add(i - 1) == b'=') {
                     ang += 1;
                 }
             }
             b'<' => {
-                if !bit_at(opch, i) {
+                if !bm_get(opch, i) {
                     continue;
                 }
                 let nx = *src.add(i + 1);
-                if nx == b'=' || (nx == b'<' && !bit_at(st, i + 1)) {
+                if nx == b'=' || (nx == b'<' && !bm_get(st, i + 1)) {
                     continue;
                 }
-                if nx == b'<' || (i > 0 && *src.add(i - 1) == b'<' && bit_at(st, i - 1)) {
+                if nx == b'<' || (i > 0 && *src.add(i - 1) == b'<' && bm_get(st, i - 1)) {
                     let first = if nx == b'<' { i } else { i - 1 };
                     if !lt_run_opens_type_args(src, st, opch, kind, n, first) {
                         continue;
@@ -3906,7 +3903,7 @@ unsafe fn ctx_after_token(
             b',' => enclosing_context(t, src, st, opch, kind, n, w, true, hops),
             b'<' => {
                 let nx = *src.add(w + 1);
-                if nx == b'=' || (nx == b'<' && !bit_at(st, w + 1)) {
+                if nx == b'=' || (nx == b'<' && !bm_get(st, w + 1)) {
                     Ctx::Expr
                 } else {
                     enclosing_list_context(t, src, st, opch, kind, n, w, hops)
@@ -3914,7 +3911,7 @@ unsafe fn ctx_after_token(
             }
             b'>' => {
                 let nx = *src.add(w + 1);
-                if ((nx == b'>' || nx == b'=') && !bit_at(st, w + 1)) || mode == After::Paren {
+                if ((nx == b'>' || nx == b'=') && !bm_get(st, w + 1)) || mode == After::Paren {
                     Ctx::Expr
                 } else {
                     Ctx::Type
@@ -4227,7 +4224,7 @@ unsafe fn arrow_after_paren_group(src: *const u8, st: *const u64, lp: usize, n: 
     let mut depth: i32 = 0;
     i += 1;
     while i < lim {
-        if bit_at(st, i) {
+        if bm_get(st, i) {
             match *src.add(i) {
                 b'(' | b'[' | b'{' | b'<' => depth += 1,
                 b')' | b']' | b'}' | b'>' => {
@@ -4631,8 +4628,8 @@ unsafe fn angle_close_fwd_capped(
     let mut brc: i32 = 0;
     while i < lim {
         let c = *src.add(i);
-        if GT_SCAN_DELIM[c as usize] && bit_at(st, i) {
-            let op = bit_at(opch, i);
+        if GT_SCAN_DELIM[c as usize] && bm_get(st, i) {
+            let op = bm_get(opch, i);
             match c {
                 b'<' => {
                     if op && *src.add(i + 1) != b'=' {
@@ -4692,7 +4689,7 @@ unsafe fn paren_close_fwd(
 ) -> Option<usize> {
     let mut d: i32 = 0;
     while i < lim {
-        if bit_at(st, i) {
+        if bm_get(st, i) {
             match *src.add(i) {
                 b'(' => d += 1,
                 b')' => {


### PR DESCRIPTION
Code to read the nth bit of a bitmap was duplicated in several places across pipeline code:

- `wordbit` in `carve`
- `bit_at` in `regex_div`
- Various places inline in `carve`, `classify`, and `coalesce`

Add a function `bm_get` for this purpose to `bitmap` module (which feels like its natural home) and replace all usages with calls to this function.

This reduces repetition, and makes the call sites easier to read.

`bm_get` is marked `#[inline(always)]`, so extracting it into a function should have no effect on perf.