### PR TITLE
fix(minifier): preserve indirect eval when inlining aliases

### DIFF
--- a/crates/oxc_minifier/src/compression_pass.rs
+++ b/crates/oxc_minifier/src/compression_pass.rs
@@ -150,12 +150,9 @@ pub fn debug_assert_no_under_prune(
 /// flags are merely conservative and not checked; only the missing direction
 /// is unsafe.
 ///
-/// Locally-bound `eval` callees are exempt: `remove_sequence_expression`
-/// deliberately forms them (`var eval; (0, eval)()` -> `var eval; eval()` —
-/// `should_keep_indirect_access` only protects the *global* `eval`), banking on
-/// a local binding named `eval` not holding the real `eval`. Under that same
-/// assumption the missing flag is inert; a later refresh may still set it (the
-/// name-based collector), which is the allowed conservative direction.
+/// This guard checks global `eval` calls only. Local bindings named `eval` can
+/// also hold the built-in function, so transformations must preserve their
+/// indirect calls too.
 ///
 /// Allocation-free by design: asserts inline per call during the walk so the
 /// allocation-tracking task (debug assertions on) sees no sys-allocs. The walk

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1597,8 +1597,9 @@ impl<'a> PeepholeOptimizations {
                 }
             }
             Expression::CallExpression(call_expr)
-                // Don't substitute something into a call target that could change "this"
+                // Preserve the receiver and indirect eval's global scope.
                 if !((replacement.is_member_expression()
+                    || replacement.is_specific_id("eval")
                     || matches!(replacement, Expression::ChainExpression(_)))
                     && call_expr.callee.is_identifier_reference())
                 => {

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1597,9 +1597,8 @@ impl<'a> PeepholeOptimizations {
                 }
             }
             Expression::CallExpression(call_expr)
-                // Preserve the receiver and indirect eval's global scope.
+                // Don't substitute something into a call target that could change "this".
                 if !((replacement.is_member_expression()
-                    || replacement.is_specific_id("eval")
                     || matches!(replacement, Expression::ChainExpression(_)))
                     && call_expr.callee.is_identifier_reference())
                 => {
@@ -1610,6 +1609,11 @@ impl<'a> PeepholeOptimizations {
                         replacement_has_side_effect,
                         ctx,
                     ) {
+                        if changed && call_expr.callee.is_specific_id("eval") {
+                            // Keep evaluation indirect, including for local bindings named eval.
+                            let callee = call_expr.callee.take_in(ctx);
+                            call_expr.callee = Self::preserve_indirect_access(callee.span(), callee, ctx);
+                        }
                         return Some(changed);
                     }
 

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -671,7 +671,8 @@ impl<'a> PeepholeOptimizations {
         match ctx.parent() {
             Ancestor::CallExpressionCallee(_) | Ancestor::TaggedTemplateExpressionTag(_) => {
                 match access_value {
-                    Expression::Identifier(id) => id.name == "eval" && ctx.is_global_reference(id),
+                    // A local binding named eval can also hold the built-in eval function.
+                    Expression::Identifier(id) => id.name == "eval",
                     match_member_expression!(Expression) => true,
                     _ => false,
                 }

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -119,6 +119,11 @@ fn test_with_options_source_type(
 }
 
 #[test]
+fn preserves_indirect_eval() {
+    test_same("export function f(script) { const alias = eval; return alias(script); }");
+}
+
+#[test]
 fn dce_if_statement() {
     test("if (true) { foo }", "foo");
     test("if (true) { foo } else { bar }", "foo");

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -120,7 +120,15 @@ fn test_with_options_source_type(
 
 #[test]
 fn preserves_indirect_eval() {
-    test_same("export function f(script) { const alias = eval; return alias(script); }");
+    test(
+        "export function f(script) { const alias = eval; return alias(script); }",
+        "export function f(script) { return (0, eval)(script); }",
+    );
+    test_source_type(
+        "function f(eval, script, x) { const alias = eval; return [x, alias(script)]; }",
+        "function f(eval, script, x) { return [x, (0, eval)(script)]; }",
+        SourceType::cjs().with_script(true),
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -28,6 +28,14 @@ fn test_keep_names(source_text: &str, expected: &str) {
 }
 
 #[test]
+fn test_inline_single_use_variable_preserves_indirect_eval() {
+    test(
+        "function f(script) { const alias = eval; alias(script); }",
+        "function f(script) { let alias = eval; alias(script); }",
+    );
+}
+
+#[test]
 fn test_inline_single_use_variable() {
     test_same("function wrapper(arg0, arg1) {using x = foo; return x}");
     test_same("async function wrapper(arg0, arg1) { await using x = foo; return x}");

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -44,6 +44,11 @@ fn test_inline_single_use_variable_preserves_local_indirect_eval() {
 }
 
 #[test]
+fn test_eval_bound_to_console_log() {
+    test_script_same("let x = console.log; var eval = x; eval('.....');");
+}
+
+#[test]
 fn test_inline_single_use_variable() {
     test_same("function wrapper(arg0, arg1) {using x = foo; return x}");
     test_same("async function wrapper(arg0, arg1) { await using x = foo; return x}");

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -31,7 +31,15 @@ fn test_keep_names(source_text: &str, expected: &str) {
 fn test_inline_single_use_variable_preserves_indirect_eval() {
     test(
         "function f(script) { const alias = eval; alias(script); }",
-        "function f(script) { let alias = eval; alias(script); }",
+        "function f(script) { (0, eval)(script); }",
+    );
+}
+
+#[test]
+fn test_inline_single_use_variable_preserves_local_indirect_eval() {
+    test_script(
+        "function f(eval, script, x) { const alias = eval; return [x, alias(script)]; }",
+        "function f(eval, script, x) { return [x, (0, eval)(script)]; }",
     );
 }
 

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -221,7 +221,7 @@ fn remove_unused_expressions_in_sequence() {
     test_same("(0, eval)();"); // this can be compressed to `eval?.()`
     test_same("(0, eval)``;"); // this can be compressed to `eval?.()`
     test_same("(0, eval)?.();"); // this can be compressed to `eval?.()`
-    test("var eval; (0, eval)();", "var eval; eval();");
+    test_same("var eval; (0, eval)();");
     test_same("(0, foo.bar)();");
     test_same("(0, foo.bar)``;");
     test_same("(0, foo.bar)?.();");

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -213,6 +213,16 @@ fn remove_unreachable() {
 }
 
 #[test]
+fn preserves_indirect_eval_with_global_var_declaration() {
+    // A top-level var declaration without an initializer keeps the built-in eval.
+    test_same_options_source_type(
+        "var eval; function f(x) { return [x, (0, eval)('x')]; }",
+        SourceType::cjs().with_script(true),
+        &default_options(),
+    );
+}
+
+#[test]
 fn remove_unused_expressions_in_sequence() {
     test("true, foo();", "foo();");
     test("(0, foo)();", "foo();");


### PR DESCRIPTION
Debug builds panic with `stale direct-eval flags` when the minifier inlines a single-use alias to `eval`:

```js
// Before.
function run(script) {
  const alias = eval;
  alias(script);
}

// After the substitution.
function run(script) {
  eval(script);
}
```

[These calls have different semantics](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval). The indirect call evaluates in global scope; the direct call can access the caller's local scope. The rewrite changes program behaviour even without the debug assertion.

This patch inlines the alias as `(0, eval)(script)` in both full compression and DCE. It also preserves the comma expression for local bindings named `eval`, since those can hold the built-in function too.

I used Codex to help prepare the patch and regression cases.
