### PR TITLE
feat(formatter_test): test Prettier dynamic snippet tests

### DIFF
--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-less.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-less.snap
@@ -2,13 +2,43 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-less compatibility: 38/40 (95.00%), 7 files skipped
+less compatibility: 206/238 (86.55%), 9 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | less/comments/value-lists.less | 💥 | 76.92% |
+| less/less-test-suite/snippet: tests-config/globalVars/extended.less | 💥 | 78.26% |
+| less/less-test-suite/snippet: tests-config/math-always/no-sm-operations.less | 💥 | 95.00% |
+| less/less-test-suite/snippet: tests-config/math-parens-division/mixins-args.less | 💥 | 99.48% |
+| less/less-test-suite/snippet: tests-config/math-parens-division/new-division.less | 💥 | 82.35% |
+| less/less-test-suite/snippet: tests-config/math-strict/mixins-args.less | 💥 | 99.48% |
+| less/less-test-suite/snippet: tests-config/namespacing/namespacing-3.less | 💥 | 98.04% |
+| less/less-test-suite/snippet: tests-config/namespacing/namespacing-functions.less | 💥 | 97.30% |
+| less/less-test-suite/snippet: tests-config/namespacing/namespacing-media.less | 💥 | 96.15% |
+| less/less-test-suite/snippet: tests-config/static-urls/urls.less | 💥 | 93.33% |
+| less/less-test-suite/snippet: tests-config/units/no-strict/no-strict.less | 💥 | 71.43% |
+| less/less-test-suite/snippet: tests-config/url-args/urls.less | 💥 | 96.64% |
+| less/less-test-suite/snippet: tests-unit/at-rules/at-rules.less | 💥 | 85.00% |
+| less/less-test-suite/snippet: tests-unit/calc/calc.less | 💥 | 90.91% |
+| less/less-test-suite/snippet: tests-unit/color-functions/rgba.less | 💥 | 82.93% |
+| less/less-test-suite/snippet: tests-unit/comments/comments.less | 💥 | 97.82% |
+| less/less-test-suite/snippet: tests-unit/comments/comments2.less | 💥 | 87.50% |
+| less/less-test-suite/snippet: tests-unit/extend-chaining/extend-chaining.less | 💥 | 98.25% |
+| less/less-test-suite/snippet: tests-unit/extend-selector/extend-selector.less | 💥 | 98.67% |
+| less/less-test-suite/snippet: tests-unit/import/import-remote.less | 💥 | 52.63% |
+| less/less-test-suite/snippet: tests-unit/import/import.less | 💥 | 87.88% |
+| less/less-test-suite/snippet: tests-unit/javascript/javascript.less | 💥 | 81.01% |
+| less/less-test-suite/snippet: tests-unit/layer/layer.less | 💥 | 96.72% |
+| less/less-test-suite/snippet: tests-unit/media/media.less | 💥 | 99.69% |
+| less/less-test-suite/snippet: tests-unit/mixins-guards-default-func/mixins-guards-default-func.less | 💥 | 98.43% |
+| less/less-test-suite/snippet: tests-unit/mixins-guards/mixins-guards.less | 💥 | 99.69% |
+| less/less-test-suite/snippet: tests-unit/namespace-targeted/namespace-targeted.less | 💥 | 96.88% |
+| less/less-test-suite/snippet: tests-unit/operations/operations.less | 💥 | 98.44% |
+| less/less-test-suite/snippet: tests-unit/parser-slashed-combinator/parser-slashed-combinator.less | 💥 | 94.74% |
+| less/less-test-suite/snippet: tests-unit/urls/urls.less | 💥 | 97.65% |
+| less/less-test-suite/snippet: tests-unit/variables/variables.less | 💥 | 97.89% |
 | less/postcss-8-improment/test.less | 💥 | 88.24% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
@@ -17,6 +47,8 @@ less compatibility: 38/40 (95.00%), 7 files skipped
 - less/comments/in-value.less
 - less/interpolation/interpolation.less
 - less/less/less.less
+- less/less-test-suite/snippet: tests-unit/property-name-interp/property-name-interp.less
+- less/less-test-suite/snippet: tests-unit/strings/strings.less
 - less/lookup/lookup-1.less
 - less/no-semicolon/url.less
 - less/parens/parens.less

--- a/crates/oxc_formatter_graphql/tests/snapshots/conformance__prettier-graphql.snap
+++ b/crates/oxc_formatter_graphql/tests/snapshots/conformance__prettier-graphql.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter_graphql/tests/conformance.rs
 expression: report
 ---
-graphql compatibility: 57/57 (100.00%), 0 files skipped
+graphql compatibility: 100/100 (100.00%), 0 files skipped
 
 # Failed
 

--- a/crates/oxc_formatter_json/tests/snapshots/conformance__prettier-jsonc.snap
+++ b/crates/oxc_formatter_json/tests/snapshots/conformance__prettier-jsonc.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter_json/tests/conformance.rs
 expression: report
 ---
-jsonc compatibility: 9/9 (100.00%), 0 files skipped
+jsonc compatibility: 10/10 (100.00%), 0 files skipped
 
 # Failed
 

