### PR TITLE
perf(linter/unicorn/no-new-buffer): avoid temporary argument vector

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression},
@@ -69,12 +71,8 @@ impl Rule for NoNewBuffer {
             };
 
             // Build arguments string
-            let args_text = new_expr
-                .arguments
-                .iter()
-                .map(|arg| ctx.source_range(arg.span()))
-                .collect::<Vec<_>>()
-                .join(", ");
+            let args_text =
+                new_expr.arguments.iter().map(|arg| ctx.source_range(arg.span())).join(", ");
 
             let replacement = format!("Buffer.{method}({args_text})");
             fixer.replace(expr_span, replacement)


### PR DESCRIPTION
Join argument source slices directly when building the `Buffer.from` or `Buffer.alloc` suggestion, avoiding an intermediate vector while preserving the replacement text.
