### PR TITLE
perf(linter/oxc/no-barrel-file): iterate module requests directly

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -100,8 +100,7 @@ impl Rule for NoBarrelFile {
                     }
                 }
                 None
-            })
-            .collect::<Vec<_>>();
+            });
 
         let mut labels = vec![];
         let mut total: u32 = 0;


### PR DESCRIPTION
Iterate matching module requests directly instead of collecting a temporary vector before counting loaded modules. Export traversal order and diagnostics remain unchanged.
