### PR TITLE
perf(linter/jsx-a11y/no-static-element-interactions): avoid role vector

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -152,9 +152,7 @@ impl Rule for NoStaticElementInteractions {
         match role_value {
             JSXAttributeValue::StringLiteral(role) => {
                 let role_str = role.value.as_str().cow_to_lowercase();
-                let roles: Vec<&str> = role_str.split_whitespace().collect();
-
-                if let Some(first_role) = roles.first() {
+                if let Some(first_role) = role_str.split_whitespace().next() {
                     if is_interactive_role(first_role) {
                         return;
                     }


### PR DESCRIPTION
Read the first role token directly instead of collecting every token into a vector. The rule continues to inspect only the first role, preserving its existing behavior for multi-role values.
