### PR TITLE
refactor(lexer): move `KwSet` selection out of `lex_raw`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/coalesce/mod.rs
@@ -18,7 +18,6 @@ use keywords::kw_flush;
 
 pub unsafe fn coalesce(
     t: &Tables,
-    kw: &KwSet,
     src: *const u8,
     n: usize,
     st: *mut u64,
@@ -29,8 +28,10 @@ pub unsafe fn coalesce(
     kwinit: *const u64,
     kind: *mut u8,
     kwpos: *mut u32,
+    ts: bool,
     lanes: &mut Lanes,
 ) {
+    let kw = if ts { &t.kwts } else { &t.kwjs };
     let nw = (n + 63) >> 6;
     let mut opprev: u64 = 0;
     let mut dtprev: u64 = 0;

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -200,7 +200,6 @@ impl Lexer {
         // Keyword recognition is mode-scoped: the TS set (and its wider
         // kwinit letter class) only ever sees TS input, so JS lexing is
         // byte-identical to a build without it.
-        let kws = if ts { &t.kwts } else { &t.kwjs };
         classify(t, ts, sp, n, word, st, kwinit, opch, digit, dot, misc, kind);
         *word.add(nb) = 0;
         *st.add(nb) = 0;
@@ -212,7 +211,7 @@ impl Lexer {
 
         let nesc = misc_pre(sp, n, nb, st, word, misc, kind, vutf8, &mut self.lanes);
         carve(t, src, n, st, kind, opch, word, digit, dot, kwinit, jsx, ts, &mut self.lanes);
-        coalesce(t, kws, sp, n, st, opch, word, digit, dot, kwinit, kind, kwpos, &mut self.lanes);
+        coalesce(t, sp, n, st, opch, word, digit, dot, kwinit, kind, kwpos, ts, &mut self.lanes);
         misc_post(sp, n, st, word, misc, kind, nesc);
         let w = compress(
             t,


### PR DESCRIPTION
Pure refactor. Small change to `oxc_lexer`.

`coalesce` stage selects a `KwSet` depending on source type - JS or TS. Move making this selection from `lex_raw` into `coalesce` itself. This just removes a little clutter from `lex_raw` and makes it clear that only `coalesce` stage uses it.