### PR TITLE
fix(formatter): match Prettier's comment placement around callees, type arguments, statement bodies and return arguments

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -158,6 +158,19 @@ The `as`/`satisfies` operator gap follows the same policy (see `as_or_satisfies_
 
 Implemented by the `write_*` helpers in `utils/statement_body.rs` and `FormatParenHeadExpression` (`print/mod.rs`); their rustdocs cover the trailing-pass suppression mechanics.
 
+A single-statement body's same-line run before its distant `;` (`for (;;) continue // c` + `;`) trails the whole statement:
+Prettier's statement `locEnd` stops at the content, so the comment is the statement's, not the body's.
+`FormatStatementBody` hides it from the body and prints it past the body's indent via `FormatTrailingComments::StatementEnd`
+(a `line_suffix` without `expand_parent`, so the body keeps its fit decision).
+Two bodies keep the comment and its break, like Prettier: an `if` consequent with an `else` and a do-while body (the statement continues past them).
+
+Call-like expressions (`write_callee_and_type_arguments`, `print/call_like_expression/mod.rs`) emit Prettier's `line_suffix_boundary()`
+after the callee and after the type arguments: a same-line line comment trailing either flushes right there (`foo // c` + break + `<T>()`),
+and an own-line comment before an empty `()` keeps its own line, trailing the callee / type arguments.
+Between a callee and its `(`, only a same-line line comment trails the callee; every other comment leads the first argument
+(`foo /* c */(1)` -> `foo(/* c */ 1)`, Prettier's fixpoint); before an empty `()` or `?.` everything trails the callee.
+`new` shares the path, bounded at the node end (a paren-less `new X` owns nothing past its callee).
+
 Prettier's comment attachment is position-heuristic and sometimes asymmetric;
 that is FORMATTER_POLICY's uniform-rule ground (reason 3): one rule over the emulated asymmetry, pinned as a divergence (e.g. DIVERGENCES.md#type-alias-trailing-comment-move).
 

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -527,3 +527,31 @@ var target = x ? y : /** @type {Document} */ ((root).head ?? fallback);
 A cast comment types the parenthesized expression directly after it.
 When the comment binds to an inner expression and the formatter adds parentheses around the whole (a `??` in a conditional branch, a sequence, a return argument), it prints inside the added pair so the cast keeps its target.
 Printed outside, the cast covers the whole expression and tsc types `root` as its uncast type again (`Property 'head' does not exist on type 'Node'`).
+
+## for-x-head-own-line-comment
+
+- Why: invariant (prettier/prettier#12880)
+- Pin: `tests/fixtures/js/comments/for-in-of-head-own-line-comment.js`
+
+An own-line comment between a for-in/for-of head's left side and its right side keeps its own line, above the statement.
+
+```js
+// input
+for (x in
+// c
+y) {}
+
+// ours
+// c
+for (x in y) {
+}
+
+// prettier (first pass; its second pass moves the comment behind the `{`: `for (x in y) { // c`)
+for (x in // c
+y) {
+}
+```
+
+Prettier's output changes line (own-line to the head's line, behind the `in`) and is not a fixpoint:
+its second pass makes the comment trail the head, crossing the `)` and the body's `{`.
+Same family as the in-paren line comment of #head-body-comment-relocation (`head-paren-line-comment.js`).

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -250,12 +250,19 @@ pub enum FormatTrailingComments<'a> {
     // (enclosing_span, preceding_span, following_span_start)
     Node((Span, Span, u32)),
     Comments(&'a [Comment]),
+    /// Same-line comments hoisted past a statement body's indent to the statement's end
+    /// (`for (;;) continue // c` + `;` -> `for (;;) continue; // c`, see `FormatStatementBody`):
+    /// a line comment rides a `line_suffix` WITHOUT `expand_parent`, the statement's own line break flushes it,
+    /// so the body's `soft_line_indent_or_space` keeps its fit decision
+    /// (Prettier attaches the comment to the statement, outside its group).
+    StatementEnd(&'a [Comment]),
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatTrailingComments<'a> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         fn format_trailing_comments_impl<'a>(
             comments: impl IntoIterator<Item = &'a Comment>,
+            expand: bool,
             f: &mut JsFormatter<'_, 'a>,
         ) {
             let mut total_lines_before = 0;
@@ -316,7 +323,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTrailingComments<'a> {
                     });
 
                     if comment.is_line() {
-                        write!(f, [line_suffix(&content), expand_parent()]);
+                        write!(f, [line_suffix(&content), expand.then_some(expand_parent())]);
                     } else {
                         write!(f, [content]);
                     }
@@ -338,14 +345,21 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTrailingComments<'a> {
                     return;
                 }
 
-                format_trailing_comments_impl(comments, f);
+                format_trailing_comments_impl(comments, true, f);
             }
             Self::Comments(comments) => {
                 if comments.is_empty() {
                     return;
                 }
 
-                format_trailing_comments_impl(*comments, f);
+                format_trailing_comments_impl(*comments, true, f);
+            }
+            Self::StatementEnd(comments) => {
+                if comments.is_empty() {
+                    return;
+                }
+
+                format_trailing_comments_impl(*comments, false, f);
             }
         }
     }

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -6,7 +6,10 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{JsFormatter, JsFormatterExt as _},
-    print::{BinaryLikeExpression, should_flatten, unary_argument_takes_comment_parens},
+    print::{
+        BinaryLikeExpression, has_argument_leading_comments, should_flatten,
+        unary_argument_takes_comment_parens,
+    },
     utils::expression::ExpressionLeftSide,
 };
 
@@ -658,6 +661,13 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
             // - `(a = b)[obj]` = parens needed for object
             #[expect(clippy::match_same_arms)]
             AstNodes::ComputedMemberExpression(_) => true,
