### PR TITLE
fix(formatter): check `this_param` for simple parameters test

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -325,7 +325,7 @@ impl<'a, 'b> ArrowFunctionLayout<'a, 'b> {
         // This matches Prettier, which allows type annotations when
         // grouping arrow expressions, but disallows them when grouping
         // normal function expressions.
-        if !has_only_simple_parameters(parameters, true) {
+        if !has_only_simple_parameters(parameters, None, true) {
             return true;
         }
 

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -630,7 +630,7 @@ fn write_grouped_arguments<'a>(
                         AstNodes::Function(function)
                             if !group_layout.is_grouped_first()
                                 && (!only_one_argument
-                                    || function_has_only_simple_parameters(&function.params)) =>
+                                    || function_has_only_simple_parameters(function)) =>
                         {
                             has_cached = true;
                             return write!(f, [FormatFunction::new_cached(function), comma]);
@@ -874,7 +874,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatGroupedLastArgument<'a, '_> {
         // to remove any soft line breaks.
         match self.argument.as_ast_nodes() {
             AstNodes::Function(function)
-                if !self.is_only || function_has_only_simple_parameters(&function.params) =>
+                if !self.is_only || function_has_only_simple_parameters(function) =>
             {
                 FormatFunction::new_cached(function).fmt(f);
             }
@@ -894,8 +894,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatGroupedLastArgument<'a, '_> {
     }
 }
 
-fn function_has_only_simple_parameters(params: &FormalParameters<'_>) -> bool {
-    has_only_simple_parameters(params, false)
+fn function_has_only_simple_parameters(function: &Function<'_>) -> bool {
+    has_only_simple_parameters(&function.params, function.this_param.as_deref(), false)
 }
 
 /// Tests if this a simple module import like `import("module-name")` or `require("module-name")`.

--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -420,16 +420,19 @@ pub fn should_hug_function_parameters<'a>(
     shape_allows_hug && !has_comment_around(only_parameter.span)
 }
 
-/// Tests if all of the parameters of `expression` are simple enough to allow
-/// a function to group.
+/// Tests if all of the parameters of `expression` and also `this_param` are
+/// simple enough to allow a function to group.
 pub fn has_only_simple_parameters(
     parameters: &FormalParameters<'_>,
+    this_param: Option<&TSThisParameter<'_>>,
     allow_type_annotations: bool,
 ) -> bool {
     // NOTE: A rest parameter is never considered simple.
     // Prettier only checks `param.type` is `Identifier` or not.
     // https://github.com/prettier/prettier/blob/7848357af654883e21ed05c0bbbedf89ee88750e/src/language-js/print/function.js#L72-L74
     parameters.rest.is_none()
+        // `allow_type_annotations` is an arrow-only rule, and arrows never have `this`.
+        && this_param.is_none_or(|this_param| this_param.type_annotation.is_none())
         && parameters
             .items
             .iter()

--- a/crates/oxc_formatter/src/utils/call_expression.rs
+++ b/crates/oxc_formatter/src/utils/call_expression.rs
@@ -71,9 +71,10 @@ pub fn is_test_call_expression(call: &AstNode<CallExpression<'_>>) -> bool {
             }
 
             let (parameter_count, has_block_body) = match second {
-                Argument::FunctionExpression(function) => {
-                    (function.params.parameters_count(), true)
-                }
+                Argument::FunctionExpression(function) => (
+                    function.params.parameters_count() + usize::from(function.this_param.is_some()),
+                    true,
+                ),
                 Argument::ArrowFunctionExpression(arrow) => {
                     (arrow.params.parameters_count(), !arrow.is_expression())
                 }

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-26465.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-26465.ts
@@ -1,0 +1,11 @@
+// A typed `this` parameter is not "simple", so the only function argument does not expand its params
+const mockFn = vi.fn().mockImplementation(function (
+  this: MockWithPrettyLongName,
+) {
+  return this;
+});
+
+// Untyped `this` stays simple
+const mockFn2 = vi.fn().mockImplementation(function (this, aaaaaaaaaaaaaaaaaaaaa) {
+  return this;
+});

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-26465.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/issue-26465.ts.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A typed `this` parameter is not "simple", so the only function argument does not expand its params
+const mockFn = vi.fn().mockImplementation(function (
+  this: MockWithPrettyLongName,
+) {
+  return this;
+});
+
+// Untyped `this` stays simple
+const mockFn2 = vi.fn().mockImplementation(function (this, aaaaaaaaaaaaaaaaaaaaa) {
+  return this;
+});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A typed `this` parameter is not "simple", so the only function argument does not expand its params
+const mockFn = vi.fn().mockImplementation(function (
+  this: MockWithPrettyLongName,
+) {
+  return this;
+});
+
+// Untyped `this` stays simple
+const mockFn2 = vi
+  .fn()
+  .mockImplementation(function (this, aaaaaaaaaaaaaaaaaaaaa) {
+    return this;
+  });
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A typed `this` parameter is not "simple", so the only function argument does not expand its params
+const mockFn = vi.fn().mockImplementation(function (this: MockWithPrettyLongName) {
+  return this;
+});
+
+// Untyped `this` stays simple
+const mockFn2 = vi.fn().mockImplementation(function (this, aaaaaaaaaaaaaaaaaaaaa) {
+  return this;
+});
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/test-call-this-param.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/test-call-this-param.ts
@@ -1,0 +1,9 @@
+// A typed `this` counts as a parameter, so `it(name, fn, timeout)` with `this` + `done` is not a test call
+it("does something long enough to reach the width", function (this: Mocha.Context, done) {
+  done();
+}, 2000);
+
+// A lone `this` keeps the test-call layout
+it("does something long enough to reach the width", function (this: Mocha.Context) {
+  return this.skip();
+}, 2000);

--- a/crates/oxc_formatter/tests/fixtures/ts/arguments/test-call-this-param.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arguments/test-call-this-param.ts.snap
@@ -1,0 +1,50 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A typed `this` counts as a parameter, so `it(name, fn, timeout)` with `this` + `done` is not a test call
+it("does something long enough to reach the width", function (this: Mocha.Context, done) {
+  done();
+}, 2000);
+
+// A lone `this` keeps the test-call layout
+it("does something long enough to reach the width", function (this: Mocha.Context) {
+  return this.skip();
+}, 2000);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A typed `this` counts as a parameter, so `it(name, fn, timeout)` with `this` + `done` is not a test call
+it(
+  "does something long enough to reach the width",
+  function (this: Mocha.Context, done) {
+    done();
+  },
+  2000,
+);
+
+// A lone `this` keeps the test-call layout
+it("does something long enough to reach the width", function (this: Mocha.Context) {
+  return this.skip();
+}, 2000);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A typed `this` counts as a parameter, so `it(name, fn, timeout)` with `this` + `done` is not a test call
+it(
+  "does something long enough to reach the width",
+  function (this: Mocha.Context, done) {
+    done();
+  },
+  2000,
+);
+
+// A lone `this` keeps the test-call layout
+it("does something long enough to reach the width", function (this: Mocha.Context) {
+  return this.skip();
+}, 2000);
+
+===================== End =====================


### PR DESCRIPTION
Fixes #26465, also fixes test-call does not count `this` params as well.
