### PR TITLE
perf(linter/unicorn/prefer-single-call): avoid temporary argument vector

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression, Statement},
@@ -182,11 +184,7 @@ impl Rule for PreferSingleCall {
 
             // Insert the source call's arguments into the target call.
             if !source_args.is_empty() {
-                let args_text = source_args
-                    .iter()
-                    .map(|a| a.span().source_text(src))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let args_text = source_args.iter().map(|a| a.span().source_text(src)).join(", ");
 
                 // Determine separator. Check whether the target call ends with a
                 // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.


### PR DESCRIPTION
Join source argument slices directly when building the merged-call fix, avoiding a temporary vector while preserving argument text and separators.
