### PR TITLE
perf(linter/eslint/no-restricted-properties): skip empty configurations

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_properties.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_properties.rs
@@ -17,7 +17,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::Rule,
+};
 
 fn no_restricted_properties_diagnostic(property: &PropertyDetails, span: Span) -> OxcDiagnostic {
     let mut warn_text = match (&property.object, &property.property) {
@@ -256,6 +260,10 @@ impl Rule for NoRestrictedProperties {
             }
         }
         Ok(Self { restricted_properties: Box::new(PropertyDetailsList(properties)) })
+    }
+
+    fn should_run(&self, _ctx: &ContextHost) -> bool {
+        !self.restricted_properties.0.is_empty()
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -109,7 +109,6 @@ eslint/no-redeclare                                        |      7
 eslint/no-regex-spaces                                     |  64236
 eslint/no-restricted-exports                               |     70
 eslint/no-restricted-globals                               |      7
-eslint/no-restricted-properties                            |  94494
 eslint/no-return-assign                                    |  13005
 eslint/no-script-url                                       |  63073
 eslint/no-self-assign                                      |  13005


### PR DESCRIPTION
Skip the rule when no property restrictions are configured, avoiding node callbacks and property-access analysis that cannot produce a diagnostic.
