### PR TITLE
fix(parser): require comma after TypeScript this parameter

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -52,7 +52,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::LParen);
         let this_param = if self.is_ts && self.at(Kind::This) {
             let param = self.parse_ts_this_parameter();
-            self.bump(Kind::Comma);
+            if !self.at(Kind::RParen) {
+                self.expect(Kind::Comma);
+            }
             Some(param)
         } else {
             None

--- a/tasks/coverage/misc/fail/this-parameter-missing-comma-class-untyped.ts
+++ b/tasks/coverage/misc/fail/this-parameter-missing-comma-class-untyped.ts
@@ -1,0 +1,1 @@
+class C { f(this x: T) {} }

--- a/tasks/coverage/misc/fail/this-parameter-missing-comma-class.ts
+++ b/tasks/coverage/misc/fail/this-parameter-missing-comma-class.ts
@@ -1,0 +1,1 @@
+class C { f(this: T x: T) {} }

--- a/tasks/coverage/misc/fail/this-parameter-missing-comma-function-type.ts
+++ b/tasks/coverage/misc/fail/this-parameter-missing-comma-function-type.ts
@@ -1,0 +1,1 @@
+type F = (this: T x: T) => void;

--- a/tasks/coverage/misc/fail/this-parameter-missing-comma-function.ts
+++ b/tasks/coverage/misc/fail/this-parameter-missing-comma-function.ts
@@ -1,0 +1,1 @@
+function f(this: T x: T) {}

--- a/tasks/coverage/misc/fail/this-parameter-missing-comma-interface.ts
+++ b/tasks/coverage/misc/fail/this-parameter-missing-comma-interface.ts
@@ -1,0 +1,1 @@
+interface I { f(this: T x: T): void }

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 281/281 (100.00%)
-Positive Passed: 281/281 (100.00%)
+AST Parsed     : 286/286 (100.00%)
+Positive Passed: 286/286 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 91/91 (100.00%)
 Positive Passed: 91/91 (100.00%)
-Negative Passed: 190/190 (100.00%)
+Negative Passed: 195/195 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -4547,6 +4547,41 @@ Negative Passed: 190/190 (100.00%)
  3 │ }
    ╰────
   help: If this is intended to be the condition for the switch statement, add `case` before it.
+
+  × Expected `,` but found `Identifier`
+   ╭─[misc/fail/this-parameter-missing-comma-class-untyped.ts:1:18]
+ 1 │ class C { f(this x: T) {} }
+   ·                  ┬
+   ·                  ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `Identifier`
+   ╭─[misc/fail/this-parameter-missing-comma-class.ts:1:21]
+ 1 │ class C { f(this: T x: T) {} }
+   ·                     ┬
+   ·                     ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `Identifier`
+   ╭─[misc/fail/this-parameter-missing-comma-function-type.ts:1:19]
+ 1 │ type F = (this: T x: T) => void;
+   ·                   ┬
+   ·                   ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `Identifier`
+   ╭─[misc/fail/this-parameter-missing-comma-function.ts:1:20]
+ 1 │ function f(this: T x: T) {}
+   ·                    ┬
+   ·                    ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `Identifier`
+   ╭─[misc/fail/this-parameter-missing-comma-interface.ts:1:25]
+ 1 │ interface I { f(this: T x: T): void }
+   ·                         ┬
+   ·                         ╰── `,` expected
+   ╰────
 
   × TS(1009): Trailing comma not allowed.
    ╭─[misc/fail/ts-interface-invalid-heritage.ts:1:22]


### PR DESCRIPTION
Require a comma after a TypeScript `this` parameter when the parameter list continues. Previously, malformed syntax such as `function f(this: T x: T) {}` parsed without a diagnostic.