### PR TITLE
fix(formatter): keep group flat for own-line comment in JSX

### DIFF
--- a/crates/oxc_formatter/src/print/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/print/binary_like_expression.rs
@@ -269,11 +269,25 @@ impl<'a> Format<'a, JsFormatContext<'a>> for BinaryLikeExpression<'a, '_> {
 
         let group_id = f.group_id("logicalChain");
 
-        // A leading line comment on the final JSX operand forces a newline in Prettier,
-        // which breaks the surrounding chain. Mirror that by expanding the chain group;
-        // block comments don't force a newline and stay length-driven.
+        // `( // comment` attaches to the preceding condition and breaks its group:
+        // ```jsx
+        //   {a &&
+        //     b && ( // why this breaks?
+        //       <div />
+        //     )}
+        // ```
+        // Own-line comments only break the JSX group:
+        // ```jsx
+        //   {a && b && (
+        //     // this does not break
+        //     <div />
+        //   )}
+        // ```
+        // This is a Prettier's comment-attachment artifact, keep it for compatibility now.
         let should_expand_chain = jsx_element.is_some_and(|jsx| {
-            f.comments().comments_before_iter(jsx.span().start).any(|comment| comment.is_line())
+            f.comments()
+                .comments_before_iter(jsx.span().start)
+                .any(|comment| comment.is_line() && !comment.preceded_by_newline())
         });
 
         let format_non_jsx_parts = format_with(|f| {

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/logical-chain-jsx-leading-comment.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/logical-chain-jsx-leading-comment.jsx
@@ -44,3 +44,26 @@ const D = () => (
       )}
   </div>
 );
+
+// 5. An own-line `//` comment only breaks the JSX operand, not the chain (#26466).
+function App() {
+  return (
+    <>
+      {!isEditing && isTruncated && (
+        // This comment breaks the formatting
+        <div />
+      )}
+    </>
+  );
+}
+
+// 6. Own-line comments before a JSX fragment also keep the conditions together.
+const E = () => (
+  <div>
+    {a || b || (
+      // First comment
+      // Second comment
+      <><span>x</span></>
+    )}
+  </div>
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/logical-chain-jsx-leading-comment.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/logical-chain-jsx-leading-comment.jsx.snap
@@ -49,6 +49,29 @@ const D = () => (
   </div>
 );
 
+// 5. An own-line `//` comment only breaks the JSX operand, not the chain (#26466).
+function App() {
+  return (
+    <>
+      {!isEditing && isTruncated && (
+        // This comment breaks the formatting
+        <div />
+      )}
+    </>
+  );
+}
+
+// 6. Own-line comments before a JSX fragment also keep the conditions together.
+const E = () => (
+  <div>
+    {a || b || (
+      // First comment
+      // Second comment
+      <><span>x</span></>
+    )}
+  </div>
+);
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -100,6 +123,31 @@ const D = () => (
   </div>
 );
 
+// 5. An own-line `//` comment only breaks the JSX operand, not the chain (#26466).
+function App() {
+  return (
+    <>
+      {!isEditing && isTruncated && (
+        // This comment breaks the formatting
+        <div />
+      )}
+    </>
+  );
+}
+
+// 6. Own-line comments before a JSX fragment also keep the conditions together.
+const E = () => (
+  <div>
+    {a || b || (
+      // First comment
+      // Second comment
+      <>
+        <span>x</span>
+      </>
+    )}
+  </div>
+);
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -146,6 +194,31 @@ const D = () => (
   <div>
     {a && ( // tiny
       <span>x</span>
+    )}
+  </div>
+);
+
+// 5. An own-line `//` comment only breaks the JSX operand, not the chain (#26466).
+function App() {
+  return (
+    <>
+      {!isEditing && isTruncated && (
+        // This comment breaks the formatting
+        <div />
+      )}
+    </>
+  );
+}
+
+// 6. Own-line comments before a JSX fragment also keep the conditions together.
+const E = () => (
+  <div>
+    {a || b || (
+      // First comment
+      // Second comment
+      <>
+        <span>x</span>
+      </>
     )}
   </div>
 );


### PR DESCRIPTION
Fixes #26466 