### PR TITLE
ci(lexer): run lexer conformance as part of main conformance job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,8 +582,16 @@ jobs:
       - name: Check Conformance
         if: steps.filter.outputs.changed == 'true'
         run: |
+          set -o pipefail
           just update-transformer-fixtures
-          just coverage
+          just coverage | tee "$RUNNER_TEMP/coverage.log"
+          # `just coverage` includes lexer conformance, and this job is what covers `oxc_lexer`'s
+          # scalar fallback - the "Lexer SIMD" job covers the SIMD core. The harness prints which
+          # implementation it was built with (`oxc_lexer::IS_SIMD`). Checking it here is what
+          # guarantees the 2 jobs really do run one implementation each, so their shared snapshots
+          # compare the implementations against each other.
+          grep -qxF "Lexer implementation: scalar" "$RUNNER_TEMP/coverage.log" ||
+            { echo "::error::Expected scalar lexer, but the harness reported otherwise"; exit 1; }
           git diff --exit-code
 
   lexer:
@@ -593,23 +601,17 @@ jobs:
     #
     # Neither feature is in the x86_64 baseline on any platform, so the SIMD core is never built
     # unless asked for explicitly - which means no other job here lints, tests or runs it.
+    # Every other job builds the scalar fallback - "Lint", "Test Linux", "Conformance" jobs.
     #
-    # Both legs regenerate the committed conformance snapshots and fail on any diff,
-    # which ensures the 2 implementations behave identically to each other.
+    # This job and the "Conformance" job regenerate the same committed conformance snapshots
+    # and fail on any diff, which ensures the 2 implementations behave identically to each other.
+    # Both assert which implementation they got, so neither can silently run the other's.
     #
     # See the LEXER section of `justfile` for the flags.
-    name: Lexer (${{ matrix.variant }})
+    name: Lexer SIMD
     runs-on: namespace-profile-linux-x64-default
     env:
       CARGO_BUILD_WARNINGS: deny
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - variant: scalar
-            suffix: ""
-          - variant: SIMD
-            suffix: "-simd"
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -617,8 +619,8 @@ jobs:
         id: filter
         uses: ./.github/actions/check-changes
         with:
-          packages: oxc_lexer,oxc_coverage
-          paths: crates/oxc_lexer/,tasks/coverage/,.cargo/lexer-simd.toml,justfile,.github/workflows/ci.yml
+          packages: oxc_lexer
+          paths: crates/oxc_lexer/,.cargo/lexer-simd.toml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 
@@ -639,29 +641,26 @@ jobs:
           tool: just
 
       - run: rustup component add clippy
-        # No need to run on scalar fallback - linting already covered by "Lint" job
-        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+        if: steps.filter.outputs.changed == 'true'
 
       - name: Lint
-        # No need to run on scalar fallback - already covered by "Lint" job
-        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+        if: steps.filter.outputs.changed == 'true'
         run: just lint-lexer-simd
 
       - name: Test
-        # No need to run on scalar fallback - already covered by "Test Linux" job
-        if: ${{ steps.filter.outputs.changed == 'true' && matrix.variant == 'SIMD' }}
+        if: steps.filter.outputs.changed == 'true'
         run: just test-lexer-simd
 
       - name: Conformance
-        # Run on both SIMD and scalar fallback - neither is run anywhere else.
         # The harness prints which implementation it was built with (`oxc_lexer::IS_SIMD`).
-        # Checking it here is what guarantees this leg exercised the build it asked for.
+        # Checking it here is what guarantees this job exercised the build it asked for -
+        # the "Conformance" job makes the mirror-image check for the scalar fallback.
         if: steps.filter.outputs.changed == 'true'
         run: |
           set -o pipefail
-          just conformance-lexer${{ matrix.suffix }} | tee "$RUNNER_TEMP/lexer.log"
-          grep -qxF "Lexer implementation: ${{ matrix.variant }}" "$RUNNER_TEMP/lexer.log" ||
-            { echo "::error::Expected ${{ matrix.variant }}, but the harness reported otherwise"; exit 1; }
+          just conformance-lexer-simd | tee "$RUNNER_TEMP/lexer.log"
+          grep -qxF "Lexer implementation: SIMD" "$RUNNER_TEMP/lexer.log" ||
+            { echo "::error::Expected SIMD lexer, but the harness reported otherwise"; exit 1; }
           git diff --exit-code
 
   test-codegen:

--- a/justfile
+++ b/justfile
@@ -178,13 +178,13 @@ test-lexer *args='':
 test-lexer-simd *args='':
   cargo test -p oxc_lexer {{_lexer-simd}} {{args}}
 
-# Run lexer conformance against the scalar fallback
+# Run lexer conformance against the scalar fallback (also part of `just coverage`)
 conformance-lexer *args='':
