### PR TITLE
fix(parser): reject return types on constructor overloads

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
@@ -269,7 +269,7 @@ fn test() {
                 }
             }",
         "class MyError extends Error {
-                constructor(): void;
+                constructor();
                 static {
                     Error.captureStackTrace(this, MyError)
                     function foo() {

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -894,10 +894,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // class Foo { constructor(this: number) {} }
             self.error(diagnostics::ts_constructor_this_parameter(this_param.span));
         }
-        if method.value.body.is_some()
-            && let Some(return_type) = &method.value.return_type
-        {
-            self.error(diagnostics::constructor_return_type(return_type.span));
+        if let Some(return_type) = &method.value.return_type {
+            self.error(diagnostics::constructor_return_type(return_type.type_annotation.span()));
         }
     }
 }

--- a/tasks/coverage/misc/fail/constructor-overload-return-type.ts
+++ b/tasks/coverage/misc/fail/constructor-overload-return-type.ts
@@ -1,0 +1,4 @@
+class C {
+  constructor(): C;
+  constructor() {}
+}

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 299/299 (100.00%)
-Positive Passed: 299/299 (100.00%)
+AST Parsed     : 300/300 (100.00%)
+Positive Passed: 300/300 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 98/98 (100.00%)
 Positive Passed: 98/98 (100.00%)
-Negative Passed: 201/201 (100.00%)
+Negative Passed: 202/202 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -374,6 +374,14 @@ Negative Passed: 201/201 (100.00%)
    · ─────
    ╰────
   help: Either remove this `await` or add the `async` keyword to the enclosing function
+
+  × TS(1093): Type annotation cannot appear on a constructor declaration.
+   ╭─[misc/fail/constructor-overload-return-type.ts:2:18]
+ 1 │ class C {
+ 2 │   constructor(): C;
+   ·                  ─
+ 3 │   constructor() {}
+   ╰────
 
   × A `continue` statement can only jump to a label of an enclosing `for`, `while` or `do while` statement.
    ╭─[misc/fail/continue-label-chain-non-iteration.js:1:1]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25350,10 +25350,10 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
 
   × TS(1093): Type annotation cannot appear on a constructor declaration.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts:2:16]
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts:2:18]
  1 │ class C {
  2 │   constructor(): number { }
-   ·                ────────
+   ·                  ──────
  3 │ }
    ╰────
 


### PR DESCRIPTION
Constructor overloads and ambient signatures previously bypassed the return type check because it required a body. Reject their return annotations with TS1093, matching constructor implementations.

Highlight only the return type itself, excluding the colon and preceding whitespace.
