### PR TITLE
fix(linter): compare label text in runtime optimization assertion

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -134,8 +134,14 @@ fn cmp_diagnostics_for_runtime_optimization_assertion(
     left.error
         .labels
         .iter()
-        .map(|label| (label.offset(), label.len(), label.primary()))
-        .cmp(right.error.labels.iter().map(|label| (label.offset(), label.len(), label.primary())))
+        .map(|label| (label.offset(), label.len(), label.primary(), label.label()))
+        .cmp(
+            right
+                .error
+                .labels
+                .iter()
+                .map(|label| (label.offset(), label.len(), label.primary(), label.label())),
+        )
         .then_with(|| left.error.message.cmp(&right.error.message))
         .then_with(|| left.error.help.cmp(&right.error.help))
         .then_with(|| left.error.note.cmp(&right.error.note))


### PR DESCRIPTION
Include label text when sorting diagnostics for the optimized/unoptimized runtime assertion. Diagnostics with identical spans and messages but different labels previously compared equal, so sorting could pair different diagnostics and trigger a false assertion failure.

Fixes the assertion seen in the [Kibana ecosystem CI job](https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/34459300249/job/102815162719).
