### PR TITLE
fix(parser): require arrow separator in TypeScript function types

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -53,7 +53,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         });
         let return_type = {
             let return_type_start = self.cur_start();
-            let return_type = self.parse_return_type();
+            let return_type = self.parse_return_type(Kind::Arrow);
             TSTypeAnnotation::boxed(self.end_span(return_type_start), return_type, self)
         };
 
@@ -1322,12 +1322,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return None;
         }
         let start = self.cur_start();
-        let return_type = self.parse_return_type();
+        let return_type = self.parse_return_type(Kind::Colon);
         Some(TSTypeAnnotation::boxed(self.end_span(start), return_type, self))
     }
 
-    fn parse_return_type(&mut self) -> TSType<'a> {
-        self.bump_any();
+    fn parse_return_type(&mut self, separator: Kind) -> TSType<'a> {
+        self.expect(separator);
         self.context_remove(Context::DisallowConditionalTypes, Self::parse_type_or_type_predicate)
     }
 

--- a/tasks/coverage/misc/fail/ts-abstract-constructor-type-colon-separator.ts
+++ b/tasks/coverage/misc/fail/ts-abstract-constructor-type-colon-separator.ts
@@ -1,0 +1,1 @@
+type F = abstract new () : number;

--- a/tasks/coverage/misc/fail/ts-abstract-constructor-type-missing-separator.ts
+++ b/tasks/coverage/misc/fail/ts-abstract-constructor-type-missing-separator.ts
@@ -1,0 +1,1 @@
+type F = abstract new ()  number;

--- a/tasks/coverage/misc/fail/ts-abstract-constructor-type-plus-separator.ts
+++ b/tasks/coverage/misc/fail/ts-abstract-constructor-type-plus-separator.ts
@@ -1,0 +1,1 @@
+type F = abstract new () + number;

--- a/tasks/coverage/misc/fail/ts-constructor-type-colon-separator.ts
+++ b/tasks/coverage/misc/fail/ts-constructor-type-colon-separator.ts
@@ -1,0 +1,1 @@
+type F = new () : number;

--- a/tasks/coverage/misc/fail/ts-constructor-type-missing-separator.ts
+++ b/tasks/coverage/misc/fail/ts-constructor-type-missing-separator.ts
@@ -1,0 +1,1 @@
+type F = new ()  number;

--- a/tasks/coverage/misc/fail/ts-constructor-type-plus-separator.ts
+++ b/tasks/coverage/misc/fail/ts-constructor-type-plus-separator.ts
@@ -1,0 +1,1 @@
+type F = new () + number;

--- a/tasks/coverage/misc/fail/ts-function-type-colon-separator.ts
+++ b/tasks/coverage/misc/fail/ts-function-type-colon-separator.ts
@@ -1,0 +1,1 @@
+type F = () : number;

--- a/tasks/coverage/misc/fail/ts-function-type-plus-separator.ts
+++ b/tasks/coverage/misc/fail/ts-function-type-plus-separator.ts
@@ -1,0 +1,1 @@
+type F = () + number;

--- a/tasks/coverage/misc/pass/ts-function-type-separators.ts
+++ b/tasks/coverage/misc/pass/ts-function-type-separators.ts
@@ -1,0 +1,7 @@
+type F = () => number;
+type C = new () => object;
+type A = abstract new () => object;
+type Predicate = (x: unknown) => x is number;
+function f(): number { return 1; }
+const arrow = (): number => 1;
+const object = { method(): number { return 1; } };

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 103/103 (100.00%)
-Positive Passed: 103/103 (100.00%)
+AST Parsed     : 104/104 (100.00%)
+Positive Passed: 104/104 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 103/103 (100.00%)
-Positive Passed: 103/103 (100.00%)
+AST Parsed     : 104/104 (100.00%)
+Positive Passed: 104/104 (100.00%)

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 305/305 (100.00%)
-Positive Passed: 305/305 (100.00%)
+AST Parsed     : 314/314 (100.00%)
+Positive Passed: 314/314 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 103/103 (100.00%)
-Positive Passed: 103/103 (100.00%)
-Negative Passed: 202/202 (100.00%)
+AST Parsed     : 104/104 (100.00%)
+Positive Passed: 104/104 (100.00%)
+Negative Passed: 210/210 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -4760,6 +4760,62 @@ Negative Passed: 202/202 (100.00%)
  1 │ interface I { f(this: T x: T): void }
    ·                         ┬
    ·                         ╰── `,` expected