-  cargo run -p oxc_coverage --profile coverage --features lexer -- lexer {{args}}
+  cargo run -p oxc_coverage --profile coverage -- lexer {{args}}
 
 # Run lexer conformance against the SIMD core
 conformance-lexer-simd *args='':
-  cargo run -p oxc_coverage --profile coverage {{_lexer-simd}} --features lexer -- lexer {{args}}
+  cargo run -p oxc_coverage --profile coverage {{_lexer-simd}} -- lexer {{args}}
 
 # Lint `oxc_lexer` and the conformance harness against the scalar fallback
 [unix]

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -25,7 +25,7 @@ doctest = false
 cow-utils = { workspace = true }
 oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance"] }
 oxc_estree_tokens = { workspace = true }
-oxc_lexer = { workspace = true, optional = true }
+oxc_lexer = { workspace = true, features = ["oxc_diagnostics"] }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_tasks_common = { workspace = true }
@@ -43,14 +43,3 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 similar = { workspace = true }
 walkdir = { workspace = true }
-
-[features]
-# Differential lexer conformance, opt-in because it is slow and `oxc_lexer` is still incubating.
-# The harness runs against whichever of the lexer's two implementations the build selects:
-#
-# * SIMD core (x86_64 only): RUSTFLAGS="-C target-feature=+avx2,+bmi2" cargo coverage --features lexer -- lexer
-# * Scalar fallback:         cargo coverage --features lexer -- lexer
-#
-# `avx2`/`bmi2` are not in the x86_64 baseline on any platform, so the rustflags are required
-# to reach the SIMD core even on an x86_64 host.
-lexer = ["dep:oxc_lexer", "oxc_lexer/oxc_diagnostics"]

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -10,9 +10,8 @@ mod typescript;
 
 mod tools;
 
-// Gated by `lexer` Cargo feature, because `oxc_lexer` is still incubating.
-// `oxc_lexer` only supports little endian at present.
-#[cfg(all(feature = "lexer", target_endian = "little"))]
+// `oxc_lexer` only supports little endian at present
+#[cfg(target_endian = "little")]
 mod lexer_diff;
 
 use std::{
@@ -335,6 +334,7 @@ impl AppArgs {
         self.run_minifier(data);
         self.run_estree(data);
         self.run_estree_tokens(data);
+        self.run_lexer(data);
     }
 
     fn run_tool<T>(
@@ -370,15 +370,12 @@ impl AppArgs {
     /// Differential lexer conformance.
     ///
     /// Compare `oxc_lexer`'s token spans against the parser's token stream over the corpora.
-    /// Opt-in (kept out of `run_all`) — requires `lexer` Cargo feature.
     /// Runs against whichever of the lexer's two implementations the build selects -
     /// the SIMD core on a static AVX2/BMI2 x86_64 build, the scalar fallback otherwise.
-    /// `oxc_lexer` only supports little endian at present.
     ///
-    /// # Panics
-    /// Panics if `lexer` Cargo feature is not enabled, or on a big endian machine.
+    /// `oxc_lexer` only supports little endian at present, so this is a no-op on big endian.
     pub fn run_lexer(&self, data: &TestData) {
-        #[cfg(all(feature = "lexer", target_endian = "little"))]
+        #[cfg(target_endian = "little")]
         {
             // Report which implementation was built.
             // CI checks this line to make sure the build it expected is the build it got.
@@ -401,10 +398,10 @@ impl AppArgs {
             self.run_tool("lexer_misc", MISC_PATH, &data.misc, lexer_diff::run_lexer_misc);
         }
 
-        #[cfg(not(all(feature = "lexer", target_endian = "little")))]
+        #[cfg(not(target_endian = "little"))]
         {
             let _ = (self, data);
-            panic!("`lexer` conformance requires `lexer` Cargo feature and a little-endian system");
+            println!("Lexer conformance skipped: `oxc_lexer` requires a little-endian system");
         }
     }
 


### PR DESCRIPTION
Lexer conformance was previously skipped by default from `cargo coverage`.

@camc314 pointed out this is annoying because if you add a new conformance test (e.g. when working on the parser or semantic) and run `just coverage` locally, it doesn't run lexer conformance, which means the lexer conformance snapshot isn't updated. But then files in `tasks/coverage` change, which triggers the `Lexer` task in CI, which then fails.

Fix this by running lexer conformance by default as part of the main conformance task, both locally and in CI.

It doesn't increase the time to run conformance by much - just ~3 seconds extra time on a local run (Macbook Air M3).

"Lexer SIMD" CI job now only runs lint, test, and conformance on the SIMD implementation when `oxc_lexer` itself is touched. CI now has less comprehensive coverage for work on `oxc_lexer` itself, but it does ensure a divergence between `oxc_lexer`'s SIMD and scalar implementations doesn't cause spurious CI failures for unrelated work on other crates.

We can harden CI coverage for `oxc_lexer` again when it's more stable.