### PR TITLE
fix(formatter_core): do not panic with align(0)

### DIFF
--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -1928,6 +1928,37 @@ a",
         assert_eq!("k: |+\n  hello world\n\n  next\n", result.as_code());
     }
 
+    /// `align(0)` pushes no frame: the content prints at the current indention,
+    /// and in tab mode the next `indent` does not gain a tab for it.
+    #[test]
+    fn zero_width_align_is_identity() {
+        let allocator = Allocator::default();
+        let content = test_format_with(|f| {
+            write!(
+                f,
+                [
+                    token("a"),
+                    align(
+                        0,
+                        &format_args!(
+                            hard_line_break(),
+                            token("b"),
+                            indent(&format_args!(hard_line_break(), token("c")))
+                        )
+                    )
+                ]
+            );
+        });
+
+        let result = format_simple(&allocator, &content);
+        assert_eq!("a\nb\n  c", result.as_code());
+
+        let options =
+            PrinterOptions { indent_style: IndentStyle::Tab, ..PrinterOptions::default() };
+        let result = format_simple_with_options(&allocator, &content, options);
+        assert_eq!("a\nb\n\tc", result.as_code());
+    }
+
     /// Known divergence from Prettier: a hard line directly after a column-0 literal line
     /// is absorbed by the "only print a newline if the line isn't already empty" rule
     /// (Prettier prints both newlines). When a consumer needs the extra structural newline

--- a/crates/oxc_formatter_core/src/write/builders.rs
+++ b/crates/oxc_formatter_core/src/write/builders.rs
@@ -590,28 +590,30 @@ impl<C> std::fmt::Debug for Dedent<'_, '_, C> {
 
 /// Aligns its content by indenting the content by `count` spaces.
 ///
-/// # Panics
-///
-/// Panics if `count` is `0`.
+/// A `count` of `0` writes the content as-is:
+/// no align frame is pushed, so it neither measures nor turns into a tab when the indent style is tabs.
+/// `count` is often computed (a column difference, the indent width, which may be `0`),
+/// and every such caller would otherwise need the same guard.
 pub fn align<'ast, C, Content>(count: u8, content: &Content) -> Align<'_, 'ast, C>
 where
     Content: Format<'ast, C>,
 {
-    Align {
-        count: NonZeroU8::new(count).expect("Alignment count must be a non-zero number."),
-        content: Argument::new(content),
-    }
+    Align { count: NonZeroU8::new(count), content: Argument::new(content) }
 }
 
 #[derive(Copy, Clone)]
 pub struct Align<'a, 'ast, C> {
-    count: NonZeroU8,
+    /// `None`: zero-width, no frame.
+    count: Option<NonZeroU8>,
     content: Argument<'a, 'ast, C>,
 }
 
 impl<'ast, C> Format<'ast, C> for Align<'_, 'ast, C> {
     fn fmt(&self, f: &mut Formatter<'_, 'ast, C>) {
-        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))));
+        let Some(count) = self.count else {
+            return Arguments::from(&self.content).fmt(f);
+        };
+        f.write_element(FormatElement::Tag(StartAlign(tag::Align(count))));
         Arguments::from(&self.content).fmt(f);
         f.write_element(FormatElement::Tag(EndAlign));
     }

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/root-indent-indicator-block-scalar.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/root-indent-indicator-block-scalar.yaml
@@ -1,0 +1,3 @@
+# A root block scalar with indentation indicator 1 puts its content in column 0:
+# the printer asks for a zero-width `align`, which used to panic.
+--- |1-

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/root-indent-indicator-block-scalar.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/root-indent-indicator-block-scalar.yaml.snap
@@ -1,0 +1,26 @@
+---
+source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+---
+==================== Input ====================
+# A root block scalar with indentation indicator 1 puts its content in column 0:
+# the printer asks for a zero-width `align`, which used to panic.
+--- |1-
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+# A root block scalar with indentation indicator 1 puts its content in column 0:
+# the printer asks for a zero-width `align`, which used to panic.
+---
+|1-
+
+-------------------
+{ printWidth: 100 }
+-------------------
+# A root block scalar with indentation indicator 1 puts its content in column 0:
+# the printer asks for a zero-width `align`, which used to panic.
+---
+|1-
+
+===================== End =====================


### PR DESCRIPTION
Prevent YAML formatter panic in certain case. And also supports `tabWidth: 0` as valid case. 