+            // `return (a = b)`, except when the statement adds the pair itself
+            // for the argument's leading comments (Prettier's `willReturnOrThrowStatementBreak`):
+            // - `return (\n  // c\n  a = b\n)`
+            AstNodes::ReturnStatement(stmt) => {
+                stmt.argument().is_none_or(|argument| !has_argument_leading_comments(argument, f))
+            }
+            AstNodes::ThrowStatement(stmt) => !has_argument_leading_comments(stmt.argument(), f),
             // For statements, no parens needed in initializer or update sections:
             // - `for (a = 1; ...; a = 2) {}` = both assignments don't need parens
             AstNodes::ForStatement(stmt) => {

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -721,6 +721,11 @@ fn write_grouped_arguments<'a>(
             // <https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/function-parameters.js#L241-L292>
             let is_decorated = is_decorated_function(argument);
 
+            // Empty parameters cannot break by themselves: a dangling comment in them
+            // (`foo((\n  // c\n) => {})`) stays hugged, like Prettier (its expansion bailout
+            // never sees a parameter-less list).
+            let has_parameters = !params.items.is_empty() || params.rest.is_some();
+
             // Remove soft lines from the cached parameters and check if they would break.
             // If they break even without soft lines, we need to use the expanded layout.
             // However, decorated functions are allowed to break while staying hugged.
@@ -729,15 +734,16 @@ fn write_grouped_arguments<'a>(
             }));
 
             if let Some(interned) = interned {
-                if interned.will_break() && !is_decorated {
+                if interned.will_break() && !is_decorated && has_parameters {
                     return format_all_elements_broken_out(node, grouped.into_iter(), true, f);
                 }
 
                 // No break; it should print the element without soft lines.
                 // It would be used in the `FormatFunction` or `FormatJsArrowFunctionExpression`.
                 // For decorated functions, we keep the original cached element (with soft lines)
-                // so the parameters can break while staying hugged.
-                if !is_decorated {
+                // so the parameters can break while staying hugged;
+                // so do empty parameters, whose dangling comment keeps its own lines.
+                if !is_decorated && has_parameters {
                     f.context_mut().cache_element(params.as_ref(), interned);
                 }
             }

--- a/crates/oxc_formatter/src/print/call_like_expression/mod.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/mod.rs
@@ -60,36 +60,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
             MemberChain::from_call_expression(self, f).fmt(f);
         } else {
             let format_inner = format_with(|f| {
-                // Preserve trailing comments of the callee in the following cases:
-                // `call /**/()`
-                // `call /**/<T>()`
-                if self.type_arguments.is_some() {
-                    write!(f, [callee]);
-                } else {
-                    write!(f, [FormatNodeWithoutTrailingComments(callee)]);
-
-                    let character = if self.optional {
-                        // For optional calls with arguments, preserve trailing comments
-                        // between the `callee` and `?.` operator.
-                        // `alert/* comment */?.('value')` → `alert /* comment */?.("value");`
-                        Some(b'?')
-                    } else if self.arguments.is_empty() {
-                        // For empty argument calls, preserve trailing comments between
-                        // the `callee` and `()`.
-                        // `call/**/()` → `call /**/();`
-                        Some(b'(')
-                    } else {
-                        None
-                    };
-                    if let Some(character) = character {
-                        let callee_trailing_comments = f
-                            .context()
-                            .comments()
-                            .comments_before_character(self.callee.span().end, character);
-                        write!(f, FormatTrailingComments::Comments(callee_trailing_comments));
-                    }
-                }
-                write!(f, [optional.then_some("?."), type_arguments]);
+                write_callee_and_type_arguments(
+                    callee,
+                    type_arguments,
+                    optional,
+                    self.arguments.first().map(|argument| argument.span().start),
+                    self.span.end,
+                    f,
+                );
 
                 // If this IS a Tailwind function call, push the Tailwind context
                 let tailwind_ctx_to_push = if is_tailwind_call {
@@ -131,7 +109,88 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, NewExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        write!(f, ["new", space(), self.callee(), self.type_arguments(), self.arguments()]);
+        write!(f, ["new", space()]);
+        write_callee_and_type_arguments(
+            self.callee(),
+            self.type_arguments(),
+            false,
+            self.arguments.first().map(|argument| argument.span().start),
+            self.span.end,
+            f,
+        );
+        write!(f, self.arguments());
+    }
+}
+
+/// Prints a call-like expression's callee and type arguments, each followed by a `line_suffix_boundary()`
+/// (Prettier's `printCallee` and `typeArgumentsDoc`):
+/// a same-line line comment trailing either flushes right there instead of riding to the end of the statement
+/// (`foo // c` + break + `<T>()`, `foo<T> // c` + break + `(1)`),
+/// and an own-line comment before an empty `()` keeps its own line (`foo<T>` + `// c` + `()`).
+///
+/// Comments between the callee and its `(` attach like Prettier's attachment defaults
+/// (`handleCallExpressionComments` claims only the ones inside the parens):
+/// - with arguments, a same-line line comment trails the callee (the boundary flushes it: `foo // c` + break + `(1)`),
+///   everything else leads the first argument (`foo /* c */(1)` -> `foo(/* c */ 1)`, Prettier's fixpoint)
+/// - before an empty `()` or an optional `?.`, everything trails the callee
+///   (`call /* c */()`, `alert /* c */?.("value")`, `foo` + `// c` + `()`)
+///
+/// With type arguments the callee's generic trailing pass already lands there
+/// (a same-line comment trails, an own-line one leads the type arguments, glued like Prettier: `foo// c` + break + `<T>()`).
+fn write_callee_and_type_arguments<'a>(
+    callee: &AstNode<'a, Expression<'a>>,
+    type_arguments: Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>>,
+    optional: bool,
+    arguments_start: Option<u32>,
+    node_end: u32,
+    f: &mut JsFormatter<'_, 'a>,
+) {
+    let callee_start = callee.span().start;
+    // The common case: no pending comment up to the arguments (or the node end), nothing to attach,
+    // no `line_suffix` a boundary could flush; the callee's own trailing pass finds nothing either
+    if !f.comments().has_comment_before(arguments_start.unwrap_or(node_end)) {
+        write!(f, [callee, optional.then_some("?."), type_arguments]);
+        return;
+    }
+    let has_arguments = arguments_start.is_some();
+    if type_arguments.is_some() {
+        write!(f, callee);
+        write_boundary_after(callee_start, f);
+        write!(f, [optional.then_some("?."), type_arguments]);
+        write_boundary_after(callee_start, f);
+        return;
+    }
+
+    write!(f, [FormatNodeWithoutTrailingComments(callee)]);
+    let callee_end = callee.span().end;
+    // The lexical scan for the token is unbounded; a `new X` without parens has no `(` of its own,
+    // so the node end fences out everything past it
+    let comments_before_token = |f: &JsFormatter<'_, 'a>, token: u8| {
+        let comments = f.context().comments().comments_before_character(callee_end, token);
+        &comments[..comments.iter().take_while(|comment| comment.span.end <= node_end).count()]
+    };
+    if optional || !has_arguments {
+        let comments = comments_before_token(f, if optional { b'?' } else { b'(' });
+        write!(f, FormatTrailingComments::Comments(comments));
+    } else {
+        let comments = comments_before_token(f, b'(');
+        let same_line_count = comments.iter().take_while(|c| !c.preceded_by_newline()).count();
+        let same_line = &comments[..same_line_count];
+        if same_line.last().is_some_and(|comment| comment.is_line()) {
+            write!(f, FormatTrailingComments::Comments(same_line));
+        }
+    }
+    write_boundary_after(callee_start, f);
+    write!(f, optional.then_some("?."));
+}
+
+/// The `line_suffix_boundary()` of [`write_callee_and_type_arguments`], emitted only when it has
+/// something to flush: a comment printed since `start` may be riding a `line_suffix`
+/// (a same-line line comment, or an own-line comment rendered trailing).
+/// Skipped otherwise to keep the IR lean, calls being the most common expression.
+fn write_boundary_after(start: u32, f: &mut JsFormatter<'_, '_>) {
+    if f.comments().printed_comments().last().is_some_and(|comment| comment.span.start >= start) {
+        write!(f, line_suffix_boundary());
     }
 }
 

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -335,14 +335,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        write!(f, ["require("]);
-
+        // Printed like a `require` call's arguments (Prettier routes it through `printCallExpression`):
+        // a lone string never breaks, whatever its width;
+        // with comments the group breaks only for one ending its line (`require(\n  // c\n  "a"\n)`),
+        // a same-line block comment stays inline (`require(/* c */ "a")`).
         if f.comments().has_comment_in_span(self.span) {
-            write!(f, [block_indent(self.expression())]);
+            write!(
+                f,
+                [group(&format_args!("require(", soft_block_indent(&self.expression()), ")"))]
+            );
         } else {
-            write!(f, [self.expression()]);
+            write!(f, ["require(", self.expression(), ")"]);
         }
-
-        write!(f, [")"]);
     }
 }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -39,7 +39,10 @@ pub use arrow_function_expression::{
 };
 pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
-pub use semicolon::write_comments_before_closing_paren;
+pub use return_or_throw_statement::has_argument_leading_comments;
+pub use semicolon::{
+    trailing_comments_to_move_behind_semicolon, write_comments_before_closing_paren,
+};
 pub use union_type::{
     alias_union_breaks_after_operator, is_line_ending_trailing_jsdoc_comment, type_alias_left_end,
 };
@@ -820,7 +823,10 @@ fn variable_declaration_content_end(
 /// the trailing `;` (and anything between it and the content) is excluded from the verbatim range,
 /// keyword statements (`debugger`/`break`/`continue`) and variable declarations always re-add `;`,
 /// content-terminated ones only when a source `;` was stripped, and statements ending in a body recurse into the rightmost body.
-fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
+pub fn suppressed_statement_content_end(
+    stmt: &Statement<'_>,
+    f: &JsFormatter<'_, '_>,
+) -> (u32, bool) {
     match stmt {
         Statement::ExpressionStatement(s) => {
             semicolon_terminated_content_end(s.expression.span().end, s.span, f)
@@ -867,9 +873,17 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
         if is_block_body {
             // The block's trailing pass would claim a comment past the `while` keyword;
             // the keyword site splits the comments instead.
-            write!(f, "do");
-            write_head_body_separator(body.span().start, f);
-            FormatNodeWithoutTrailingComments(body).fmt(f);
+            // Grouped like the other heads, so a same-line block comment ending its line
+            // stays inline before an empty body (`do /* c */ {} while (1)`, like Prettier)
+            // and breaks only when the body does.
+            write!(
+                f,
+                group(&format_with(|f| {
+                    write!(f, "do");
+                    write_head_body_separator(body.span().start, f);
+                    FormatNodeWithoutTrailingComments(body).fmt(f);
+                }))
+            );
         } else {
             write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
         }

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -14,14 +14,11 @@ use crate::{
         semicolon::{OptionalSemicolon, assignment_chain_leaf_end},
         semicolon_terminated_content_end, write_suppressed_statement,
     },
-    utils::{
-        format_node_without_trailing_comments::format_content_without_comments_after,
-        typecast::format_leading_comments_and_open_paren,
-    },
+    utils::format_node_without_trailing_comments::format_content_without_comments_after,
     write,
 };
 
-use super::FormatWrite;
+use super::{FormatWrite, sequence_expression::sequence_leading_comments_start};
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
@@ -153,21 +150,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
         let argument = self.0;
 
         if !argument.is_jsx() && has_argument_leading_comments(argument, f) {
-            // When we have leading comments and a sequence expression, we need inner parentheses
-            // e.g. `return ( // comment\n a, b )` -> `return (\n  // comment\n  (a, b)\n)`
-            let inner = format_with(|f| {
-                if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-                    // The argument's parentheses survive here,
-                    // so even a comment inside the first element's source parens stays inside:
-                    // bound at the span start.
-                    let span = argument.span();
-                    format_leading_comments_and_open_paren(span, span.start, true, f);
-                    write!(f, [argument, token(")")]);
-                } else {
-                    write!(f, argument);
-                }
-            });
-            write!(f, [token("("), &block_indent(&inner), token(")")]);
+            // The parentheses added here are the argument's own (Prettier's `willReturnOrThrowStatementBreak`):
+            // a sequence or assignment prints no pair of its own inside them
+            // (`return ( // c\n a, b )` -> `return (\n  // c\n  a, b\n)`, see `NeedsParentheses`).
+            write!(f, [token("("), &block_indent(&argument), token(")")]);
         } else if argument.is_binaryish() {
             write!(
                 f,
@@ -177,8 +163,18 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
                     if_group_breaks(&token(")"))
                 ))]
             );
