### PR TITLE
test(codegen): enable number printing cases

### DIFF
--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -8,18 +8,17 @@ use crate::tester::{test, test_minify};
 #[test]
 fn test_number() {
     // Check "1eN"
-    // TODO FIXME
-    // test("x = 1e-100", "x = 1e-100;\n");
-    // test("x = 1e-4", "x = 1e-4;\n");
-    // test("x = 1e-3", "x = 1e-3;\n");
-    // test("x = 1e-2", "x = 1e-2;\n");
-    // test("x = 1e-1", "x = 1e-1;\n");
-    // test("x = 1e0", "x = 1e0;\n");
-    // test("x = 1e1", "x = 1e1;\n");
-    // test("x = 1e2", "x = 1e2;\n");
-    // test("x = 1e3", "x = 1e3;\n");
-    // test("x = 1e4", "x = 1e4;\n");
-    // test("x = 1e100", "x = 1e100;\n");
+    test("x = 1e-100", "x = 1e-100;\n");
+    test("x = 1e-4", "x = 1e-4;\n");
+    test("x = 1e-3", "x = .001;\n");
+    test("x = 1e-2", "x = .01;\n");
+    test("x = 1e-1", "x = .1;\n");
+    test("x = 1e0", "x = 1;\n");
+    test("x = 1e1", "x = 10;\n");
+    test("x = 1e2", "x = 100;\n");
+    test("x = 1e3", "x = 1e3;\n");
+    test("x = 1e4", "x = 1e4;\n");
+    test("x = 1e100", "x = 1e100;\n");
     test_minify("x = 1e-100", "x=1e-100;");
     test_minify("x = 1e-5", "x=1e-5;");
     test_minify("x = 1e-4", "x=1e-4;");
@@ -34,19 +33,18 @@ fn test_number() {
     test_minify("x = 1e100", "x=1e100;");
 
     // Check "12eN"
-    // TODO FIXME
-    // test("x = 12e-100", "x = 12e-100;\n");
-    // test("x = 12e-5", "x = 12e-5;\n");
-    // test("x = 12e-4", "x = 12e-4;\n");
-    // test("x = 12e-3", "x = 12e-3;\n");
-    // test("x = 12e-2", "x = 12e-2;\n");
-    // test("x = 12e-1", "x = 12e-1;\n");
-    // test("x = 12e0", "x = 12e0;\n");
-    // test("x = 12e1", "x = 12e1;\n");
-    // test("x = 12e2", "x = 12e2;\n");
-    // test("x = 12e3", "x = 12e3;\n");
-    // test("x = 12e4", "x = 12e4;\n");
-    // test("x = 12e100", "x = 12e100;\n");
+    test("x = 12e-100", "x = 1.2e-99;\n");
+    test("x = 12e-5", "x = 12e-5;\n");
+    test("x = 12e-4", "x = .0012;\n");
+    test("x = 12e-3", "x = .012;\n");
+    test("x = 12e-2", "x = .12;\n");
+    test("x = 12e-1", "x = 1.2;\n");
+    test("x = 12e0", "x = 12;\n");
+    test("x = 12e1", "x = 120;\n");
+    test("x = 12e2", "x = 1200;\n");
+    test("x = 12e3", "x = 12e3;\n");
+    test("x = 12e4", "x = 12e4;\n");
+    test("x = 12e100", "x = 12e100;\n");
     test_minify("x = 12e-100", "x=1.2e-99;");
     test_minify("x = 12e-6", "x=12e-6;");
     test_minify("x = 12e-5", "x=12e-5;");
@@ -62,20 +60,19 @@ fn test_number() {
     test_minify("x = 12e100", "x=12e100;");
 
     // Check cases for "A.BeX" => "ABeY" simplification
-    // TODO FIXME
-    // test("x = 123456789", "x = 123456789;\n");
-    // test("x = 1123456789", "x = 1123456789;\n");
-    // test("x = 10123456789", "x = 10123456789;\n");
-    // test("x = 100123456789", "x = 100123456789;\n");
-    // test("x = 1000123456789", "x = 1000123456789;\n");
-    // test("x = 10000123456789", "x = 10000123456789;\n");
-    // test("x = 100000123456789", "x = 100000123456789;\n");
-    // test("x = 1000000123456789", "x = 1000000123456789;\n");
-    // test("x = 10000000123456789", "x = 10000000123456789;\n");
-    // test("x = 100000000123456789", "x = 100000000123456789;\n");
-    // test("x = 1000000000123456789", "x = 1000000000123456789;\n");
-    // test("x = 10000000000123456789", "x = 10000000000123456789;\n");
-    // test("x = 100000000000123456789", "x = 100000000000123456789;\n");
+    test("x = 123456789", "x = 123456789;\n");
+    test("x = 1123456789", "x = 1123456789;\n");
+    test("x = 10123456789", "x = 10123456789;\n");
+    test("x = 100123456789", "x = 100123456789;\n");
+    test("x = 1000123456789", "x = 0xe8dc00dd15;\n");
+    test("x = 10000123456789", "x = 0x91855ce6d15;\n");
+    test("x = 100000123456789", "x = 0x5af317d60d15;\n");
+    test("x = 1000000123456789", "x = 0x38d7eac224d15;\n");
+    test("x = 10000000123456789", "x = 0x2386f2771ccd14;\n");
+    test("x = 100000000123456789", "x = 0x163457864e5cd10;\n");
+    test("x = 1000000000123456789", "x = 0xde0b6b3aebfcd00;\n");
+    test("x = 10000000000123456789", "x = 0x8ac723049143d000;\n");
+    test("x = 100000000000123456789", "x = 0x56bc75e2d6a6bc000;\n");
 
     // Check numbers around the ends of various integer ranges. These were
     // crashing in the WebAssembly build due to a bug in the Go runtime.
@@ -113,14 +110,13 @@ fn test_number() {
     test_minify("x = -0x1_0000_0000_0000_1000", "x=-0x10000000000001000;");
 
     // Check the hex vs. decimal decision boundary when minifying
-    // TODO FIXME
-    // test("x = 999999999999", "x = 999999999999;\n");
-    // test("x = 1000000000001", "x = 1000000000001;\n");
-    // test("x = 0x0FFF_FFFF_FFFF_FF80", "x = 0x0FFF_FFFF_FFFF_FF80;\n");
-    // test("x = 0x1000_0000_0000_0000", "x = 0x1000_0000_0000_0000;\n");
-    // test("x = 0xFFFF_FFFF_FFFF_F000", "x = 0xFFFF_FFFF_FFFF_F000;\n");
-    // test("x = 0xFFFF_FFFF_FFFF_F800", "x = 0xFFFF_FFFF_FFFF_F800;\n");
-    // test("x = 0xFFFF_FFFF_FFFF_FFFF", "x = 0xFFFF_FFFF_FFFF_FFFF;\n");
+    test("x = 999999999999", "x = 999999999999;\n");
+    test("x = 1000000000001", "x = 0xe8d4a51001;\n");
+    test("x = 0x0FFF_FFFF_FFFF_FF80", "x = 0xfffffffffffff80;\n");
+    test("x = 0x1000_0000_0000_0000", "x = 0x1000000000000000;\n");
+    test("x = 0xFFFF_FFFF_FFFF_F000", "x = 0xfffffffffffff000;\n");
+    test("x = 0xFFFF_FFFF_FFFF_F800", "x = 0xfffffffffffff800;\n");
+    test("x = 0xFFFF_FFFF_FFFF_FFFF", "x = 0x10000000000000000;\n");
     test_minify("x = 999999999999", "x=999999999999;");
     test_minify("x = 1000000000001", "x=0xe8d4a51001;");
     test_minify("x = 0x0FFF_FFFF_FFFF_FF80", "x=0xfffffffffffff80;");


### PR DESCRIPTION
Enable all 43 commented-out number-printing cases ported from esbuild, with expectations matching Oxc's existing output.

The old expectations preserved the input spelling, but Oxc uses the same value-based number printer with and without whitespace minification. It removes numeric separators and compares decimal, exponent, and hexadecimal spellings by length, keeping the current candidate on ties. For example, `1e-3` becomes `.001` (equal length), while `1000000000001` becomes `0xe8d4a51001` (shorter).

Large integer literals also reflect JavaScript `Number` rounding already applied during parsing. For example, `0xFFFF_FFFF_FFFF_FFFF` rounds to `0x10000000000000000`, so the changed spelling preserves the runtime value.