--- a/crates/oxc_formatter_tests/Cargo.toml
+++ b/crates/oxc_formatter_tests/Cargo.toml
@@ -50,4 +50,3 @@ conformance = [
 
 [lib]
 doctest = false
-test = false

--- a/crates/oxc_formatter_tests/src/conformance.rs
+++ b/crates/oxc_formatter_tests/src/conformance.rs
@@ -16,6 +16,10 @@
 //! └── *.yml                               <- inputs, one snapshot section per file × option set
 //! ```
 //!
+//! Specs may also pass `snippets` (inputs built at runtime, e.g. the CommonMark / YAML test suites).
+//! Those have no input file; their `snippet:` snapshot sections carry input, options and output,
+//! and are run straight from the snapshot under a synthetic `<dir>/snippet: <name>` path.
+//!
 //! Debugging: `PRETTIER_FILTER=<substring>` formats only matching files
 //! and prints per-option-set diffs instead of producing a report.
 
@@ -49,6 +53,17 @@ const FORMAT_TEST_SPEC_NAME: &str = "format.test.js";
 const SNAPSHOT_DIR_NAME: &str = "__snapshots__";
 const SNAPSHOT_FILE_NAME: &str = "format.test.js.snap";
 
+/// Section layout of a jest snapshot entry (`createSnapshot` in Prettier's format-test config):
+/// options block, `printWidth` indicator line, input, output, closing rule.
+const OPTIONS_SEPARATOR: &str =
+    "====================================options=====================================\n";
+const INPUT_SEPARATOR: &str =
+    "\n=====================================input======================================\n";
+const OUTPUT_SEPARATOR: &str =
+    "\n=====================================output=====================================\n";
+const END_SEPARATOR: &str =
+    "\n================================================================================";
+
 /// Spec dirs every language skips: parser error message snapshots
 /// (added in Prettier v3.9.1) are not a formatter concern.
 /// Matched against the suite-relative path, like every ignore entry.
@@ -63,6 +78,7 @@ pub struct ConformanceConfig<'a> {
     /// When set, only `runFormatTest` calls whose parser list contains this name are exercised
     /// (a shared `format.test.js` may target several parsers).
     /// `None` accepts every call (JS/TS).
+    /// Also gates `snippets` sections: they are matched by parser name, so `None` runs files only.
     pub exact_parser: Option<&'a str>,
     /// Path substrings to skip (unsupported constructs, no snapshot to compare, ...).
     pub ignore: &'a [&'a str],
@@ -98,9 +114,7 @@ where
     if let Some(filter) = filter.as_deref() {
         for dir in &test_dirs {
             let inputs = collect_test_files(dir, &format_root, config.ignore, Some(filter));
-            if !inputs.is_empty() {
-                test_snapshots(config, &mut format, dir, &inputs, true);
-            }
+            test_snapshots(config, &mut format, dir, &format_root, &inputs, Some(filter), true);
         }
         return None;
     }
@@ -118,11 +132,13 @@ where
         let inputs = collect_test_files(dir, &format_root, config.ignore, None);
         // `None`: no spec call targets this language config (shared dir, or every combination skipped).
         // The files were never exercised, keep them out of the totals instead of counting them as passed.
