### PR TITLE
refactor(lexer): rename `load8` to `load64`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/chunk.rs
+++ b/crates/oxc_lexer/src/pipeline/chunk.rs
@@ -23,7 +23,7 @@ mod primitives {
     use core::ptr;
 
     #[inline(always)]
-    pub unsafe fn load8(src: *const u8, i: usize) -> u64 {
+    pub unsafe fn load64(src: *const u8, i: usize) -> u64 {
         ptr::read_unaligned(src.add(i) as *const u64)
     }
 

--- a/crates/oxc_lexer/src/pipeline/compress/generic.rs
+++ b/crates/oxc_lexer/src/pipeline/compress/generic.rs
@@ -4,7 +4,7 @@ use crate::{lanes::Lanes, tables::Tables, token::is_trivia_byte};
 
 use super::super::{
     BIGINT, HASHBANG, IDENT_ESC, NUM, PRIV_IDENT_ESC,
-    chunk::{eqm, load8},
+    chunk::{eqm, load64},
 };
 
 use super::common::{emit_value, invalid_diags};
@@ -70,7 +70,7 @@ pub(super) unsafe fn lanes_post(
     let mut inv = 0u64;
     let mut i = 0usize;
     while i + 8 <= m {
-        let x = load8(out_kinds, i);
+        let x = load64(out_kinds, i);
         let mut hits = eqm(x, NUM) | eqm(x, BIGINT) | eqm(x, IDENT_ESC) | eqm(x, PRIV_IDENT_ESC);
         inv |= eqm(x, 255);
         while hits != 0 {

--- a/crates/oxc_lexer/src/pipeline/find/generic.rs
+++ b/crates/oxc_lexer/src/pipeline/find/generic.rs
@@ -1,9 +1,9 @@
-use super::super::chunk::{eqm, load8};
+use super::super::chunk::{eqm, load64};
 
 #[inline]
 pub unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usize {
     while i + 8 <= n {
-        let m = eqm(load8(src, i), a);
+        let m = eqm(load64(src, i), a);
         if m != 0 {
             return i + (m.trailing_zeros() >> 3) as usize;
         }
@@ -21,7 +21,7 @@ pub unsafe fn find1(src: *const u8, n: usize, mut i: usize, a: u8) -> usize {
 #[inline]
 pub unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8) -> usize {
     while i + 8 <= n {
-        let x = load8(src, i);
+        let x = load64(src, i);
         let m = eqm(x, a) | eqm(x, b);
         if m != 0 {
             return i + (m.trailing_zeros() >> 3) as usize;
@@ -41,7 +41,7 @@ pub unsafe fn find2(src: *const u8, n: usize, mut i: usize, a: u8, b: u8) -> usi
 #[inline]
 pub unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8) -> usize {
     while i + 8 <= n {
-        let x = load8(src, i);
+        let x = load64(src, i);
         let m = eqm(x, a) | eqm(x, b) | eqm(x, c);
         if m != 0 {
             return i + (m.trailing_zeros() >> 3) as usize;
@@ -61,7 +61,7 @@ pub unsafe fn find3(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8)
 #[inline]
 pub unsafe fn find4(src: *const u8, n: usize, mut i: usize, a: u8, b: u8, c: u8, d: u8) -> usize {
     while i + 8 <= n {
-        let x = load8(src, i);
+        let x = load64(src, i);
         let m = eqm(x, a) | eqm(x, b) | eqm(x, c) | eqm(x, d);
         if m != 0 {
             return i + (m.trailing_zeros() >> 3) as usize;
@@ -83,10 +83,10 @@ macro_rules! define_find_function {
         $(#[$attr])*
         #[inline]
         pub unsafe fn $name(src: *const u8, n: usize, mut i: usize) -> usize {
-            use super::super::chunk::{load8, eqm};
+            use super::super::chunk::{load64, eqm};
 
             while i + 8 <= n {
-                let x = load8(src, i);
+                let x = load64(src, i);
                 let m = $(eqm(x, $needle))|+;
                 if m != 0 {
                     return i + (m.trailing_zeros() >> 3) as usize;

--- a/crates/oxc_lexer/src/pipeline/scan/generic.rs
+++ b/crates/oxc_lexer/src/pipeline/scan/generic.rs
@@ -1,4 +1,4 @@
-use super::super::chunk::{eqm, load8};
+use super::super::chunk::{eqm, load64};
 
 use super::common::lic_verify_at;
 
@@ -6,8 +6,8 @@ pub unsafe fn scan_block_comment(src: *const u8, n: usize, mut i: usize) -> (usi
     let mut saw_nl = false;
     let mut lic_q: i64 = -1;
     while i + 8 <= n {
-        let x = load8(src, i);
-        let y = load8(src, i + 1);
+        let x = load64(src, i);
+        let y = load64(src, i + 1);
         let term = eqm(x, b'*') & eqm(y, b'/');
         let nl = eqm(x, b'\n') | eqm(x, b'\r');
         let at = eqm(x, b'@');
@@ -53,7 +53,7 @@ pub unsafe fn scan_block_comment(src: *const u8, n: usize, mut i: usize) -> (usi
 pub unsafe fn scan_line_comment(src: *const u8, n: usize, mut i: usize) -> (usize, i64) {
     let mut lic_q: i64 = -1;
     while i + 8 <= n {
-        let x = load8(src, i);
+        let x = load64(src, i);
         let mut term = eqm(x, b'\n') | eqm(x, b'\r') | eqm(x, 0xE2);
         let at = eqm(x, b'@');
         while term != 0 {


### PR DESCRIPTION
Pure refactor - just renaming.

`load8` loads 8 bytes. Rename it to `load64` (64 bits).

This matches `load256`, which loads 256 bits (not bytes).