### PR TITLE
refactor(lexer): add `bm_clear` function to clear a bitmap bit

### DIFF
--- a/crates/oxc_lexer/src/pipeline/bitmap.rs
+++ b/crates/oxc_lexer/src/pipeline/bitmap.rs
@@ -116,6 +116,17 @@ pub(super) unsafe fn bm_set(bm: *mut u64, i: usize) {
     *bm.add(i >> 6) |= 1u64 << (i & 63);
 }
 
+/// Clear bit `i`.
+///
+/// # SAFETY
+///
+/// - `bm` must be aligned for `u64`.
+/// - `bm` must be valid for reads and writes of `(i / 64) + 1` words.
+#[inline(always)]
+pub(super) unsafe fn bm_clear(bm: *mut u64, i: usize) {
+    *bm.add(i >> 6) &= !(1u64 << (i & 63));
+}
+
 /// Clear bits `a` to `b` inclusive.
 ///
 /// If `a > b`, this is a no-op - no bits are cleared.

--- a/crates/oxc_lexer/src/pipeline/carve/common.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/common.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::super::{
     BCOM, LCOM, REGEX, STR,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set},
+    bitmap::{bm_clear, bm_clear_range, bm_get, bm_next0, bm_set},
     find::{scan_block_comment, scan_line_comment, scan_quoted, scan_regex, scan_tmpl_text},
     regex_div::prev_is_regex,
 };
@@ -106,8 +106,8 @@ pub(super) unsafe fn lex_slash(
     } else if s + 1 < n && *src.add(s + 1) == b'=' {
         // `/=`: absorb the `=`.
         *kind.add(s) = OP_SLASH_EQ;
-        *st.add((s + 1) >> 6) &= !(1u64 << ((s + 1) & 63));
-        *opch.add((s + 1) >> 6) &= !(1u64 << ((s + 1) & 63));
+        bm_clear(st, s + 1);
+        bm_clear(opch, s + 1);
         s + 2
     } else {
         s + 1

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/hyphens.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/hyphens.rs
@@ -1,4 +1,4 @@
-use super::super::super::bitmap::bm_get;
+use super::super::super::bitmap::{bm_clear, bm_get};
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use super::super::super::find::{load256, mm, veq};
@@ -72,10 +72,10 @@ unsafe fn glue_hyphen_at(
     if h == 0 || !(bm_get(word, h - 1) || *last == h - 1) {
         return;
     }
-    *st.add(h >> 6) &= !(1u64 << (h & 63));
-    *opch.add(h >> 6) &= !(1u64 << (h & 63));
+    bm_clear(st, h);
+    bm_clear(opch, h);
     if h + 1 < n && bm_get(word, h + 1) {
-        *st.add((h + 1) >> 6) &= !(1u64 << ((h + 1) & 63));
+        bm_clear(st, h + 1);
     }
     *last = h;
 }

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::super::{
     HASHBANG, JEND, JSX_LT, JTEXT, STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL,
-    bitmap::{bm_clear_range, bm_set},
+    bitmap::{bm_clear, bm_clear_range, bm_set},
     find::{
         find_jsx_tag, find_jsx_text, find_line_terminator, find_opener, find_opener_jsx5,
         find_opener_jsx7, find_opener6, find1, find2, scan_block_comment,
@@ -507,12 +507,10 @@ pub(super) unsafe fn carve_jsx(
                     // against coalesce/keywords and clear the interior.
                     bm_set(st, text_start);
                     *kind.add(text_start) = JTEXT;
-                    let w = text_start >> 6;
-                    let bit = 1u64 << (text_start & 63);
-                    *opch.add(w) &= !bit;
-                    *digit.add(w) &= !bit;
-                    *dot.add(w) &= !bit;
-                    *kwinit.add(w) &= !bit;
+                    bm_clear(opch, text_start);
+                    bm_clear(digit, text_start);
+                    bm_clear(dot, text_start);
+                    bm_clear(kwinit, text_start);
                     if runend > text_start + 1 {
                         bm_clear_range(st, text_start + 1, runend - 1);
                     }
@@ -534,7 +532,7 @@ pub(super) unsafe fn carve_jsx(
                 } else if c == b'>' || c == b'}' {
                     // A stray `>`/`}` ends the run; clear its opch so
                     // coalesce can't fuse adjacent strays into `>>`.
-                    *opch.add(s >> 6) &= !(1u64 << (s & 63));
+                    bm_clear(opch, s);
                     lanes.push_diag(s as u32, 1, diag_code::JSX_TEXT_INVALID_CHARACTER);
                     text_start = s + 1;
                     i = s + 1;
@@ -615,7 +613,7 @@ pub(super) unsafe fn carve_jsx(
                         i = s + 1;
                     } else {
                         // malformed lone `<` in text — clear opch, no `<<` fusion
-                        *opch.add(s >> 6) &= !(1u64 << (s & 63));
+                        bm_clear(opch, s);
                         text_start = s + 1;
                         i = s + 1;
                     }
@@ -645,5 +643,5 @@ pub(super) unsafe fn carve_jsx(
 #[inline(always)]
 unsafe fn jsx_punct(kind: *mut u8, opch: *mut u64, off: usize, k: u8) {
     *kind.add(off) = k;
-    *opch.add(off >> 6) &= !(1u64 << (off & 63));
+    bm_clear(opch, off);
 }

--- a/crates/oxc_lexer/src/pipeline/classify/common.rs
+++ b/crates/oxc_lexer/src/pipeline/classify/common.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::super::{
     IDENT, IDENT_ESC, PRIV_IDENT, PRIV_IDENT_ESC, WS,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_prev1, bm_set},
+    bitmap::{bm_clear, bm_clear_range, bm_get, bm_next0, bm_prev1, bm_set},
     find::scan_ident_esc,
 };
 
@@ -146,7 +146,7 @@ pub unsafe fn misc_post(
             let k = *kind.add(tt as usize);
             if k == IDENT || (k >= KW_KIND_BASE && k != PUNCT1_KIND_UNKNOWN) {
                 *kind.add(tt as usize) = IDENT_ESC;
-                *st.add(p >> 6) &= !(1u64 << (p & 63));
+                bm_clear(st, p);
             }
         }
     }

--- a/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     NUM,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set},
+    bitmap::{bm_clear, bm_clear_range, bm_get, bm_next0, bm_set},
     find::scan_number,
     regex_div::{gt_run_split, lt_run_split},
 };
@@ -327,7 +327,7 @@ unsafe fn munch_walk(
             *kind.add(pos) = opk as u8;
             let mut j = 1usize;
             while j < opl as usize {
-                *st.add((pos + j) >> 6) &= !(1u64 << ((pos + j) & 63));
+                bm_clear(st, pos + j);
                 j += 1;
             }
             pos += opl as usize;


### PR DESCRIPTION
Pure refactor.

Add `bm_clear` function that clears a bit in a bitmap at specified index. This is the converse of `bm_set`, and single-bit version of `bm_clear_range`.

This operation is performed in various places across `classify`, `carve`, and `coalesce` stages. Replace the duplicated code with `bm_clear` calls. This makes the logic easier to read.

`bm_clear` is `#[inline(always)]` so this change makes zero difference to codegen. The changes in `carve_jsx` look more substantive, but compiling to ASM and diffing it before/after this PR shows 0 difference. The compiler is able to identify the repeated terms across the 4 calls - there's no need to perform that optimization manually.