-        } else if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-            write!(f, [group(&format_args!(token("("), soft_block_indent(&argument), token(")")))]);
+        } else if let Expression::SequenceExpression(sequence) = argument.as_ref() {
+            // The sequence's leading comments print outside the re-added pair, like at every other
+            // sequence site (`return (/* c */ a, b)` -> `return /* c */ (a, b)`, Prettier's fixpoint),
+            // the ones inside the first element's dropped parens included (`sequence_leading_comments_start`)
+            let leading_comments_start = sequence_leading_comments_start(sequence);
+            write!(
+                f,
+                [
+                    format_leading_comments(Span::new(leading_comments_start, argument.span().end)),
+                    group(&format_args!(token("("), soft_block_indent(&argument), token(")")))
+                ]
+            );
         } else {
             write!(f, argument);
         }
@@ -191,7 +187,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
 ///
 /// Traversing the left nodes is necessary in case the first node is parenthesized because
 /// parentheses will be removed (and be re-added by the return statement, but only if the argument breaks)
-fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &JsFormatter<'_, '_>) -> bool {
+pub fn has_argument_leading_comments(
+    argument: &AstNode<Expression>,
+    f: &JsFormatter<'_, '_>,
+) -> bool {
     let comments = f.context().comments();
 
     // Comments inside type cast parens (e.g., `/** @type {X} */ (/* here */ expr)`) are handled

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -74,24 +74,32 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
 
         let comments = f.context().comments().comments_before(quasi.span.start);
         if !comments.is_empty() {
-            // The separator before the first comment is a plain space when the comment starts on the same line,
-            // and a soft line break otherwise.
+            // The same-line run trails the tag with a space on each side
+            // (`foo /* a */ `x``, Prettier's fixpoint whether or not the comment ended its source line;
+            // a line comment rides a `line_suffix` flushed by the boundary below),
+            // an own-line run keeps its lines after a soft line break:
             // ```js
-            // foo /* a */ `x`; // same line -> space
+            // foo /* a */ `x`;
             //
             // foo
             // /* b */
-            // `x`;             // own line  -> soft line break
+            // `x`;
             // ```
             // No `group` here:
-            // the line elements inside the comments must inherit the enclosing mode,
+            // the line elements inside the own-line comments must inherit the enclosing mode,
             // so a comment followed by a newline in the source keeps its line break.
-            if comments[0].preceded_by_newline() {
-                write!(f, [soft_line_break()]);
-            } else {
-                write!(f, [space()]);
+            let same_line_count =
+                comments.iter().take_while(|comment| !comment.preceded_by_newline()).count();
+            let (same_line, own_line) = comments.split_at(same_line_count);
+            if !same_line.is_empty() {
+                write!(f, FormatTrailingComments::Comments(same_line));
+                if same_line.last().is_some_and(|comment| comment.is_block()) {
+                    write!(f, space());
+                }
             }
-            write!(f, [FormatLeadingComments::Comments(comments)]);
+            if !own_line.is_empty() {
+                write!(f, [soft_line_break(), FormatLeadingComments::Comments(own_line)]);
+            }
         }
 
         write!(f, [line_suffix_boundary()]);

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_formatter_core::{Buffer, Format, GroupId};
-use oxc_span::FileExtension;
+use oxc_span::{FileExtension, GetSpan};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -200,7 +200,22 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
             );
         });
 
