### PR TITLE
perf(linter/unicorn/no-useless-undefined): skip calls without trailing undefined

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -307,11 +307,14 @@ impl Rule for NoUselessUndefined {
                     return;
                 }
 
-                if should_ignore(&call_expr.callee) {
+                let arguments = &call_expr.arguments;
+                if !arguments.last().is_some_and(is_undefined) {
                     return;
                 }
 
-                let arguments = &call_expr.arguments;
+                if should_ignore(&call_expr.callee) {
+                    return;
+                }
 
                 // Ignore arguments in `Function#bind()`, but not `this` argument
                 if is_function_bind_call(call_expr) && arguments.len() != 1 {
@@ -322,7 +325,7 @@ impl Rule for NoUselessUndefined {
                     let arg = &arguments[i];
                     if is_undefined(arg) {
                         let span = arg.span();
-                        undefined_args_spans.insert(0, span);
+                        undefined_args_spans.push(span);
                     } else {
                         break;
                     }
@@ -331,6 +334,7 @@ impl Rule for NoUselessUndefined {
                 if undefined_args_spans.is_empty() {
                     return;
                 }
+                undefined_args_spans.reverse();
                 let first_undefined_span = undefined_args_spans[0];
                 let last_undefined_span = undefined_args_spans[undefined_args_spans.len() - 1];
                 let mut start = first_undefined_span.start;
@@ -779,6 +783,28 @@ fn test_issue_14368() {
         Some(serde_json::json!([{ "checkArguments": true }])),
     )];
 
+    Tester::new(NoUselessUndefined::NAME, NoUselessUndefined::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test();
+}
+
+#[test]
+fn test_trailing_arguments() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "call(undefined, ...values);",
+        "call(...values);",
+        "call?.(value);",
+        "call.bind(receiver);",
+        "call.bind(receiver, undefined);",
+    ];
+    let fail =
+        vec!["call(...values, undefined, undefined);", "call?.(value, undefined, undefined);"];
+    let fix = vec![
+        ("call(...values, undefined, undefined);", "call(...values);", None),
+        ("call?.(value, undefined, undefined);", "call?.(value);", None),
+    ];
     Tester::new(NoUselessUndefined::NAME, NoUselessUndefined::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test();


### PR DESCRIPTION
Return early for calls whose last argument is not `undefined`, avoiding unnecessary callee and `bind` checks. Collect trailing undefined spans with pushes followed by one reversal instead of repeated front insertions, preserving diagnostic and fix order.