-        let Some(results) = test_snapshots(config, &mut format, dir, &inputs, false) else {
+        let Some(results) =
+            test_snapshots(config, &mut format, dir, &format_root, &inputs, None, false)
+        else {
             continue;
         };
 
-        total_tested_file_count += inputs.len();
+        total_tested_file_count += results.tested;
         total_failed_file_count += results.failed.len();
         total_skipped_files.extend(results.skipped);
         total_non_idempotent_files.extend(results.non_idempotent);
@@ -130,8 +146,7 @@ where
         for (path, (failed, passed, ratio)) in results.failed {
             writeln!(
                 failed_reports,
-                "| {} | {}{} | {:.2}% |",
-                report_path(&path, &format_root),
+                "| {path} | {}{} | {:.2}% |",
                 "💥".repeat(failed),
                 "✨".repeat(passed),
                 ratio * 100.0
@@ -156,14 +171,14 @@ where
     if !total_skipped_files.is_empty() {
         report.push_str("\n# Skipped (parse error, TODO: should be ignored or supported)\n\n");
         for path in &total_skipped_files {
-            writeln!(report, "- {}", report_path(path, &format_root)).unwrap();
+            writeln!(report, "- {path}").unwrap();
         }
     }
     if !total_non_idempotent_files.is_empty() {
         report.push_str("\n# Not idempotent\n\n");
         for (path, parse_failed) in &total_non_idempotent_files {
             let note = if *parse_failed { " (second pass failed to parse)" } else { "" };
-            writeln!(report, "- {}{note}", report_path(path, &format_root)).unwrap();
+            writeln!(report, "- {path}{note}").unwrap();
         }
     }
 
@@ -173,6 +188,15 @@ where
 /// Suite-relative path with `/` separators, so reports are identical on Windows.
 fn report_path(path: &Path, format_root: &Path) -> String {
     path.strip_prefix(format_root).unwrap().to_string_lossy().cow_replace('\\', "/").into_owned()
+}
+
+/// Ignore / filter substrings match the SUITE-RELATIVE path (`/`-separated):
+/// matching the absolute path would let the checkout location leak in (a repo
+/// under e.g. `.../cursor-work/` would silently ignore everything via `"cursor"`).
+fn is_selected(report_path: &str, ignore: &[&str], filter: Option<&str>) -> bool {
+    !report_path.contains(UNIVERSAL_IGNORE)
+        && !ignore.iter().any(|s| report_path.contains(s))
+        && filter.is_none_or(|name| report_path.contains(name))
 }
 
 /// Read the first level of directories that contain `__snapshots__` and `format.test.js`
@@ -219,10 +243,6 @@ fn collect_test_dirs(fixture_roots: &[PathBuf]) -> Vec<PathBuf> {
 }
 
 /// Read all test files in the directory with applying ignore + filter.
-///
-/// Ignore/filter substrings match against the SUITE-RELATIVE path (`/`-separated):
-/// matching the absolute path would let the checkout location leak in (a repo
-/// under e.g. `.../cursor-work/` would silently ignore everything via `"cursor"`).
 fn collect_test_files(
     dir: &Path,
     format_root: &Path,
@@ -236,12 +256,7 @@ fn collect_test_files(
         .filter_map(Result::ok)
         .filter(|e| !e.file_type().is_dir())
         .filter(|e| e.path().file_name().is_none_or(|name| name != FORMAT_TEST_SPEC_NAME))
-        .filter(|e| {
-            let path = report_path(e.path(), format_root);
-            !path.contains(UNIVERSAL_IGNORE)
-                && !ignore.iter().any(|s| path.contains(s))
-                && filter.is_none_or(|name| path.contains(name))
-        })
+        .filter(|e| is_selected(&report_path(e.path(), format_root), ignore, filter))
         .map(|e| e.path().to_path_buf())
         .collect();
     test_files.sort_unstable();
@@ -249,15 +264,18 @@ fn collect_test_files(
     test_files
 }
 
+/// Per-dir tallies, keyed by the suite-relative report path (see [`report_path`]).
 #[derive(Default)]
 struct SnapshotResults {
+    /// Files plus snippets that were exercised
+    tested: usize,
     /// `(path, (failed_count, passed_count, diff_ratio))` per file with at least one mismatch
-    failed: Vec<(PathBuf, (usize, usize, f32))>,
+    failed: Vec<(String, (usize, usize, f32))>,
     /// Files the formatter failed to parse for at least one options combination
-    skipped: Vec<PathBuf>,
+    skipped: Vec<String>,
     /// `(path, second_pass_parse_failed)` per file
     /// whose re-formatted output differs from the first pass for at least one options combination
-    non_idempotent: Vec<(PathBuf, bool)>,
+    non_idempotent: Vec<(String, bool)>,
 }
 
 /// Run the formatter and compare the output with the Prettier's snapshot.
@@ -267,7 +285,9 @@ fn test_snapshots<F>(
     config: &ConformanceConfig,
     format: &mut F,
     dir: &Path,
+    format_root: &Path,
     test_files: &[PathBuf],
+    filter: Option<&str>,
     debug: bool,
 ) -> Option<SnapshotResults>
 where
@@ -284,9 +304,6 @@ where
     if let Some(skip_spec) = config.skip_spec {
         spec_calls.retain(|call| !skip_spec(&call.options));
     }
-    if spec_calls.is_empty() {
-        return None;
-    }
 
     let snapshots =
         fs::read_to_string(dir.join(SNAPSHOT_DIR_NAME).join(SNAPSHOT_FILE_NAME)).unwrap();
@@ -299,11 +316,7 @@ where
         // Single source text is used for multiple options
         let source_text = fs::read_to_string(path).unwrap();
 
-        let mut failed_count = 0;
-        let mut skipped_count = 0;
-        let mut non_idempotent_count = 0;
-        let mut second_pass_parse_failed = false;
-        let mut total_diff_ratio = 0.0;
+        let mut tally = CaseTally::default();
         // Check every combination of options!
         for call in &spec_calls {
             // Single snapshot file contains multiple test cases, so need to find the right one
@@ -313,87 +326,191 @@ where
                 &call.snapshot_options,
             )
             .unwrap();
+            tally.record(&run_case(format, path, &source_text, call, &expected, debug));
+        }
+        tally.finish(report_path(path, format_root), &mut results);
+    }
 
-            let Some(actual) = format(path, &source_text, &call.options) else {
-                // Skip the test if parsing failed
-                skipped_count += 1;
-                if debug {
-                    println!("  => Skipped (parsing failed)");
-                }
+    // `snippets` cases live only in the snapshot (see `collect_snippets`) and are matched by
+    // parser name. A dir-level ignore entry covers every snippet in the dir.
+    let dir_report_path = report_path(dir, format_root);
+    if let Some(exact) = config.exact_parser
+        && is_selected(&format!("{dir_report_path}/"), config.ignore, None)
+    {
+        let mut cases = collect_snippets(&snapshots, exact);
+        if let Some(skip_spec) = config.skip_spec {
+            cases.retain(|case| !skip_spec(&case.call.options));
+        }
+        // One row per name, like a file run under several option sets.
+        cases.sort_by(|a, b| a.name.cmp(&b.name));
+        for group in cases.chunk_by(|a, b| a.name == b.name) {
+            // Synthetic `<dir>/snippet: <name>` path: ignore / filter substrings, report rows and
+            // the `format` callback's path argument all see snippets the same way as files.
+            // The row path is built from the dir so a `\` inside the name survives as-is.
+            let leaf = format!("snippet: {}", group[0].name);
+            let row_path = format!("{dir_report_path}/{leaf}");
+            if !is_selected(&row_path, config.ignore, filter) {
                 continue;
-            };
-
-            // Idempotency: re-formatting the raw output must reproduce it.
-            // Checked before snapshot escaping/EOL visualization.
-            // A second pass that fails to parse is the stronger violation
-            // (the output's own parser rejects it) and is annotated separately in the report.
-            let reformatted = format(path, &actual, &call.options);
-            let idempotent = reformatted.as_deref() == Some(actual.as_str());
-            if !idempotent {
-                non_idempotent_count += 1;
-                second_pass_parse_failed |= reformatted.is_none();
             }
-
-            let escaped = replace_escape_and_eol(
-                &actual,
-                expected.contains("LF>") || expected.contains("<CR"),
-            );
-
-            let result = expected == escaped;
-            if !result {
-                failed_count += 1;
-                total_diff_ratio += TextDiff::from_lines(&expected, &escaped).ratio();
-            }
-
+            let path = dir.join(&leaf);
             if debug {
-                println!(
-                    "Options: {{ {} }}",
-                    call.snapshot_options
-                        .iter()
-                        .filter(|(k, _)| k != "parsers")
-                        .map(|(k, v)| format!("{k}: {v}"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-
-                if result {
-                    println!("Passed ✅");
-                } else {
-                    println!("Failed ❌");
-                    print_text_diff(&TextDiff::from_lines(&expected, &escaped));
-                }
-                if !idempotent {
-                    match &reformatted {
-                        Some(reformatted) => {
-                            println!("Not idempotent ⚠️ (second pass differs)");
-                            print_text_diff(&TextDiff::from_lines(&actual, reformatted));
-                        }
-                        None => println!("Not idempotent 💥 (second pass failed to parse)"),
-                    }
-                }
-                println!();
+                println!("Test: {}", path.to_string_lossy());
             }
-        }
 
-        if failed_count != 0 {
-            let total_count = spec_calls.len();
-            let passed_count = total_count - failed_count;
-            #[expect(clippy::cast_precision_loss)]
-            let max_diff_ratio = total_count as f32;
-            results.failed.push((
-                path.clone(),
-                (failed_count, passed_count, total_diff_ratio / max_diff_ratio),
-            ));
-        }
-        if skipped_count != 0 {
-            results.skipped.push(path.clone());
-        }
-        if non_idempotent_count != 0 {
-            results.non_idempotent.push((path.clone(), second_pass_parse_failed));
+            let mut tally = CaseTally::default();
+            for case in group {
+                tally.record(&run_case(
+                    format,
+                    &path,
+                    &case.input,
+                    &case.call,
+                    case.expected,
+                    debug,
+                ));
+            }
+            tally.finish(row_path, &mut results);
         }
     }
 
+    // Nothing here targets this language config (shared dir, every combination skipped, ...).
+    if results.tested == 0 {
+        return None;
+    }
     Some(results)
+}
+
+/// Result of one (input, option set) run.
+#[derive(Default)]
+struct CaseOutcome {
+    /// The formatter could not parse the input.
+    skipped: bool,
+    /// Line similarity to the snapshot, when the output differs from it.
+    mismatch: Option<f32>,
+    /// Whether the second pass failed to parse, when re-formatting did not reproduce the output.
+    non_idempotent: Option<bool>,
+}
+
+/// Formats one input under one option set and compares it with the snapshot's expected output.
+/// Shared by file fixtures and snapshot-only snippets.
+fn run_case<F>(
+    format: &mut F,
+    path: &Path,
+    source_text: &str,
+    call: &SpecCall,
+    expected: &str,
+    debug: bool,
+) -> CaseOutcome
+where
+    F: FnMut(&Path, &str, &OptionSet) -> Option<String>,
+{
+    let mut outcome = CaseOutcome::default();
+
+    let Some(actual) = format(path, source_text, &call.options) else {
+        // Skip the test if parsing failed
+        outcome.skipped = true;
+        if debug {
+            println!("  => Skipped (parsing failed)");
+        }
+        return outcome;
+    };
+
+    // Idempotency: re-formatting the raw output must reproduce it.
+    // Checked before snapshot escaping/EOL visualization.
+    // A second pass that fails to parse is the stronger violation
+    // (the output's own parser rejects it) and is annotated separately in the report.
+    let reformatted = format(path, &actual, &call.options);
+    let idempotent = reformatted.as_deref() == Some(actual.as_str());
+    if !idempotent {
+        outcome.non_idempotent = Some(reformatted.is_none());
+    }
+
+    let escaped =
+        replace_escape_and_eol(&actual, expected.contains("LF>") || expected.contains("<CR"));
+
+    let result = expected == escaped;
+    if !result {
+        outcome.mismatch = Some(TextDiff::from_lines(expected, &escaped).ratio());
+    }
+
+    if debug {
+        println!(
+            "Options: {{ {} }}",
+            call.snapshot_options
+                .iter()
+                .filter(|(k, _)| k != "parsers")
+                .map(|(k, v)| format!("{k}: {v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        if result {
+            println!("Passed ✅");
+        } else {
+            println!("Failed ❌");
+            print_text_diff(&TextDiff::from_lines(expected, &escaped));
+        }
+        if !idempotent {
+            match &reformatted {
+                Some(reformatted) => {
+                    println!("Not idempotent ⚠️ (second pass differs)");
+                    print_text_diff(&TextDiff::from_lines(&actual, reformatted));
+                }
+                None => println!("Not idempotent 💥 (second pass failed to parse)"),
+            }
+        }
+        println!();
+    }
+
+    outcome
+}
+
+/// Aggregates the outcomes of one input across its option sets into a report row.
+#[derive(Default)]
+struct CaseTally {
+    total: usize,
+    failed: usize,
+    skipped: bool,
+    non_idempotent: bool,
+    second_pass_parse_failed: bool,
+    total_diff_ratio: f32,
+}
+
+impl CaseTally {
+    fn record(&mut self, outcome: &CaseOutcome) {
+        self.total += 1;
+        self.skipped |= outcome.skipped;
+        if let Some(ratio) = outcome.mismatch {
+            self.failed += 1;
+            self.total_diff_ratio += ratio;
+        }
+        if let Some(second_pass_parse_failed) = outcome.non_idempotent {
+            self.non_idempotent = true;
+            self.second_pass_parse_failed |= second_pass_parse_failed;
+        }
+    }
+
+    /// Records the row; an input with no option set (no spec call for this language) is not counted.
+    fn finish(self, report_path: String, results: &mut SnapshotResults) {
+        if self.total == 0 {
+            return;
+        }
+        results.tested += 1;
+        if self.failed != 0 {
+            let passed = self.total - self.failed;
+            #[expect(clippy::cast_precision_loss)]
+            let max_diff_ratio = self.total as f32;
+            results.failed.push((
+                report_path.clone(),
+                (self.failed, passed, self.total_diff_ratio / max_diff_ratio),
+            ));
+        }
+        if self.skipped {
+            results.skipped.push(report_path.clone());
+        }
+        if self.non_idempotent {
+            results.non_idempotent.push((report_path, self.second_pass_parse_failed));
+        }
+    }
 }
 
 /// Prints a line diff with `-`/`+`/` ` gutters (debug output for conformance-style tests).
@@ -449,18 +566,14 @@ fn find_output_from_snapshots(
     // matched options and the input marker to be exactly one line (the
     // visualization), retrying past the false match otherwise.
     let options_pattern = format!(
-        "====================================options=====================================
-{}
-",
+        "{OPTIONS_SEPARATOR}{}\n",
         snapshot_options.iter().map(|(k, v)| format!("{k}: {v}")).collect::<Vec<_>>().join("\n"),
     );
-    let input_marker =
-        "\n=====================================input======================================\n";
     let mut search_from = 0;
-    let expected = loop {
+    let section = loop {
         let pos = after_filename[search_from..].find(&options_pattern)?;
         let after_options = search_from + pos + options_pattern.len();
-        let input_pos = after_filename[after_options..].find(input_marker)?;
+        let input_pos = after_filename[after_options..].find(INPUT_SEPARATOR)?;
         let between = &after_filename[after_options..after_options + input_pos];
         if !between.contains('\n') {
             break &after_filename[after_options + input_pos..];
@@ -468,17 +581,8 @@ fn find_output_from_snapshots(
         search_from = after_options;
     };
 
-    let output_start_line =
-        "=====================================output=====================================\n";
-    let output_started = expected.find(output_start_line)?;
-    let output_end_line =
-        "\n================================================================================";
-    let output_ended = expected.find(output_end_line)?;
-
-    let output = expected[output_started..output_ended]
-        .trim_start_matches(output_start_line)
-        .trim_end_matches(output_end_line);
-
+    let (_, output) = section.split_once(OUTPUT_SEPARATOR)?;
+    let (output, _) = output.split_once(END_SEPARATOR)?;
     Some(output.to_string())
 }
 
@@ -517,6 +621,149 @@ fn replace_escape_and_eol(input: &str, need_eol_visualized: bool) -> String {
     }
 
     input
+}
+
+/// One `snippet:` section of a snapshot file.
+///
+/// `runFormatTest({ importMeta, snippets: [...] })` cases have no input file: the spec builds
+/// their inputs at runtime (npm test suites, `outdent`, loops), so the snapshot is the only
+/// record of input, options and expected output. Prettier writes every explicit option into
+/// the section's options block (`parsers` included), which is why the spec is not consulted.
+struct SnippetCase<'a> {
+    /// Snippet title without the options suffix, e.g. `example-1.md (Tabs)` or `#0`.
+    name: String,
+    call: SpecCall,
+    input: String,
+    expected: &'a str,
+}
+
+const SNIPPET_KEY_PREFIX: &str = "exports[`snippet: ";
+
+/// Extracts every `snippet:` section that targets `exact` parser.
+///
+/// A title is snapshotted once under the first parser (`format 1`); parsers whose output
+/// differs get their own `format[<parser>] 1` entry, which wins over the shared entry.
+///
+/// Sections with placeholder-driven options (`cursorOffset`, `rangeStart`, `rangeEnd`)
+/// or values the option set cannot hold (`Infinity`) are dropped.
+fn collect_snippets<'a>(snap_content: &'a str, exact: &str) -> Vec<SnippetCase<'a>> {
+    // `(title, is_variant, case)`
+    let mut targeted = vec![];
+    for section in snap_content.split(SNIPPET_KEY_PREFIX).skip(1) {
+        let Some((key, rest)) = section.split_once("`] = `\n") else { continue };
+        let Some((body, _)) = rest.split_once(END_SEPARATOR) else { continue };
+        // The key is a template literal too, so it carries the same escaping as the body.
+        let Some((title, variant)) = parse_snippet_key(&unescape_snapshot_text(key)) else {
+            continue;
+        };
+        let Some((options_block, rest)) =
+            body.strip_prefix(OPTIONS_SEPARATOR).and_then(|body| body.split_once(INPUT_SEPARATOR))
+        else {
+            continue;
+        };
+        let Some((input, expected)) = rest.split_once(OUTPUT_SEPARATOR) else { continue };
+        let Some((call, parsers)) = parse_snippet_options(options_block) else { continue };
+
+        let is_targeted = match &variant {
+            Some(variant) => variant == exact,
+            None => parsers.iter().any(|p| p == exact),
+        };
+        if !is_targeted {
+            continue;
+        }
+
+        let input = unescape_snapshot_text(input);
+        let input =
+            if call.options.contains_key("endOfLine") { devisualize_eol(&input) } else { input };
+        let case = SnippetCase { name: snippet_name(&title).to_string(), call, input, expected };
+        targeted.push((title, variant.is_some(), case));
+    }
+
+    let variant_titles = targeted
+        .iter()
+        .filter(|(_, is_variant, _)| *is_variant)
+        .map(|(title, ..)| title.clone())
+        .collect::<FxHashSet<_>>();
+    targeted
+        .into_iter()
+        .filter(|(title, is_variant, _)| *is_variant || !variant_titles.contains(title))
+        .map(|(_, _, case)| case)
+        .collect()
+}
+
+/// Splits a snapshot key (after `snippet: `) into the title and the `format[parser]` variant.
+///
+/// Key shape: `<name>[ - <options json>] format[<parser>] <n>`; the title is everything before ` format`.
+fn parse_snippet_key(key: &str) -> Option<(String, Option<String>)> {
+    // Trailing jest counter
+    let key = key.trim_end_matches(|c: char| c.is_ascii_digit()).strip_suffix(' ')?;
+    if let Some(title) = key.strip_suffix(" format") {
+        return Some((title.to_string(), None));
+    }
+    let title_end = key.rfind(" format[")?;
+    let variant = key[title_end + " format[".len()..].strip_suffix(']')?;
+    Some((key[..title_end].to_string(), Some(variant.to_string())))
+}
+
+/// The snippet name is the title minus the ` - {...}` options suffix.
+/// A name may itself contain ` - ` (yaml test suite), so anchor on the last ` - {`
+/// and require the JSON to close the title.
+fn snippet_name(title: &str) -> &str {
+    match title.rfind(" - {") {
+        Some(pos) if title.ends_with('}') => &title[..pos],
+        _ => title,
+    }
+}
+
+/// Parses the options block into a spec call plus the `parsers` list.
+///
+/// The block is `key: <json>` lines; the `printWidth` indicator line is indented and skipped.
+/// Returns `None` for placeholder-driven sections or values the option set cannot represent.
+fn parse_snippet_options(block: &str) -> Option<(SpecCall, Vec<String>)> {
+    let mut call = SpecCall { options: OptionSet::new(), snapshot_options: vec![] };
+    let mut parsers = vec![];
+    for line in block.lines() {
+        if line.starts_with(' ') || line.is_empty() {
+            continue;
+        }
+        let (key, raw) = line.split_once(": ")?;
+        if matches!(key, "cursorOffset" | "rangeStart" | "rangeEnd") {
+            return None;
+        }
+        call.snapshot_options.push((key.to_string(), raw.to_string()));
+        if key == "parsers" {
+            parsers = serde_json::from_str(raw).ok()?;
+        } else {
+            call.options.insert(key.to_string(), serde_json::from_str(raw).ok()?);
+        }
+    }
+    Some((call, parsers))
+}
+
+/// Inverse of the template-literal escaping jest applies to snapshot bodies
+/// (`` ` ``, `\` and `${` get a leading `\`).
+/// Every original backslash is doubled, so "a backslash escapes the next char" is exact.
+fn unescape_snapshot_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                result.push(next);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Inverse of Prettier's `visualizeEndOfLine` (applied to inputs when `endOfLine` is set).
+fn devisualize_eol(text: &str) -> String {
+    text.cow_replace("<CRLF>\n", "\r\n")
+        .cow_replace("<CR>\n", "\r")
+        .cow_replace("<LF>\n", "\n")
+        .into_owned()
 }
 
 /// One `runFormatTest(import.meta, parsers, opts)` call from a spec file.
@@ -693,5 +940,123 @@ impl VisitMut<'_> for SpecParser<'_> {
         snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));
 
         self.calls.push(SpecCall { options, snapshot_options });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snippet_key_shapes() {
+        assert_eq!(
+            parse_snippet_key(r#"example-1.md (Tabs) - {"proseWrap":"always"} format 1"#),
+            Some((r#"example-1.md (Tabs) - {"proseWrap":"always"}"#.into(), None))
+        );
+        // No options suffix, jest counter above 9
+        assert_eq!(parse_snippet_key("#0 format 12"), Some(("#0".into(), None)));
+        assert_eq!(
+            parse_snippet_key("x.js format[typescript] 1"),
+            Some(("x.js".into(), Some("typescript".into())))
+        );
+        assert_eq!(parse_snippet_key("x.js format"), None);
+
+        assert_eq!(
+            snippet_name(r#"example-1.md (Tabs) - {"proseWrap":"always"}"#),
+            "example-1.md (Tabs)"
+        );
+        // Name containing ` - ` (yaml test suite) keeps everything before the JSON
+        assert_eq!(
+            snippet_name(r#"DE56-3.yaml - Spec Example 7.4 - {"tabWidth":4}"#),
+            "DE56-3.yaml - Spec Example 7.4"
+        );
+        assert_eq!(snippet_name("a - b"), "a - b");
+    }
+
+    #[test]
+    fn snippet_options_block() {
+        let block = "parsers: [\"markdown\"]
+proseWrap: \"always\"
+tabWidth: 4
+                                                      printWidth: 80 (default) |";
+        let (call, parsers) = parse_snippet_options(block).unwrap();
+        assert_eq!(parsers, ["markdown"]);
+        assert_eq!(call.options.get("proseWrap"), Some(&serde_json::Value::from("always")));
+        assert_eq!(call.options.get("tabWidth"), Some(&serde_json::Value::from(4)));
+        assert!(!call.options.contains_key("parsers"));
+        assert_eq!(call.snapshot_options[0], ("parsers".into(), "[\"markdown\"]".into()));
+        assert_eq!(call.snapshot_options.len(), 3);
+
+        let placeholder = block.cow_replace("tabWidth: 4", "cursorOffset: 2");
+        assert!(parse_snippet_options(&placeholder).is_none());
+        let infinity = block.cow_replace("tabWidth: 4", "printWidth: Infinity");
+        assert!(parse_snippet_options(&infinity).is_none());
+    }
+
+    #[test]
+    fn snapshot_text_round_trip() {
+        let original = "a\\b `code` ${x} \\` \\${ end\\";
+        let escaped = replace_escape_and_eol(original, false);
+        assert_eq!(unescape_snapshot_text(&escaped), original);
+        assert_eq!(devisualize_eol("a<CRLF>\nb<CR>\nc<LF>\n"), "a\r\nb\rc\n");
+    }
+
+    #[test]
+    fn snippet_sections() {
+        let snap = "// Jest Snapshot v1
+
+exports[`snippet: #0 - {\"proseWrap\":\"always\"} format 1`] = `
+====================================options=====================================
+parsers: [\"markdown\"]
+proseWrap: \"always\"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+\\`in\\` \\\\
+
+=====================================output=====================================
+\\`out\\`
+
+================================================================================
+`;
+
+exports[`snippet: #1 format 1`] = `
+====================================options=====================================
+parsers: [\"babel\", \"typescript\"]
+=====================================input======================================
+a
+=====================================output=====================================
+a;
+
+================================================================================
+`;
+
+exports[`snippet: #1 format[typescript] 1`] = `
+====================================options=====================================
+parsers: [\"babel\", \"typescript\"]
+=====================================input======================================
+a
+=====================================output=====================================
+a; // ts
+
+================================================================================
+`;
+";
+        let markdown = collect_snippets(snap, "markdown");
+        assert_eq!(markdown.len(), 1);
+        assert_eq!(markdown[0].name, "#0");
+        assert_eq!(markdown[0].input, "`in` \\\n");
+        assert_eq!(markdown[0].expected, "\\`out\\`\n");
+        assert_eq!(
+            markdown[0].call.options.get("proseWrap"),
+            Some(&serde_json::Value::from("always"))
+        );
+
+        // Shared entry for babel, the `format[typescript]` variant for typescript
+        let babel = collect_snippets(snap, "babel");
+        assert_eq!(babel.len(), 1);
+        assert_eq!(babel[0].expected, "a;\n");
+        let ts = collect_snippets(snap, "typescript");
+        assert_eq!(ts.len(), 1);
+        assert_eq!(ts[0].expected, "a; // ts\n");
     }
 }

--- a/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier-yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier-yaml.snap
@@ -2,14 +2,82 @@
 source: crates/oxc_formatter_yaml/tests/conformance.rs
 expression: report
 ---
-yaml compatibility: 345/354 (97.46%), 0 files skipped
+yaml compatibility: 922/1014 (90.93%), 19 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | yaml/block-folded/block-folded-strip.yml | 💥💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >+\n" | 💥💥💥 | 0.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n   \n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >-\n  x\n  \t\n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n   \n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: >\n  x\n  \t\n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |+\n" | 💥💥💥 | 0.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n   \n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |-\n  x\n  \t\n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n   \n\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n\n\n" | 💥 | 80.00% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n\n\n..." | 💥 | 85.71% |
+| yaml/block-value/snippet: "foo: |\n  x\n  \t\n\n\n\n\n..." | 💥 | 85.71% |
 | yaml/flow-mapping/comments/key.yml | 💥 | 43.75% |
+| yaml/json-test-suite/snippet: i_string_UTF-16LE_with_BOM.json | 💥 | 0.00% |
+| yaml/json-test-suite/snippet: i_string_utf16BE_no_BOM.json | 💥 | 0.00% |
 | yaml/mapping/duplicated-keys/flow-mapping.yml | 💥 | 85.71% |
 | yaml/spec/anchors-and-tags.yml | 💥💥 | 75.00% |
 | yaml/spec/node-anchor-and-tag-on-seperate-lines.yml | 💥💥 | 50.00% |
@@ -17,3 +85,40 @@ yaml compatibility: 345/354 (97.46%), 0 files skipped
 | yaml/spec/spec-example-7-20-single-pair-explicit-entry.yml | 💥✨ | 12.50% |
 | yaml/spec/spec-example-9-4-explicit-documents.yml | 💥✨ | 33.33% |
 | yaml/spec/various-combinations-of-tags-and-anchors.yml | 💥💥 | 75.00% |
+| yaml/yaml-test-suite/snippet: 2G84-4.yaml - Literal modifers | 💥 | 50.00% |
+| yaml/yaml-test-suite/snippet: 6HB6.yaml - Spec Example 6.1. Indentation Spaces | 💥 | 84.62% |
+| yaml/yaml-test-suite/snippet: 9KAX.yaml - Various combinations of tags and anchors | 💥 | 75.00% |
+| yaml/yaml-test-suite/snippet: 9SA2.yaml - Multiline double quoted flow mapping key | 💥 | 50.00% |
+| yaml/yaml-test-suite/snippet: BU8L.yaml - Node Anchor and Tag on Seperate Lines | 💥 | 50.00% |
+| yaml/yaml-test-suite/snippet: CT4Q.yaml - Spec Example 7.20. Single Pair Explicit Entry | 💥 | 25.00% |
+| yaml/yaml-test-suite/snippet: F2C7.yaml - Anchors and Tags | 💥 | 75.00% |
+| yaml/yaml-test-suite/snippet: HWV9.yaml - Document-end marker | 💥 | 66.67% |
+| yaml/yaml-test-suite/snippet: JEF9-3.yaml - Trailing whitespace in streams | 💥 | 66.67% |
+| yaml/yaml-test-suite/snippet: K3WX.yaml - Colon and adjacent value after comment on next line | 💥 | 25.00% |
+| yaml/yaml-test-suite/snippet: L24T-2.yaml - Trailing line of spaces | 💥 | 80.00% |
+| yaml/yaml-test-suite/snippet: L24T.yaml - Trailing line of spaces | 💥 | 80.00% |
+| yaml/yaml-test-suite/snippet: NJ66.yaml - Multiline plain flow mapping key | 💥 | 50.00% |
+| yaml/yaml-test-suite/snippet: UT92.yaml - Spec Example 9.4. Explicit Documents | 💥 | 66.67% |
+| yaml/yaml-test-suite/snippet: Y79Y-2.yaml - Tabs in various contexts | 💥 | 66.67% |
+
+# Skipped (parse error, TODO: should be ignored or supported)
+
+- yaml/json-test-suite/snippet: i_object_key_lone_2nd_surrogate.json
+- yaml/json-test-suite/snippet: i_string_1st_surrogate_but_2nd_missing.json
+- yaml/json-test-suite/snippet: i_string_1st_valid_surrogate_2nd_invalid.json
+- yaml/json-test-suite/snippet: i_string_incomplete_surrogate_and_escape_valid.json
+- yaml/json-test-suite/snippet: i_string_incomplete_surrogate_pair.json
+- yaml/json-test-suite/snippet: i_string_incomplete_surrogates_escape_valid.json
+- yaml/json-test-suite/snippet: i_string_invalid_lonely_surrogate.json
+- yaml/json-test-suite/snippet: i_string_invalid_surrogate.json
+- yaml/json-test-suite/snippet: i_string_inverted_surrogates_U+1D11E.json
+- yaml/json-test-suite/snippet: i_string_lone_second_surrogate.json
+- yaml/json-test-suite/snippet: string_1_escaped_invalid_codepoint.json
+- yaml/json-test-suite/snippet: string_2_escaped_invalid_codepoints.json
+- yaml/json-test-suite/snippet: string_3_escaped_invalid_codepoints.json
+- yaml/json-test-suite/snippet: y_string_accepted_surrogate_pair.json
+- yaml/json-test-suite/snippet: y_string_accepted_surrogate_pairs.json
+- yaml/json-test-suite/snippet: y_string_last_surrogates_1_and_2.json
+- yaml/json-test-suite/snippet: y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json
+- yaml/json-test-suite/snippet: y_string_unicode_U+10FFFE_nonchar.json
+- yaml/json-test-suite/snippet: y_string_unicode_U+1FFFE_nonchar.json


### PR DESCRIPTION
Enable Prettier's dynamic snippet tests with `xxx-test-suite` module.

They do not have physical file, so need to slice during conformance run.