-        let should_inline = !is_arrow_function_vars && first_arg_can_be_hugged;
+        // Like Prettier's `shouldInline`: a line comment, or any comment ending its line,
+        // around the argument (its own leading/trailing comments, not the ones nested inside it)
+        // needs the group to break (`foo<A // c` + break + `>()`), so the hug is off
+        let has_line_ending_comment =
+            first_arg_can_be_hugged && f.comments().has_comment_in_span(self.span) && {
+                let comments = f.comments();
+                let argument_span = self.params.first().unwrap().span();
+                comments
+                    .comments_in_range(self.span.start, argument_span.start)
+                    .iter()
+                    .chain(comments.comments_in_range(argument_span.end, self.span.end))
+                    .any(|comment| comment.is_line() || comment.followed_by_newline())
+            };
+
+        let should_inline =
+            !is_arrow_function_vars && first_arg_can_be_hugged && !has_line_ending_comment;
 
         if should_inline {
             write!(f, ["<", format_params, ">"]);

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -7,7 +7,7 @@ use crate::{
     formatter::{
         Comments, JsFormatter,
         prelude::{FormatElements, format_once, line_suffix_boundary, *},
-        trivia::FormatTrailingComments,
+        trivia::{FormatTrailingComments, is_alignable_comment},
     },
     print::{
         BinaryLikeExpression, FormatWrite, alias_union_breaks_after_operator,
@@ -766,6 +766,15 @@ fn should_break_after_operator<'a>(
             return true;
         }
 
+        // Prettier's `isIndentableBlockComment` (also applied ahead of the type-cast comment rule):
+        // a star-aligned multiline block comment breaks after the operator even when the value follows it inline
+        // (`x =\n  /**\n   * c\n   */ value`).
+        if comment.is_multiline_block()
+            && is_alignable_comment(f.source_text().text_for(&comment.span))
+        {
+            return true;
+        }
+
         // A tight type-cast comment hugs its parenthesized node,
         // so it doesn't force the break itself,
         // and the comments after it sit inside the cast's parentheses and belong to the inner node, stop scanning;
@@ -1060,19 +1069,22 @@ fn is_poorly_breakable_member_or_call_chain<'a>(
         return true;
     }
 
-    if f.comments().has_comment_in_span(call_expressions[0].span) {
-        return false;
-    }
-
     for call_expression in &call_expressions {
         let args = &call_expression.arguments;
 
         let is_breakable_call = match args.len() {
             0 => false,
             1 => match args.iter().next() {
-                Some(first_argument) => first_argument
-                    .as_expression()
-                    .is_none_or(|e| !is_short_argument(e, threshold, f)),
+                // A commented lone argument is never short (Prettier's `isLoneShortArgument`);
+                // a dangling comment in an empty `()` doesn't count
+                Some(first_argument) => {
+                    f.comments().has_comment_in_range(
+                        call_expression.callee.span().end,
+                        call_expression.span.end,
+                    ) || first_argument
+                        .as_expression()
+                        .is_none_or(|e| !is_short_argument(e, threshold, f))
+                }
                 None => false,
             },
             _ => true,

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -9,7 +9,10 @@ use crate::{
         prelude::{empty_line, format_once, hard_line_break, soft_line_indent_or_space, space},
         trivia::{FormatCommentBeforeContent, FormatLeadingComments, FormatTrailingComments},
     },
-    utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+    print::{suppressed_statement_content_end, trailing_comments_to_move_behind_semicolon},
+    utils::format_node_without_trailing_comments::{
+        FormatNodeWithoutTrailingComments, format_content_without_comments_after,
+    },
     write,
 };
 
@@ -193,29 +196,57 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
         } else if self.force_space {
             write!(f, [space(), self.body]);
         } else {
+            let body_span = self.body.span();
+            // Only live for a suppressed `if` consequent (`stuff() // oxfmt-ignore` before `else`):
+            // print it verbatim, then flush its end-of-line comments.
+            // Otherwise the `IfStatement` wrapper has hidden everything past the consequent already,
+            // and this reduces to the `else` arm.
+            let is_consequent_of_if_statement_parent = matches!(
+                self.body.parent(),
+                AstNodes::IfStatement(if_stmt)
+                if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
+            );
+
+            // The same-line run before the body's distant `;` trails the whole statement
+            // (`for (;;) continue // c` + `;` -> `for (;;) continue; // c`), like Prettier,
+            // whose statement `locEnd` stops at the content: printed past the body's indent, the comment
+            // no longer expands it (see `FormatTrailingComments::StatementEnd`).
+            // Not for a consequent with an `else`, nor for a do-while body:
+            // there the statement continues past the body (`else`, `while (x)`),
+            // so Prettier keeps the comment on the body and its break (the if-else pin in `head-body-blocks.js`).
+            let hoisted = if is_consequent_of_if_statement_parent
+                || matches!(self.body.parent(), AstNodes::DoWhileStatement(_))
+            {
+                None
+            } else {
+                let (content_end, _) = suppressed_statement_content_end(self.body.as_ref(), f);
+                (content_end < body_span.end)
+                    .then(|| {
+                        trailing_comments_to_move_behind_semicolon(f, content_end, body_span.end)
+                    })
+                    .flatten()
+                    .map(|comments| (content_end, comments))
+            };
+
             write!(
                 f,
                 [soft_line_indent_or_space(&format_once(|f| {
-                    // Only live for a suppressed `if` consequent (`stuff() // oxfmt-ignore` before `else`):
-                    // print it verbatim, then flush its end-of-line comments.
-                    // Otherwise the `IfStatement` wrapper has hidden everything past the consequent already,
-                    // and this reduces to the `else` arm.
-                    let body_span = self.body.span();
-                    let is_consequent_of_if_statement_parent = matches!(
-                        self.body.parent(),
-                        AstNodes::IfStatement(if_stmt)
-                        if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
-                    );
                     if is_consequent_of_if_statement_parent {
                         write!(f, FormatNodeWithoutTrailingComments(self.body));
                         let comments =
                             f.context().comments().end_of_line_comments_after(body_span.end);
                         FormatTrailingComments::Comments(comments).fmt(f);
+                    } else if let Some((content_end, _)) = hoisted {
+                        format_content_without_comments_after(self.body, content_end, f);
                     } else {
                         write!(f, self.body);
                     }
                 }))]
             );
+
+            if let Some((_, comments)) = hoisted {
+                FormatTrailingComments::StatementEnd(comments).fmt(f);
+            }
         }
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/issue-16125.js.snap
@@ -25,8 +25,10 @@ call?.( // argument line comment
 call /* C1 */();
 call /* C2 */?.();
 
-call(); // C3
-call?.(); // C4
+call // C3
+();
+call // C4
+?.();
 
 call(/* argument comment */);
 call?.(/* argument comment */);
@@ -43,8 +45,10 @@ call?.(
 call /* C1 */();
 call /* C2 */?.();
 
-call(); // C3
-call?.(); // C4
+call // C3
+();
+call // C4
+?.();
 
 call(/* argument comment */);
 call?.(/* argument comment */);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/arrow-dangling-parameter-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/arrow-dangling-parameter-comment.js
@@ -1,0 +1,9 @@
+// A dangling comment in an empty parameter list keeps the last-argument hug
+// (Prettier's expansion bailout never sees a parameter-less list)
+foo((
+  // c1
+) => {});
+foo(a, (
+  // c2
+) => {});
+foo((/* c3 */) => {});

--- a/crates/oxc_formatter/tests/fixtures/js/comments/arrow-dangling-parameter-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/arrow-dangling-parameter-comment.js.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A dangling comment in an empty parameter list keeps the last-argument hug
+// (Prettier's expansion bailout never sees a parameter-less list)
+foo((
+  // c1
+) => {});
+foo(a, (
+  // c2
+) => {});
+foo((/* c3 */) => {});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A dangling comment in an empty parameter list keeps the last-argument hug
+// (Prettier's expansion bailout never sees a parameter-less list)
+foo((
+  // c1
+) => {});
+foo(a, (
+  // c2
+) => {});
+foo((/* c3 */) => {});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A dangling comment in an empty parameter list keeps the last-argument hug
+// (Prettier's expansion bailout never sees a parameter-less list)
+foo((
+  // c1
+) => {});
+foo(a, (
+  // c2
+) => {});
+foo((/* c3 */) => {});
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-indentable-block-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-indentable-block-comment.js
@@ -1,0 +1,25 @@
+// A star-aligned multiline block comment before the value breaks after the operator even
+// when the value follows it on the comment's last line (Prettier's `isIndentableBlockComment`);
+// other multiline block comments keep the inline layout.
+fnString = /**
+ * multi-line
+ */ value;
+var fnString = /**
+ * multi-line
+ */ value;
+const style = /** @type {{
+  width: number,
+}} */ ({
+  width,
+});
+const style2 = /**
+ * @type {{
+ *   width: number,
+ * }}
+ */ ({
+  width,
+});
+// An argument-less call stays poorly breakable with a dangling comment
+call = call(/* call argument long long long long long long long long long long long long long long */);
+// A commented lone argument is never short
+node.id = this.flowParseTypeAnnotatableIdentifier(/*allowPrimitiveOverride*/ true);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-indentable-block-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-indentable-block-comment.js.snap
@@ -1,0 +1,102 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A star-aligned multiline block comment before the value breaks after the operator even
+// when the value follows it on the comment's last line (Prettier's `isIndentableBlockComment`);
+// other multiline block comments keep the inline layout.
+fnString = /**
+ * multi-line
+ */ value;
+var fnString = /**
+ * multi-line
+ */ value;
+const style = /** @type {{
+  width: number,
+}} */ ({
+  width,
+});
+const style2 = /**
+ * @type {{
+ *   width: number,
+ * }}
+ */ ({
+  width,
+});
+// An argument-less call stays poorly breakable with a dangling comment
+call = call(/* call argument long long long long long long long long long long long long long long */);
+// A commented lone argument is never short
+node.id = this.flowParseTypeAnnotatableIdentifier(/*allowPrimitiveOverride*/ true);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A star-aligned multiline block comment before the value breaks after the operator even
+// when the value follows it on the comment's last line (Prettier's `isIndentableBlockComment`);
+// other multiline block comments keep the inline layout.
+fnString =
+  /**
+   * multi-line
+   */ value;
+var fnString =
+  /**
+   * multi-line
+   */ value;
+const style = /** @type {{
+  width: number,
+}} */ ({
+  width,
+});
+const style2 =
+  /**
+   * @type {{
+   *   width: number,
+   * }}
+   */ ({
+    width,
+  });
+// An argument-less call stays poorly breakable with a dangling comment
+call =
+  call(
+    /* call argument long long long long long long long long long long long long long long */
+  );
+// A commented lone argument is never short
+node.id = this.flowParseTypeAnnotatableIdentifier(
+  /*allowPrimitiveOverride*/ true,
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A star-aligned multiline block comment before the value breaks after the operator even
+// when the value follows it on the comment's last line (Prettier's `isIndentableBlockComment`);
+// other multiline block comments keep the inline layout.
+fnString =
+  /**
+   * multi-line
+   */ value;
+var fnString =
+  /**
+   * multi-line
+   */ value;
+const style = /** @type {{
+  width: number,
+}} */ ({
+  width,
+});
+const style2 =
+  /**
+   * @type {{
+   *   width: number,
+   * }}
+   */ ({
+    width,
+  });
+// An argument-less call stays poorly breakable with a dangling comment
+call =
+  call(/* call argument long long long long long long long long long long long long long long */);
+// A commented lone argument is never short
+node.id = this.flowParseTypeAnnotatableIdentifier(/*allowPrimitiveOverride*/ true);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js
@@ -15,3 +15,9 @@ do x();
 // a
 while (y);
 do {} while (x); // real trailing
+// A same-line block comment ending its line stays inline before an empty body
+// and breaks only when the body does (grouped like the other heads)
+do /* b */
+{} while (x);
+do /* c */
+{ y(); } while (x);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js.snap
@@ -19,6 +19,12 @@ do x();
 // a
 while (y);
 do {} while (x); // real trailing
+// A same-line block comment ending its line stays inline before an empty body
+// and breaks only when the body does (grouped like the other heads)
+do /* b */
+{} while (x);
+do /* c */
+{ y(); } while (x);
 
 ==================== Output ====================
 ------------------
@@ -41,6 +47,13 @@ do x();
 // a
 while (y);
 do {} while (x); // real trailing
+// A same-line block comment ending its line stays inline before an empty body
+// and breaks only when the body does (grouped like the other heads)
+do /* b */ {} while (x);
+do /* c */
+{
+  y();
+} while (x);
 
 -------------------
 { printWidth: 100 }
@@ -62,5 +75,12 @@ do x();
 // a
 while (y);
 do {} while (x); // real trailing
+// A same-line block comment ending its line stays inline before an empty body
+// and breaks only when the body does (grouped like the other heads)
+do /* b */ {} while (x);
+do /* c */
+{
+  y();
+} while (x);
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-in-of-head-own-line-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-in-of-head-own-line-comment.js
@@ -1,0 +1,17 @@
+// An own-line comment between a for-in/for-of head's left side and its right side
+// keeps its own line, above the statement.
+// Divergence (js/for-of/comments.js): Prettier makes it lead the right side
+// (`for (x in // c` + break + `y)`), a shape its second pass moves behind the `)`
+// and the body's `{`; not a fixpoint (prettier#12880 family).
+for (x
+// c1
+in y);
+for (x in
+// c2
+y) {}
+for (x of
+/* c3 */
+y) {}
+for (const [a, b] of
+// c4
+entries) {}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-in-of-head-own-line-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-in-of-head-own-line-comment.js.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// An own-line comment between a for-in/for-of head's left side and its right side
+// keeps its own line, above the statement.
+// Divergence (js/for-of/comments.js): Prettier makes it lead the right side
+// (`for (x in // c` + break + `y)`), a shape its second pass moves behind the `)`
+// and the body's `{`; not a fixpoint (prettier#12880 family).
+for (x
+// c1
+in y);
+for (x in
+// c2
+y) {}
+for (x of
+/* c3 */
+y) {}
+for (const [a, b] of
+// c4
+entries) {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// An own-line comment between a for-in/for-of head's left side and its right side
+// keeps its own line, above the statement.
+// Divergence (js/for-of/comments.js): Prettier makes it lead the right side
+// (`for (x in // c` + break + `y)`), a shape its second pass moves behind the `)`
+// and the body's `{`; not a fixpoint (prettier#12880 family).
+// c1
+for (x in y);
+// c2
+for (x in y) {
+}
+/* c3 */
+for (x of y) {
+}
+// c4
+for (const [a, b] of entries) {
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// An own-line comment between a for-in/for-of head's left side and its right side
+// keeps its own line, above the statement.
+// Divergence (js/for-of/comments.js): Prettier makes it lead the right side
+// (`for (x in // c` + break + `y)`), a shape its second pass moves behind the `)`
+// and the body's `{`; not a fixpoint (prettier#12880 family).
+// c1
+for (x in y);
+// c2
+for (x in y) {
+}
+/* c3 */
+for (x of y) {
+}
+// c4
+for (const [a, b] of entries) {
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-comment-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-comment-parens.js
@@ -1,0 +1,23 @@
+// A return/throw argument with a leading comment gets the statement's own parentheses;
+// a sequence or assignment prints no pair of its own inside them
+// (Prettier's `willReturnOrThrowStatementBreak`).
+function f() {
+  return ( // c1
+    a, b
+  );
+  return (
+    // c2
+    a = b
+  );
+  throw (
+    // c3
+    a, b
+  );
+  throw ( // c4
+    a = b
+  );
+  // Without the comment the pair is the argument's own
+  return a = b;
+  return (a, b);
+  throw (a, b);
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-comment-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-comment-parens.js.snap
@@ -1,0 +1,88 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A return/throw argument with a leading comment gets the statement's own parentheses;
+// a sequence or assignment prints no pair of its own inside them
+// (Prettier's `willReturnOrThrowStatementBreak`).
+function f() {
+  return ( // c1
+    a, b
+  );
+  return (
+    // c2
+    a = b
+  );
+  throw (
+    // c3
+    a, b
+  );
+  throw ( // c4
+    a = b
+  );
+  // Without the comment the pair is the argument's own
+  return a = b;
+  return (a, b);
+  throw (a, b);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A return/throw argument with a leading comment gets the statement's own parentheses;
+// a sequence or assignment prints no pair of its own inside them
+// (Prettier's `willReturnOrThrowStatementBreak`).
+function f() {
+  return (
+    // c1
+    a, b
+  );
+  return (
+    // c2
+    a = b
+  );
+  throw (
+    // c3
+    a, b
+  );
+  throw (
+    // c4
+    a = b
+  );
+  // Without the comment the pair is the argument's own
+  return (a = b);
+  return (a, b);
+  throw (a, b);
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A return/throw argument with a leading comment gets the statement's own parentheses;
+// a sequence or assignment prints no pair of its own inside them
+// (Prettier's `willReturnOrThrowStatementBreak`).
+function f() {
+  return (
+    // c1
+    a, b
+  );
+  return (
+    // c2
+    a = b
+  );
+  throw (
+    // c3
+    a, b
+  );
+  throw (
+    // c4
+    a = b
+  );
+  // Without the comment the pair is the argument's own
+  return (a = b);
+  return (a, b);
+  throw (a, b);
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/statement-body-trailing-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/statement-body-trailing-comment.js
@@ -1,0 +1,26 @@
+// A same-line comment before a single-statement body's distant `;` trails the whole
+// statement (Prettier's statement `locEnd` stops at the content): printed past the body's
+// indent, it no longer breaks the body onto its own line.
+for (;;) continue // c1
+;
+for (;;) break /* c2 */
+;
+while (x) foo() // c3
+;
+if (x) foo() // c4
+;
+if (a) if (b) foo() // c5
+;
+with (a) foo() // c6
+;
+for (;;) return // c7
+;
+while (x) var a = 1 // c8
+;
+label: for (;;) continue label // c9
+;
+if (x) foo() /* c10 */ // c11
+;
+// A do-while body keeps it as well: the statement continues past the body
+do foo() // c13
+; while (x);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/statement-body-trailing-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/statement-body-trailing-comment.js.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A same-line comment before a single-statement body's distant `;` trails the whole
+// statement (Prettier's statement `locEnd` stops at the content): printed past the body's
+// indent, it no longer breaks the body onto its own line.
+for (;;) continue // c1
+;
+for (;;) break /* c2 */
+;
+while (x) foo() // c3
+;
+if (x) foo() // c4
+;
+if (a) if (b) foo() // c5
+;
+with (a) foo() // c6
+;
+for (;;) return // c7
+;
+while (x) var a = 1 // c8
+;
+label: for (;;) continue label // c9
+;
+if (x) foo() /* c10 */ // c11
+;
+// A do-while body keeps it as well: the statement continues past the body
+do foo() // c13
+; while (x);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A same-line comment before a single-statement body's distant `;` trails the whole
+// statement (Prettier's statement `locEnd` stops at the content): printed past the body's
+// indent, it no longer breaks the body onto its own line.
+for (;;) continue; // c1
+for (;;) break; /* c2 */
+while (x) foo(); // c3
+if (x) foo(); // c4
+if (a) if (b) foo(); // c5
+with (a) foo(); // c6
+for (;;) return; // c7
+while (x) var a = 1; // c8
+label: for (;;) continue label; // c9
+if (x) foo(); /* c10 */ // c11
+// A do-while body keeps it as well: the statement continues past the body
+do
+  foo(); // c13
+while (x);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A same-line comment before a single-statement body's distant `;` trails the whole
+// statement (Prettier's statement `locEnd` stops at the content): printed past the body's
+// indent, it no longer breaks the body onto its own line.
+for (;;) continue; // c1
+for (;;) break; /* c2 */
+while (x) foo(); // c3
+if (x) foo(); // c4
+if (a) if (b) foo(); // c5
+with (a) foo(); // c6
+for (;;) return; // c7
+while (x) var a = 1; // c8
+label: for (;;) continue label; // c9
+if (x) foo(); /* c10 */ // c11
+// A do-while body keeps it as well: the statement continues past the body
+do
+  foo(); // c13
+while (x);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js
@@ -1,5 +1,7 @@
-// Comments between a tagged template's tag and its quasi always attach to the
-// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+// Comments between a tagged template's tag and its quasi: a same-line run trails the tag
+// with a space on each side (Prettier's fixpoint; its first pass glues a block comment ending
+// its source line to the quasi, `foo /* c */`x``, and re-spaces it on the second),
+// an own-line run keeps its lines (prettier#19345).
 foo`` // comment 1
 ;
 foo // comment 2

--- a/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js.snap
@@ -2,8 +2,10 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// Comments between a tagged template's tag and its quasi always attach to the
-// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+// Comments between a tagged template's tag and its quasi: a same-line run trails the tag
+// with a space on each side (Prettier's fixpoint; its first pass glues a block comment ending
+// its source line to the quasi, `foo /* c */`x``, and re-spaces it on the second),
+// an own-line run keeps its lines (prettier#19345).
 foo`` // comment 1
 ;
 foo // comment 2
@@ -34,8 +36,10 @@ bar(foo /* comment 11 */
 ------------------
 { printWidth: 80 }
 ------------------
-// Comments between a tagged template's tag and its quasi always attach to the
-// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+// Comments between a tagged template's tag and its quasi: a same-line run trails the tag
+// with a space on each side (Prettier's fixpoint; its first pass glues a block comment ending
+// its source line to the quasi, `foo /* c */`x``, and re-spaces it on the second),
+// an own-line run keeps its lines (prettier#19345).
 foo``; // comment 1
 foo // comment 2
 ``;
@@ -43,11 +47,9 @@ foo // comment 3
 `x`;
 foo /* comment 4 */ `
 `;
-foo /* comment 5 */
-`
+foo /* comment 5 */ `
 `;
-foo /* comment 6 */
-`x`;
+foo /* comment 6 */ `x`;
 foo // comment 7
 `x`;
 foo
@@ -65,8 +67,10 @@ bar(foo /* comment 11 */ `x`);
 -------------------
 { printWidth: 100 }
 -------------------
-// Comments between a tagged template's tag and its quasi always attach to the
-// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+// Comments between a tagged template's tag and its quasi: a same-line run trails the tag
+// with a space on each side (Prettier's fixpoint; its first pass glues a block comment ending
+// its source line to the quasi, `foo /* c */`x``, and re-spaces it on the second),
+// an own-line run keeps its lines (prettier#19345).
 foo``; // comment 1
 foo // comment 2
 ``;
@@ -74,11 +78,9 @@ foo // comment 3
 `x`;
 foo /* comment 4 */ `
 `;
-foo /* comment 5 */
-`
+foo /* comment 5 */ `
 `;
-foo /* comment 6 */
-`x`;
+foo /* comment 6 */ `x`;
 foo // comment 7
 `x`;
 foo

--- a/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js
@@ -34,7 +34,8 @@ var whole = x ? y : /** @type {D} */ (b.head ?? c);
 // arrow body sequence with a leading cast comment,
 const arrow = () => (/** @type {D} */ (a).b, x);
 
-// and return argument sequence; only the cast comment moves inside the added parens.
+// and return argument sequence, where the statement's own parentheses are the added pair
+// (the sequence prints none of its own inside them).
 function ret() {
   return (
     // c

--- a/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-comment-inside-added-parens.js.snap
@@ -38,7 +38,8 @@ var whole = x ? y : /** @type {D} */ (b.head ?? c);
 // arrow body sequence with a leading cast comment,
 const arrow = () => (/** @type {D} */ (a).b, x);
 
-// and return argument sequence; only the cast comment moves inside the added parens.
+// and return argument sequence, where the statement's own parentheses are the added pair
+// (the sequence prints none of its own inside them).
 function ret() {
   return (
     // c
@@ -87,11 +88,12 @@ var whole = x ? y : /** @type {D} */ (b.head ?? c);
 const arrow = () =>
   (/** @type {D} */ (a).b, x);
 
-// and return argument sequence; only the cast comment moves inside the added parens.
+// and return argument sequence, where the statement's own parentheses are the added pair
+// (the sequence prints none of its own inside them).
 function ret() {
   return (
     // c
-    (/** @type {D} */ (a).b, x)
+    /** @type {D} */ (a).b, x
   );
 }
 
@@ -134,11 +136,12 @@ var whole = x ? y : /** @type {D} */ (b.head ?? c);
 const arrow = () =>
   (/** @type {D} */ (a).b, x);
 
-// and return argument sequence; only the cast comment moves inside the added parens.
+// and return argument sequence, where the statement's own parentheses are the added pair
+// (the sequence prints none of its own inside them).
 function ret() {
   return (
     // c
-    (/** @type {D} */ (a).b, x)
+    /** @type {D} */ (a).b, x
   );
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js
@@ -20,7 +20,7 @@ const v = ((/* c */ a), b);
 // Arrow body: the comment leads the sequence and forces the body onto its own line
 ret = () => ((/* c */ a), b);
 
-// return keeps its argument parentheses; the comment stays inside them
+// A return argument re-adds the parentheses too; the comment leads the sequence outside them
 function g() {
   return ((/* c */ a), b);
 }

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js.snap
@@ -24,7 +24,7 @@ const v = ((/* c */ a), b);
 // Arrow body: the comment leads the sequence and forces the body onto its own line
 ret = () => ((/* c */ a), b);
 
-// return keeps its argument parentheses; the comment stays inside them
+// A return argument re-adds the parentheses too; the comment leads the sequence outside them
 function g() {
   return ((/* c */ a), b);
 }
@@ -57,9 +57,9 @@ const v = /* c */ (a, b);
 ret = () =>
   /* c */ (a, b);
 
-// return keeps its argument parentheses; the comment stays inside them
+// A return argument re-adds the parentheses too; the comment leads the sequence outside them
 function g() {
-  return (/* c */ a, b);
+  return /* c */ (a, b);
 }
 
 // for-init adds no parentheses
@@ -89,9 +89,9 @@ const v = /* c */ (a, b);
 ret = () =>
   /* c */ (a, b);
 
-// return keeps its argument parentheses; the comment stays inside them
+// A return argument re-adds the parentheses too; the comment leads the sequence outside them
 function g() {
-  return (/* c */ a, b);
+  return /* c */ (a, b);
 }
 
 // for-init adds no parentheses

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/callee-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/callee-comments.ts
@@ -1,0 +1,57 @@
+// Comments around a call's callee and type arguments attach like Prettier's:
+// a same-line line comment trails the callee / the type arguments and flushes right there
+// (`line_suffix_boundary`, Prettier's `printCallee`), never riding to the statement's end.
+foo // c1
+<string>(1);
+foo<string> // c2
+(1);
+foo // c3
+<string>();
+foo<string> // c4
+();
+// An own-line comment before an empty `()` keeps its own line, trailing the type arguments
+foo<string>
+// c5
+();
+foo<string>
+/* c6 */
+();
+// Block comments keep Prettier's shapes (a same-line one leads the type arguments)
+foo /* c7 */<string>(1);
+foo/* c8 */ <string>(1);
+foo<string> /* c9 */();
+// Without type arguments: a same-line line comment trails the callee,
+// block and own-line comments lead the first argument
+foo // c10
+(1);
+foo /* c11 */(1);
+foo
+// c12
+(1);
+foo // c13
+();
+foo
+// c14
+();
+foo /* c15 */();
+// `new` shares the callee handling
+new A(// c16
+b, c);
+new A /* c17 */(b, c);
+new A // c18
+(b, c);
+new A
+// c19
+(b, c);
+new A // c20
+<T>(b);
+new A // c21
+();
+// A `new` without parentheses has nothing of its own past the callee
+new A // c22
+;
+new A
+// c23
+;
+x = foo // c24
+(1);

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/callee-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/callee-comments.ts.snap
@@ -1,0 +1,196 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments around a call's callee and type arguments attach like Prettier's:
+// a same-line line comment trails the callee / the type arguments and flushes right there
+// (`line_suffix_boundary`, Prettier's `printCallee`), never riding to the statement's end.
+foo // c1
+<string>(1);
+foo<string> // c2
+(1);
+foo // c3
+<string>();
+foo<string> // c4
+();
+// An own-line comment before an empty `()` keeps its own line, trailing the type arguments
+foo<string>
+// c5
+();
+foo<string>
+/* c6 */
+();
+// Block comments keep Prettier's shapes (a same-line one leads the type arguments)
+foo /* c7 */<string>(1);
+foo/* c8 */ <string>(1);
+foo<string> /* c9 */();
+// Without type arguments: a same-line line comment trails the callee,
+// block and own-line comments lead the first argument
+foo // c10
+(1);
+foo /* c11 */(1);
+foo
+// c12
+(1);
+foo // c13
+();
+foo
+// c14
+();
+foo /* c15 */();
+// `new` shares the callee handling
+new A(// c16
+b, c);
+new A /* c17 */(b, c);
+new A // c18
+(b, c);
+new A
+// c19
+(b, c);
+new A // c20
+<T>(b);
+new A // c21
+();
+// A `new` without parentheses has nothing of its own past the callee
+new A // c22
+;
+new A
+// c23
+;
+x = foo // c24
+(1);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments around a call's callee and type arguments attach like Prettier's:
+// a same-line line comment trails the callee / the type arguments and flushes right there
+// (`line_suffix_boundary`, Prettier's `printCallee`), never riding to the statement's end.
+foo // c1
+<string>(1);
+foo<string> // c2
+(1);
+foo // c3
+<string>();
+foo<string> // c4
+();
+// An own-line comment before an empty `()` keeps its own line, trailing the type arguments
+foo<string>
+// c5
+();
+foo<string>
+/* c6 */
+();
+// Block comments keep Prettier's shapes (a same-line one leads the type arguments)
+foo/* c7 */ <string>(1);
+foo/* c8 */ <string>(1);
+foo<string> /* c9 */();
+// Without type arguments: a same-line line comment trails the callee,
+// block and own-line comments lead the first argument
+foo // c10
+(1);
+foo(/* c11 */ 1);
+foo(
+  // c12
+  1,
+);
+foo // c13
+();
+foo
+// c14
+();
+foo /* c15 */();
+// `new` shares the callee handling
+new A(
+  // c16
+  b,
+  c,
+);
+new A(/* c17 */ b, c);
+new A // c18
+(b, c);
+new A(
+  // c19
+  b,
+  c,
+);
+new A // c20
+<T>(b);
+new A // c21
+();
+// A `new` without parentheses has nothing of its own past the callee
+new A(); // c22
+new A();
+// c23
+x =
+  foo // c24
+  (1);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments around a call's callee and type arguments attach like Prettier's:
+// a same-line line comment trails the callee / the type arguments and flushes right there
+// (`line_suffix_boundary`, Prettier's `printCallee`), never riding to the statement's end.
+foo // c1
+<string>(1);
+foo<string> // c2
+(1);
+foo // c3
+<string>();
+foo<string> // c4
+();
+// An own-line comment before an empty `()` keeps its own line, trailing the type arguments
+foo<string>
+// c5
+();
+foo<string>
+/* c6 */
+();
+// Block comments keep Prettier's shapes (a same-line one leads the type arguments)
+foo/* c7 */ <string>(1);
+foo/* c8 */ <string>(1);
+foo<string> /* c9 */();
+// Without type arguments: a same-line line comment trails the callee,
+// block and own-line comments lead the first argument
+foo // c10
+(1);
+foo(/* c11 */ 1);
+foo(
+  // c12
+  1,
+);
+foo // c13
+();
+foo
+// c14
+();
+foo /* c15 */();
+// `new` shares the callee handling
+new A(
+  // c16
+  b,
+  c,
+);
+new A(/* c17 */ b, c);
+new A // c18
+(b, c);
+new A(
+  // c19
+  b,
+  c,
+);
+new A // c20
+<T>(b);
+new A // c21
+();
+// A `new` without parentheses has nothing of its own past the callee
+new A(); // c22
+new A();
+// c23
+x =
+  foo // c24
+  (1);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/import-require.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/import-require.ts
@@ -1,0 +1,12 @@
+// `require(...)` prints like a `require` call's arguments: a lone string never breaks,
+// a comment ending its line breaks the group, a same-line block comment stays inline
+import A1 = require("./a/long/long/long/long/long/long/long/long/long/long/long/long/long/path/to/module");
+import B1 = require(
+  // c1
+  "b"
+);
+import B2 = require(/* c2 */ "b");
+import B3 = require(
+  /* c3 */
+  "b"
+);

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/import-require.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/import-require.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `require(...)` prints like a `require` call's arguments: a lone string never breaks,
+// a comment ending its line breaks the group, a same-line block comment stays inline
+import A1 = require("./a/long/long/long/long/long/long/long/long/long/long/long/long/long/path/to/module");
+import B1 = require(
+  // c1
+  "b"
+);
+import B2 = require(/* c2 */ "b");
+import B3 = require(
+  /* c3 */
+  "b"
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `require(...)` prints like a `require` call's arguments: a lone string never breaks,
+// a comment ending its line breaks the group, a same-line block comment stays inline
+import A1 = require("./a/long/long/long/long/long/long/long/long/long/long/long/long/long/path/to/module");
+import B1 = require(
+  // c1
+  "b"
+);
+import B2 = require(/* c2 */ "b");
+import B3 = require(
+  /* c3 */
+  "b"
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `require(...)` prints like a `require` call's arguments: a lone string never breaks,
+// a comment ending its line breaks the group, a same-line block comment stays inline
+import A1 = require("./a/long/long/long/long/long/long/long/long/long/long/long/long/long/path/to/module");
+import B1 = require(
+  // c1
+  "b"
+);
+import B2 = require(/* c2 */ "b");
+import B3 = require(
+  /* c3 */
+  "b"
+);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/type-arguments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/type-arguments.ts
@@ -1,0 +1,20 @@
+// A single huggable type argument stays inline unless a comment of its own ends its line
+// (Prettier's `shouldInline`)
+foo<A /* c1 */>();
+foo<
+  A // c2
+>();
+foo<
+  // c3
+  string
+>(1);
+new Foo<
+  // c4
+  T
+>();
+foo</* c5 */ A>();
+// Comments nested inside the argument don't count
+const dispatch = createEventDispatcher<{
+  loaded: null; // c6
+  change: string; // c7
+}>();

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/type-arguments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/type-arguments.ts.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A single huggable type argument stays inline unless a comment of its own ends its line
+// (Prettier's `shouldInline`)
+foo<A /* c1 */>();
+foo<
+  A // c2
+>();
+foo<
+  // c3
+  string
+>(1);
+new Foo<
+  // c4
+  T
+>();
+foo</* c5 */ A>();
+// Comments nested inside the argument don't count
+const dispatch = createEventDispatcher<{
+  loaded: null; // c6
+  change: string; // c7
+}>();
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A single huggable type argument stays inline unless a comment of its own ends its line
+// (Prettier's `shouldInline`)
+foo<A /* c1 */>();
+foo<
+  A // c2
+>();
+foo<
+  // c3
+  string
+>(1);
+new Foo<
+  // c4
+  T
+>();
+foo</* c5 */ A>();
+// Comments nested inside the argument don't count
+const dispatch = createEventDispatcher<{
+  loaded: null; // c6
+  change: string; // c7
+}>();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A single huggable type argument stays inline unless a comment of its own ends its line
+// (Prettier's `shouldInline`)
+foo<A /* c1 */>();
+foo<
+  A // c2
+>();
+foo<
+  // c3
+  string
+>(1);
+new Foo<
+  // c4
+  T
+>();
+foo</* c5 */ A>();
+// Comments nested inside the argument don't count
+const dispatch = createEventDispatcher<{
+  loaded: null; // c6
+  change: string; // c7
+}>();
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
-assertion_line: 172
 expression: report
 ---
-js compatibility: 765/810 (94.44%), 23 files skipped
+js compatibility: 771/810 (95.19%), 23 files skipped
 
 # Failed
 
@@ -11,40 +10,34 @@ js compatibility: 765/810 (94.44%), 23 files skipped
 | :-------- | :--------------: | :---------: |
 | js/arrows/arrow-chain-with-trailing-comments.js | 💥💥 | 93.75% |
 | js/arrows/issue-17421.js | 💥💥 | 88.70% |
-| js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/assignment-comments/string.js | 💥 | 96.59% |
 | js/binary-expressions/mutiple-comments/17192.js | 💥✨ | 45.83% |
-| js/call/no-argument/no-arguments.js | 💥 | 57.53% |
+| js/call/no-argument/no-arguments.js | 💥 | 83.54% |
 | js/class-comment/misc.js | 💥 | 66.67% |
 | js/class-comment/superclass.js | 💥 | 70.33% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
-| js/comments/return-statement-2.js | 💥💥 | 87.32% |
-| js/comments/return-statement.js | 💥💥 | 97.25% |
-| js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
+| js/comments/return-statement.js | 💥💥 | 98.90% |
+| js/comments/tagged-template-literal.js | 💥💥 | 92.86% |
 | js/comments/try.js | 💥💥 | 66.67% |
 | js/comments/assignment/variable-declarator.js | 💥 | 88.00% |
-| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 90.85% |
+| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 92.83% |
 | js/comments/between-head-and-body/empty-statement.js | 💥 | 86.05% |
-| js/comments/first-argument/first-argument.js | 💥 | 92.98% |
 | js/comments/function/18146.js | 💥 | 51.80% |
 | js/comments/function/between-parentheses-and-function-body.js | 💥 | 47.62% |
-| js/comments/in-list/dangling-comment-in-list.js | 💥 | 95.91% |
-| js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 88.24% |
 | js/for/9812-2.js | 💥 | 88.89% |
-| js/for/continue-and-break-comment-without-blocks.js | 💥 | 67.59% |
+| js/for/continue-and-break-comment-without-blocks.js | 💥 | 81.16% |
 | js/for-of/comments.js | 💥 | 44.83% |
-| js/function/iife.js | 💥 | 14.89% |
+| js/function/iife.js | 💥 | 14.43% |
 | js/function/issue-12967.js | 💥 | 0.00% |
 | js/if/expr_and_same_line_comments.js | 💥 | 81.93% |
 | js/if/issue-15168.js | 💥 | 91.43% |
 | js/if/non-block.js | 💥 | 82.35% |
-| js/if/condition-break/boolean-expression.js | 💥 | 94.03% |
+| js/if/condition-break/boolean-expression.js | 💥 | 97.01% |
 | js/if/condition-break/unary-expression.js | 💥 | 61.38% |
 | js/label/comment.js | 💥 | 58.82% |
-| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
 | js/sequence-expression/parenthesized-trailing-comment-unstable.js | 💥 | 66.67% |
 | js/sequence-expression/parenthesized.js | 💥 | 85.71% |
@@ -86,8 +79,6 @@ js compatibility: 765/810 (94.44%), 23 files skipped
 - js/arrays/numbers-negative-comment-after-minus.js
 - js/arrays/numbers-with-holes.js
 - js/comments/return-statement.js
-- js/comments/first-argument/first-argument.js
-- js/for/continue-and-break-comment-without-blocks.js
 - js/function/issue-12967.js
 - js/object-prop-break-in/short-keys.js
 - jsx/comments/in-attributes.js

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
-assertion_line: 178
 expression: report
 ---
-ts compatibility: 621/659 (94.23%), 16 files skipped
+ts compatibility: 627/659 (95.14%), 16 files skipped
 
 # Failed
 
@@ -14,13 +13,10 @@ ts compatibility: 621/659 (94.23%), 16 files skipped
 | typescript/as/break-after-keyword/18148.ts | 💥 | 93.33% |
 | typescript/as/comments/17407.ts | 💥 | 47.06% |
 | typescript/as/comments/18160.ts | 💥 | 54.21% |
-| typescript/call/callee-comments.ts | 💥 | 75.00% |
 | typescript/cast/18406.ts | 💥 | 84.21% |
 | typescript/class-comment/class-implements.ts | 💥 | 93.33% |
 | typescript/class-comment/declare.ts | 💥 | 72.00% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
-| typescript/comments/type-parameters.ts | 💥 | 81.82% |
-| typescript/comments/first-argument/first-argument.ts | 💥 | 81.16% |
 | typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 85.25% |
 | typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 91.62% |
 | typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 83.64% |
@@ -35,10 +31,7 @@ ts compatibility: 621/659 (94.23%), 16 files skipped
 | typescript/satisfies-operators/comments-unstable.ts | 💥💥 | 61.54% |
 | typescript/template-literals/member-expression.ts | 💥 | 65.12% |
 | typescript/type-parameters-arguments/18041.ts | 💥 | 91.43% |
-| typescript/type-parameters-arguments/18604.ts | 💥 | 60.00% |
-| typescript/type-parameters-arguments/19505.ts | 💥 | 61.54% |
 | typescript/type-parameters-arguments/constraints-and-default.ts | 💥 | 91.67% |
-| typescript/type-parameters-arguments/issue-6858.ts | 💥 | 60.61% |
 | typescript/union/5849.ts | 💥 | 95.38% |
 | typescript/union/union-parens.ts | 💥 | 97.67% |
 | typescript/union/comments/18106.ts | 💥 | 86.36% |


### PR DESCRIPTION
Closes a batch of comment-placement parity gaps against the pinned Prettier (3.9.6), taken from the crate's conformance report rather than one-off reports.

Prettier conformance: js 765/810 → 771/810, ts 621/659 → 627/659, no new failures.

Fixtures that now pass outright: `js/assignment-comments/indentable-block-comment.js`, `js/comments/first-argument/first-argument.js`, `js/comments/in-list/dangling-comment-in-list.js`, `js/comments-closure-typecast/closure-compiler-type-cast.js`, `js/comments/return-statement-2.js`, `js/last-argument-expansion/dangling-comment-in-arrow-function.js`, `typescript/call/callee-comments.ts`, `typescript/comments/type-parameters.ts`, `typescript/comments/first-argument/first-argument.ts`, `typescript/type-parameters-arguments/{18604,19505,issue-6858}.ts`. Several others improved their match ratio (`return-statement.js`, `tagged-template-literal.js`, `between-head-and-body.js`, `continue-and-break-comment-without-blocks.js`, `no-arguments.js`, `boolean-expression.js`).

### What changed

- **Callee and type-argument comments** (`write_callee_and_type_arguments`): emit Prettier's `lineSuffixBoundary` after the callee and after type arguments, so a same-line line comment flushes right there (`foo // c` + break + `<T>()`, `foo<T> // c` + break + `(1)`) instead of riding to the statement end, and an own-line comment before an empty `()` keeps its line. Comments between a callee and its `(` attach like Prettier's defaults: only a same-line line comment trails the callee, everything else leads the first argument. `new` now shares this path (it previously printed the callee with its generic trailing pass, so `new A(// c` + break + `b, c)` lost the comment to the statement end). Both are skipped entirely when no comment is pending before the arguments, so the common case emits nothing extra.
- **Inline type-argument lists**: a single huggable argument stays inline unless a comment of its own ends its line (Prettier's `shouldInline`), fixing `foo<A // c` + `>()` being glued.
- **Return/throw with a commented sequence or assignment**: the statement's own parens are the added pair, the argument prints none of its own (Prettier's `willReturnOrThrowStatementBreak`); a sequence's leading comments print outside the re-added pair (`return /* c */ (a, b)`).
- **Single-statement bodies**: a same-line comment before the body's distant `;` (`for (;;) continue // c` + `;`) trails the whole statement, `for (;;) continue; // c`, like Prettier whose statement `locEnd` stops at the content. Printed past the body's indent via a new `FormatTrailingComments::StatementEnd` (a `line_suffix` without `expand_parent`), so the body keeps its fit decision; this was also not idempotent before. An `if` consequent with an `else` and a do-while body keep the comment and its break, like Prettier.
- **Assignment layout**: a star-aligned multiline block comment before the value breaks after the operator (`isIndentableBlockComment`); the poorly-breakable chain rule now checks comments on the lone argument like `isLoneShortArgument` instead of anywhere in the call.
- **Last-argument hug** with a dangling comment in empty parameters (`foo((` + `// c` + `) => {})`), `require(...)` references printed like a `require` call's arguments, do-while head comments grouped like the other heads, tagged-template same-line block comments printed as Prettier's fixpoint.

### Divergences

One new entry, `for-x-head-own-line-comment`: an own-line comment between a for-in/of head's left and right side keeps its own line above the statement; Prettier's placement there is not a fixpoint and its second pass crosses the `)`. Pinned by a fixture.

The remaining comment failures in the report are the already-documented pins, plus `memberInAndOutWithCalls` in `return-statement.js`, where Prettier's own output is not a fixpoint.

### Performance

Measured with `cargo benchmark --bench formatter`, alternating pre/post binaries three times per file (run-to-run drift on the machine was up to ±4%): all files within ±1% (errors.ts +0.9%, core.js −0.5%, types.ts +0.3%, App.tsx −0.9%). A first version regressed `errors.ts` by ~3.5% through the `new` path; the no-comment fast path above removed that.

### AI disclosure

Written with an AI assistant (Claude); every output was verified against the pinned Prettier and reviewed by me.
