### PR TITLE
refactor(lexer): rename `bm_set1` to `bm_set`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/bitmap.rs
+++ b/crates/oxc_lexer/src/pipeline/bitmap.rs
@@ -112,7 +112,7 @@ pub(super) unsafe fn bm_prev1(bm: *const u64, p: usize) -> i64 {
 /// - `bm` must be aligned for `u64`.
 /// - `bm` must be valid for reads and writes of `(i / 64) + 1` words.
 #[inline(always)]
-pub(super) unsafe fn bm_set1(bm: *mut u64, i: usize) {
+pub(super) unsafe fn bm_set(bm: *mut u64, i: usize) {
     *bm.add(i >> 6) |= 1u64 << (i & 63);
 }
 

--- a/crates/oxc_lexer/src/pipeline/carve/common.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/common.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::super::{
     BCOM, LCOM, REGEX, STR,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set},
     find::{scan_block_comment, scan_line_comment, scan_quoted, scan_regex, scan_tmpl_text},
     regex_div::prev_is_regex,
 };
@@ -131,7 +131,7 @@ pub(super) unsafe fn lex_line_comment(
         bm_clear_range(st, s + 1, end - 1);
     }
     if end < n {
-        bm_set1(st, end);
+        bm_set(st, end);
     }
     let lic = lic_q >= 0 && (lic_q as usize) + 8 < end;
     let m = comment_meta::meta_byte_flags(&srcs[..n], s as u32, end as u32, false, false, lic);

--- a/crates/oxc_lexer/src/pipeline/carve/js.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/js.rs
@@ -2,7 +2,7 @@ use crate::{comment_meta, error::diag_code, lanes::Lanes, tables::Tables};
 
 use super::super::{
     HASHBANG, LCOM, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL,
-    bitmap::{bm_clear_range, bm_set1},
+    bitmap::{bm_clear_range, bm_set},
     find::{find_line_terminator, find_opener, find_opener6},
 };
 
@@ -28,7 +28,7 @@ pub(super) unsafe fn carve_js(
         *kind = HASHBANG;
         bm_clear_range(st, 1, end - 1);
         if end < n {
-            bm_set1(st, end);
+            bm_set(st, end);
         }
         i = end;
     }
@@ -102,7 +102,7 @@ pub(super) unsafe fn carve_js(
                         bm_clear_range(st, s + 1, end - 1);
                     }
                     if end < n {
-                        bm_set1(st, end);
+                        bm_set(st, end);
                     }
                     // `<`, `!`, `-` are opchars: clear the span from `opch`
                     // or `coalesce` would re-tokenize `<!--` as operators.
@@ -133,12 +133,12 @@ pub(super) unsafe fn carve_js(
                     let start = s - 2;
                     let end = find_line_terminator(src, n, s + 1);
                     *kind.add(start) = LCOM;
-                    bm_set1(st, start);
+                    bm_set(st, start);
                     if end > start + 1 {
                         bm_clear_range(st, start + 1, end - 1);
                     }
                     if end < n {
-                        bm_set1(st, end);
+                        bm_set(st, end);
                     }
                     // Clear the span from `opch` (see `<!--` above).
                     bm_clear_range(opch, start, end - 1);

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::super::{
     HASHBANG, JEND, JSX_LT, JTEXT, STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL,
-    bitmap::{bm_clear_range, bm_set1},
+    bitmap::{bm_clear_range, bm_set},
     find::{
         find_jsx_tag, find_jsx_text, find_line_terminator, find_opener, find_opener_jsx5,
         find_opener_jsx7, find_opener6, find1, find2, scan_block_comment,
@@ -94,7 +94,7 @@ pub(super) unsafe fn carve_jsx(
         *kind = HASHBANG;
         bm_clear_range(st, 1, end - 1);
         if end < n {
-            bm_set1(st, end);
+            bm_set(st, end);
         }
         i = end;
     }
@@ -505,7 +505,7 @@ pub(super) unsafe fn carve_jsx(
                 if runend > text_start {
                     // One JTEXT token for the run; neutralize its start byte
                     // against coalesce/keywords and clear the interior.
-                    bm_set1(st, text_start);
+                    bm_set(st, text_start);
                     *kind.add(text_start) = JTEXT;
                     let w = text_start >> 6;
                     let bit = 1u64 << (text_start & 63);

--- a/crates/oxc_lexer/src/pipeline/classify/common.rs
+++ b/crates/oxc_lexer/src/pipeline/classify/common.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::super::{
     IDENT, IDENT_ESC, PRIV_IDENT, PRIV_IDENT_ESC, WS,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_prev1, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_prev1, bm_set},
     find::scan_ident_esc,
 };
 
@@ -68,10 +68,10 @@ pub unsafe fn misc_pre<const VUTF8: bool>(
                 if len != 0 {
                     *kind.add(p) = WS;
                     bm_clear_range(word, p, p + len - 1);
-                    bm_set1(st, p);
+                    bm_set(st, p);
                     bm_clear_range(st, p + 1, p + len - 1);
                     if p + len < n {
-                        bm_set1(st, p + len);
+                        bm_set(st, p + len);
                     }
                 } else if (0xC2..=0xF4).contains(&c) {
                     // Non-whitespace lead: record the position only. The

--- a/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     NUM,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set1},
+    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set},
     find::scan_number,
     regex_div::{gt_run_split, lt_run_split},
 };
@@ -229,7 +229,7 @@ unsafe fn glue_number(
         if e2 >= n {
             return n;
         }
-        bm_set1(st, e2);
+        bm_set(st, e2);
         let c = *src.add(e2);
         // A word char abutting the number end (`1.5n`, `3in`, `0b12`, `1π`)
         // is a spec-invalid adjacency. Never true on valid input, so the
@@ -304,7 +304,7 @@ unsafe fn munch_walk(
 ) -> usize {
     let end = bm_next0(opch, pos, n);
     while end - pos >= 2 {
-        bm_set1(st, pos);
+        bm_set(st, pos);
         let rem = end - pos;
         let lmax: u32 = if rem < 4 { rem as u32 } else { 4 };
         let b0 = *src.add(pos);
@@ -336,7 +336,7 @@ unsafe fn munch_walk(
         }
     }
     if end - pos == 1 {
-        bm_set1(st, pos);
+        bm_set(st, pos);
     }
     pos
 }


### PR DESCRIPTION
Pure refactor. Just rename a function.

The `1` in `bm_set1` was unnecessary - "set" means set bit to 1, "clear" means unset bit to 0.