+   ╰────
+
+  × Expected `=>` but found `:`
+   ╭─[misc/fail/ts-abstract-constructor-type-colon-separator.ts:1:26]
+ 1 │ type F = abstract new () : number;
+   ·                          ┬
+   ·                          ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `number`
+   ╭─[misc/fail/ts-abstract-constructor-type-missing-separator.ts:1:27]
+ 1 │ type F = abstract new ()  number;
+   ·                           ───┬──
+   ·                              ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `+`
+   ╭─[misc/fail/ts-abstract-constructor-type-plus-separator.ts:1:26]
+ 1 │ type F = abstract new () + number;
+   ·                          ┬
+   ·                          ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `:`
+   ╭─[misc/fail/ts-constructor-type-colon-separator.ts:1:17]
+ 1 │ type F = new () : number;
+   ·                 ┬
+   ·                 ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `number`
+   ╭─[misc/fail/ts-constructor-type-missing-separator.ts:1:18]
+ 1 │ type F = new ()  number;
+   ·                  ───┬──
+   ·                     ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `+`
+   ╭─[misc/fail/ts-constructor-type-plus-separator.ts:1:17]
+ 1 │ type F = new () + number;
+   ·                 ┬
+   ·                 ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `:`
+   ╭─[misc/fail/ts-function-type-colon-separator.ts:1:13]
+ 1 │ type F = () : number;
+   ·             ┬
+   ·             ╰── `=>` expected
+   ╰────
+
+  × Expected `=>` but found `+`
+   ╭─[misc/fail/ts-function-type-plus-separator.ts:1:13]
+ 1 │ type F = () + number;
+   ·             ┬
+   ·             ╰── `=>` expected
    ╰────
 
   × TS(1009): Trailing comma not allowed.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -7560,20 +7560,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  15 │ }
     ╰────
 
-  × Expected `,` or `)` but found `var`
-   ╭─[typescript/tests/cases/compiler/functionTypesLackingReturnTypes.ts:2:11]
+  × Expected `=>` but found `)`
+   ╭─[typescript/tests/cases/compiler/functionTypesLackingReturnTypes.ts:2:17]
  1 │ // Error (no '=>')
  2 │ function f(x: ()) {
-   ·           ┬
-   ·           ╰── Opened here
+   ·                 ┬
+   ·                 ╰── `=>` expected
  3 │ }
-   ╰────
-   ╭─[typescript/tests/cases/compiler/functionTypesLackingReturnTypes.ts:6:1]
- 5 │ // Error (no '=>')
- 6 │ var g: (param);
-   · ─┬─
-   ·  ╰── `,` or `)` expected
- 7 │ 
    ╰────
 
   × Identifier `total` has already been declared

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 103/103 (100.00%)
-Positive Passed: 99/103 (96.12%)
+AST Parsed     : 104/104 (100.00%)
+Positive Passed: 100/104 (96.15%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 103/103 (100.00%)
-Positive Passed: 103/103 (100.00%)
+AST Parsed     : 104/104 (100.00%)
+Positive Passed: 104/104 (100.00%)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 276/404
+Passed: 277/405
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -48,7 +48,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (41/60)
+# babel-plugin-transform-typescript (42/61)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/input.ts
@@ -1,0 +1,3 @@
+const a = true, b = 1, c = 2;
+const f = a ? (b) : (): any => b ? c : (x = 1): any => x;
+console.log(typeof f);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-typescript"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/oxc/function-type-separator/output.js
@@ -1,0 +1,3 @@
+const a = true, b = 1, c = 2;
+const f = a ? b : () => b ? c : (x = 1) => x;
+console.log(typeof f);


### PR DESCRIPTION
Require `=>` when parsing TypeScript function and constructor types, while retaining `:` for function, method, and arrow return annotations. Previously, any token could be consumed as the separator, accepting invalid types such as `type F = (): number` and `type F = new () + number`.

This also prevents a valid conditional expression from being silently grouped into the wrong arrows:

```ts
const a = true, b = 1, c = 2;
const f = a ? (b) : (): any => b ? c : (x = 1): any => x;
console.log(typeof f);
```

The transformed program now prints `number`; previously it printed `function`.
