### PR TITLE
fix(formatter_yaml): bump oxc-yaml-parser to 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -697,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1528,7 +1528,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1736,9 +1736,9 @@ checksum = "71bca8630e33e93a38d8dceb0daba6f562f29215b47098a7f05e8d295227ed94"
 
 [[package]]
 name = "oxc-yaml-parser"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7217ca01ae9b98ab99c6f7cc59640c85bbc90e341df5743e08a3ecd7d611b2"
+checksum = "097919ec3fb73bb7ec22ceea30171c0af1f14fa67d03bd410a15dc3b6b8eff1b"
 dependencies = [
  "oxc_allocator",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3480,7 +3480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3776,7 +3776,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4309,7 +4309,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ num-traits = "0.2.19" # Numeric traits
 oxc-css-parser = "0.0.14" # CSS/SCSS/Less parser (raffia 0.12.3 fork: adds `template_placeholder` typed placeholders for css-in-js + valid-syntax coverage fixes (see crates/oxc_formatter_css/AGENTS.md))
 oxc-graphql-parser = "0.0.9" # GraphQL parser (direct AST; apollo-parser 0.8.6 fork aligned with graphql-js 17 syntax)
 oxc-toml = "0.14.5" # TOML formatter
-oxc-yaml-parser = "0.0.5" # YAML 1.2 parser (comment-preserving typed AST, node naming from `yaml-unist-parser`)
+oxc-yaml-parser = "0.0.6" # YAML 1.2 parser (comment-preserving typed AST, node naming from `yaml-unist-parser`)
 papaya = "0.2.4" # Concurrent hash map
 percent-encoding = "2.3.2" # URL encoding
 petgraph = { version = "0.8.3", default-features = false } # Graph data structures

--- a/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier-yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier-yaml.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter_yaml/tests/conformance.rs
 expression: report
 ---
-yaml compatibility: 922/1012 (91.11%), 19 files skipped
+yaml compatibility: 922/1012 (91.11%), 0 files skipped
 
 # Failed
 
@@ -98,25 +98,3 @@ yaml compatibility: 922/1012 (91.11%), 19 files skipped
 | yaml/yaml-test-suite/snippet: NJ66.yaml - Multiline plain flow mapping key | 💥 | 50.00% |
 | yaml/yaml-test-suite/snippet: UT92.yaml - Spec Example 9.4. Explicit Documents | 💥 | 66.67% |
 | yaml/yaml-test-suite/snippet: Y79Y-2.yaml - Tabs in various contexts | 💥 | 66.67% |
-
-# Skipped (parse error, TODO: should be ignored or supported)
-
-- yaml/json-test-suite/snippet: i_object_key_lone_2nd_surrogate.json
-- yaml/json-test-suite/snippet: i_string_1st_surrogate_but_2nd_missing.json
-- yaml/json-test-suite/snippet: i_string_1st_valid_surrogate_2nd_invalid.json
-- yaml/json-test-suite/snippet: i_string_incomplete_surrogate_and_escape_valid.json
-- yaml/json-test-suite/snippet: i_string_incomplete_surrogate_pair.json
-- yaml/json-test-suite/snippet: i_string_incomplete_surrogates_escape_valid.json
-- yaml/json-test-suite/snippet: i_string_invalid_lonely_surrogate.json
-- yaml/json-test-suite/snippet: i_string_invalid_surrogate.json
-- yaml/json-test-suite/snippet: i_string_inverted_surrogates_U+1D11E.json
-- yaml/json-test-suite/snippet: i_string_lone_second_surrogate.json
-- yaml/json-test-suite/snippet: string_1_escaped_invalid_codepoint.json
-- yaml/json-test-suite/snippet: string_2_escaped_invalid_codepoints.json
-- yaml/json-test-suite/snippet: string_3_escaped_invalid_codepoints.json
-- yaml/json-test-suite/snippet: y_string_accepted_surrogate_pair.json
-- yaml/json-test-suite/snippet: y_string_accepted_surrogate_pairs.json
-- yaml/json-test-suite/snippet: y_string_last_surrogates_1_and_2.json
-- yaml/json-test-suite/snippet: y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json
-- yaml/json-test-suite/snippet: y_string_unicode_U+10FFFE_nonchar.json
-- yaml/json-test-suite/snippet: y_string_unicode_U+1FFFE_nonchar.json


### PR DESCRIPTION
> https://github.com/oxc-project/oxc-yaml-parser/releases/tag/oxc-yaml-parser-v0.0.6

Fixed scanner bugs to parse more files.