### PR TITLE
docs(formatter): note why jsx-test-suite snippets stay off

### DIFF
--- a/crates/oxc_formatter/tests/conformance.rs
+++ b/crates/oxc_formatter/tests/conformance.rs
@@ -125,6 +125,7 @@ fn skip_unsupported_options(spec: &OptionSet) -> bool {
 const JS: ConformanceConfig = ConformanceConfig {
     language: "js",
     fixture_roots: &["js", "jsx"],
+    // `None` also leaves `jsx/jsx-test-suite` snippets unexercised, on purpose for now
     exact_parser: None,
     ignore: IGNORE,
     skip_spec: Some(skip_unsupported_options),


### PR DESCRIPTION
For now, `jsx-test-suite` are off by intension. Almost all cases are already covered by our fixtures.
