### PR TITLE
refactor(lexer): rename `finder!` macro to `define_find_function!`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/find/avx2.rs
+++ b/crates/oxc_lexer/src/pipeline/find/avx2.rs
@@ -83,7 +83,7 @@ pub unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8,
     n
 }
 
-macro_rules! finder {
+macro_rules! define_find_function {
     ($(#[$attr:meta])* $name:ident: $($needle:expr),+ $(,)?) => {
         $(#[$attr])*
         #[inline]
@@ -111,7 +111,7 @@ macro_rules! finder {
         }
     };
 }
-pub(super) use finder;
+pub(super) use define_find_function;
 
 /// OR-fold of `vpcmpeqb` results, associated as a tree.
 macro_rules! vor {

--- a/crates/oxc_lexer/src/pipeline/find/common.rs
+++ b/crates/oxc_lexer/src/pipeline/find/common.rs
@@ -1,30 +1,30 @@
-use super::{find3, finder};
+use super::{define_find_function, find3};
 
-finder!(
+define_find_function!(
     /// JS-mode top-level scan: string/template/regex-or-comment openers plus
     /// the Annex B `<!--` / `-->` trigger bytes.
     find_opener: b'"', b'\'', b'`', b'/', b'<', b'>'
 );
 
-finder!(
+define_find_function!(
     /// [`find_opener`] widened with `{` / `}` — used inside template
     /// substitutions, where braces drive the nesting depth.
     find_opener6: b'"', b'\'', b'`', b'/', b'{', b'}', b'<', b'>'
 );
 
-finder!(
+define_find_function!(
     /// [`find_opener`] shape for `carve_jsx` JS mode at top level: `<` (the
     /// JSX-start byte) instead of the Annex B `<` / `>` pair.
     find_opener_jsx5: b'"', b'\'', b'`', b'/', b'<'
 );
 
-finder!(
+define_find_function!(
     /// [`find_opener_jsx5`] widened with `{` / `}`. Used by `carve_jsx` JS
     /// mode inside a template substitution or JSX expression container.
     find_opener_jsx7: b'"', b'\'', b'`', b'/', b'{', b'}', b'<'
 );
 
-finder!(
+define_find_function!(
     /// TAG-mode scan: the bytes that matter inside an opening `<...>` tag.
     /// Deliberately not widened with `-` for hyphenated JSXIdentifiers: an
     /// extra needle costs a broadcast in every call, and TAG mode calls this
@@ -32,18 +32,18 @@ finder!(
     find_jsx_tag: b'"', b'\'', b'{', b'/', b'>', b'<'
 );
 
-finder!(
+define_find_function!(
     /// TEXT-mode scan (strict): JSX child text ends at any of `< { > }`.
     find_jsx_text: b'<', b'{', b'>', b'}'
 );
 
-finder!(
+define_find_function!(
     /// Template-body scan: terminator, escape lead, or `$` (`${` starts a
     /// substitution).
     find_tmpl: b'`', b'\\', b'$'
 );
 
-finder!(
+define_find_function!(
     /// Regex-body scan. LF/CR and the 0xE2 lead (LS/PS) are watched so
     /// line terminators in the body can be diagnosed.
     find_regex: b'/', b'\\', b'[', b']', b'\n', b'\r', 0xE2

--- a/crates/oxc_lexer/src/pipeline/find/generic.rs
+++ b/crates/oxc_lexer/src/pipeline/find/generic.rs
@@ -78,7 +78,7 @@ pub unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8,
     n
 }
 
-macro_rules! finder {
+macro_rules! define_find_function {
     ($(#[$attr:meta])* $name:ident: $($needle:expr),+ $(,)?) => {
         $(#[$attr])*
         #[inline]
@@ -104,4 +104,4 @@ macro_rules! finder {
         }
     };
 }
-pub(super) use finder;
+pub(super) use define_find_function;

--- a/crates/oxc_lexer/src/pipeline/find/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/find/mod.rs
@@ -1,14 +1,14 @@
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 mod avx2;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
-use avx2::finder;
+use avx2::define_find_function;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 pub(super) use avx2::{find1, find2, find3, find4};
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 mod generic;
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
-use generic::finder;
+use generic::define_find_function;
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 pub(super) use generic::{find1, find2, find3, find4};
 


### PR DESCRIPTION
Pure refactor - just renaming.

Rename the `finder!` macro to the more descriptive `define_find_function!`.