### PR TITLE
refactor(lexer): move `misc` dispatch and early exit out of `lex_raw`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/misc/post.rs
+++ b/crates/oxc_lexer/src/pipeline/misc/post.rs
@@ -5,7 +5,22 @@ use super::super::{
     bitmap::{bm_clear, bm_get, bm_prev1},
 };
 
+#[inline]
 pub unsafe fn misc_post(
+    src: *const u8,
+    n: usize,
+    st: *mut u64,
+    word: *const u64,
+    misc: *const u64,
+    kind: *mut u8,
+    nesc: usize,
+) {
+    if nesc != 0 {
+        misc_post_impl(src, n, st, word, misc, kind)
+    }
+}
+
+unsafe fn misc_post_impl(
     src: *const u8,
     n: usize,
     st: *mut u64,

--- a/crates/oxc_lexer/src/pipeline/misc/pre.rs
+++ b/crates/oxc_lexer/src/pipeline/misc/pre.rs
@@ -2,15 +2,38 @@ use crate::{error::diag_code, lanes::Lanes, tables::is_id_start};
 
 use super::super::{
     IDENT_ESC, PRIV_IDENT, PRIV_IDENT_ESC, WS,
-    bitmap::{bm_clear_range, bm_get, bm_next0, bm_set},
+    bitmap::{bm_any, bm_clear_range, bm_get, bm_next0, bm_set},
     classify::unicode_ws_len,
     find::scan_ident_esc,
 };
 
+#[inline]
+pub unsafe fn misc_pre(
+    src: *const u8,
+    n: usize,
+    nb: usize,
+    st: *mut u64,
+    word: *mut u64,
+    misc: *const u64,
+    kind: *mut u8,
+    vutf8: bool,
+    lanes: &mut Lanes,
+) -> usize {
+    if !bm_any(misc, nb) {
+        return 0;
+    }
+
+    if vutf8 {
+        misc_pre_impl::<true>(src, n, st, word, misc, kind, lanes)
+    } else {
+        misc_pre_impl::<false>(src, n, st, word, misc, kind, lanes)
+    }
+}
+
 /// `VUTF8` (`LexOptions::validate_utf8`) adds UTF-8 well-formedness
 /// validation to the non-ASCII walk. Monomorphized so the default `false`
 /// copy pays nothing for it.
-pub unsafe fn misc_pre<const VUTF8: bool>(
+unsafe fn misc_pre_impl<const VUTF8: bool>(
     src: *const u8,
     n: usize,
     st: *mut u64,

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -28,7 +28,6 @@ use crate::options::LexOptions;
 use crate::tables::Tables;
 use crate::token::SPAN_SENTINELS;
 
-use bitmap::bm_any;
 use carve::carve;
 use classify::classify;
 use coalesce::{KWB, coalesce};
@@ -211,19 +210,10 @@ impl Lexer {
         *dot.add(nb) = 0;
         *misc.add(nb) = 0;
 
-        let mut nesc = 0usize;
-        if bm_any(misc, nb) {
-            nesc = if vutf8 {
-                misc_pre::<true>(sp, n, st, word, misc, kind, &mut self.lanes)
-            } else {
-                misc_pre::<false>(sp, n, st, word, misc, kind, &mut self.lanes)
-            };
-        }
+        let nesc = misc_pre(sp, n, nb, st, word, misc, kind, vutf8, &mut self.lanes);
         carve(t, src, n, st, kind, opch, word, digit, dot, kwinit, jsx, ts, &mut self.lanes);
         coalesce(t, kws, sp, n, st, opch, word, digit, dot, kwinit, kind, kwpos, &mut self.lanes);
-        if nesc != 0 {
-            misc_post(sp, n, st, word, misc, kind);
-        }
+        misc_post(sp, n, st, word, misc, kind, nesc);
         let w = compress(
             t,
             src,


### PR DESCRIPTION
`misc_pre` and `misc_post` both have early exit branches. `misc_pre` also dispatches to 2 different implementations depending on whether UTF-8 validation is required.

This logic was all in `Lexer::lex_raw`, mixed around the calls into other stages. Move it into the `misc` module, simplifying `lex_raw`.

The early exits are handled in the `misc_pre` / `misc_post` entry points (which are marked `#[inline]`), and only pass control into the main implementations `misc_pre_impl` / `misc_post_impl` if the early exit checks pass. ASM after this PR is completely unchanged from before, so this PR is pure refactor in the strictest sense.