### PR TITLE
fix(parser): remove stale statements after top-level await reparse

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -93,7 +93,7 @@ use oxc_ast::{
     builder::{AstBuilder, GetAstBuilder},
 };
 use oxc_diagnostics::Diagnostics;
-use oxc_span::{SourceType, Span};
+use oxc_span::{GetSpan, SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
 pub use crate::lexer::{Kind, Token};
@@ -862,7 +862,11 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         let original_tokens =
             if self.lexer.config.tokens() { Some(self.lexer.take_tokens()) } else { None };
 
-        let checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
+        // Reparse in reverse statement order so removing stale statements never
+        // invalidates the indices of later checkpoints.
+        let mut checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
+        checkpoints.reverse();
+
         for (stmt_index, checkpoint) in checkpoints {
             // Rewind to the checkpoint
             self.rewind(checkpoint);
@@ -874,7 +878,17 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
 
             // Replace the statement if the index is valid
             if stmt_index < statements.len() {
+                let prev_end = stmt.span().end;
                 statements[stmt_index] = stmt;
+                // The first pass ended the statement at the line break and
+                // started a new statement on the `await` operand. The reparsed
+                // statement now covers that operand, so drop the stale
+                // statements swallowed by the reparse.
+                while stmt_index + 1 < statements.len()
+                    && statements[stmt_index + 1].span().start < prev_end
+                {
+                    statements.remove(stmt_index + 1);
+                }
             }
         }
 
@@ -1167,6 +1181,38 @@ mod test {
         for source in sources {
             let ret = Parser::new(&allocator, source, source_type).parse();
             assert!(ret.program.source_type.is_script());
+        }
+    }
+
+    #[test]
+    fn unambiguous_top_level_await_reparse_removes_stale_statements() {
+        // https://github.com/oxc-project/oxc/issues/26414
+        // In unambiguous mode, `await` parses as an identifier until module syntax
+        // commits to the Module goal. If that `await` statement is followed by a
+        // line break, the first pass ends the statement early and the next
+        // statement begins on the `await` operand. Reparsing then produces a
+        // single statement covering both, but the stale statement from the first
+        // pass must be removed.
+        let allocator = Allocator::default();
+        let source_type = SourceType::unambiguous();
+        for source in [
+            "await\nx\nexport {}",
+            "await\nimport('./x.js')\nexport {}",
+            "await\nimport.meta\nexport {}",
+            "import { x } from 'y';\nawait\nx\nimport { z } from 'w';",
+        ] {
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert!(ret.diagnostics.is_empty(), "{source}");
+            // After the reparse, no statement may start inside the span of a
+            // preceding statement: every `await` operand must be covered by the
+            // `await` statement itself, not duplicated as its own statement.
+            for pair in ret.program.body.windows(2) {
+                let (prev, next) = (&pair[0], &pair[1]);
+                assert!(
+                    prev.span().end <= next.span().start,
+                    "statement {next:?} starts inside {prev:?} for source {source:?}"
+                );
+            }
         }
     }
 

--- a/tasks/coverage/misc/pass/oxc-26414.js
+++ b/tasks/coverage/misc/pass/oxc-26414.js
@@ -1,0 +1,21 @@
+// https://github.com/oxc-project/oxc/issues/26414
+// In unambiguous mode, the `await` statement before a line break must not
+// duplicate its operand as a separate statement when module syntax later
+// commits the file to the Module goal and the statement is reparsed with
+// await context enabled.
+await
+x
+export {}
+
+await
+import('./x.js')
+export {}
+
+await
+import.meta
+export {}
+
+import { x } from 'y';
+await
+x
+import { z } from 'w';


### PR DESCRIPTION
Fixes #26414

## Problem

When `sourceType` is unspecified, this three-line file parses into three statements instead of two:

```js
await
x
export {}
```

The first pass (script goal) ends the `await` statement at the line break and starts a new statement on `x`. When the later `export {}` commits the file to the Module goal, `reparse_potential_top_level_awaits` reparses the checkpointed statement with await context, producing a single `await x` statement spanning 0-7. But the first pass's separate `x` statement (span 6-7) was never removed, so the AST contains the operand twice. The same happens with `import('./x.js')`, `import.meta`, or an `import` declaration as the later module syntax.

## Root cause

`reparse_potential_top_level_awaits` (`crates/oxc_parser/src/lib.rs`) replaces `statements[stmt_index]` with the reparsed statement but leaves every statement the first pass produced after that index untouched. When the reparsed statement swallows those statements (the line-break case), the stale ones remain.

## Fix

After replacing the statement at the checkpoint index, remove following statements whose span starts inside the reparsed statement's span (they are exactly the stale statements from the first pass; statements in a correct list never overlap). Checkpoints are processed in reverse statement order so removals never invalidate the recorded indices of later checkpoints.

## Tests

- `crates/oxc_parser/src/lib.rs` unit test `unambiguous_top_level_await_reparse_removes_stale_statements`: asserts no statement starts inside the span of the preceding one for the issue's four source variants (line-break operand with `export {}`, `import()`, `import.meta`, and a mid-file `import`). Fails on the current parser with the duplicate `x` at span 6-7, passes with the fix.
- `tasks/coverage/misc/pass/oxc-26414.js` fixture per the parser testing guide.

## Verification

- `cargo test -p oxc_parser`: 86/86 unit + integration green.
- `cargo coverage -p parser --filter misc`: parser_misc 97/97 pass and 201/201 fail fixtures green (includes the new fixture); codegen_misc 97/97; transformer_misc 97/97; semantic_misc passes the new fixture (4 pre-existing failures on unrelated fixtures verified identical on pristine main).
- `cargo run -p oxc_parser --example parser -- <repro> --estree`: Program with exactly `ExpressionStatement(AwaitExpression)` + `ExportNamedDeclaration`, no duplicate `x`.
- `cargo clippy -p oxc_parser --all-targets` and `just fmt` clean.

Conformance suites (test262/babel/typescript submodules) were not cloned locally; CI runs them.
