### PR TITLE
fix(parser): retry contextual conditional-arrow speculation

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -521,6 +521,22 @@ fn ts_satisfies_expression() {
 }
 
 #[test]
+fn conditional_arrow_cache() {
+    for preserve_parens in [false, true] {
+        let options = ParseOptions { preserve_parens, ..Default::default() };
+        for (source, expected) in [
+            ("a ? (b) : x => x ? c : (): any => b;", "a ? b : (x) => x ? c : (): any => b;\n"),
+            ("a ? (b) : x => x;", "a ? b : (x) => x;\n"),
+            ("a ? x => ({ b }) : y => ({ c });", "a ? (x) => ({ b }) : (y) => ({ c });\n"),
+            ("a ? (x): any => x : b;", "a ? (x): any => x : b;\n"),
+        ] {
+            test_with_parse_options(source, expected, options);
+            test_with_parse_options(expected, expected, options);
+        }
+    }
+}
+
+#[test]
 fn type_codegen_with_preserve_parens_off() {
     let parse_options = ParseOptions { preserve_parens: false, ..Default::default() };
 

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -406,36 +406,3 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         Some(body)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use oxc_allocator::Allocator;
-    use oxc_span::SourceType;
-
-    use crate::{ParseOptions, ParserImpl, UniquePromise, config::NoTokensParserConfig};
-
-    #[test]
-    fn failed_speculation_cache_respects_return_type_context() {
-        for source in ["(): any => b", "(c): y => x ? (c) : y => (): any => b"] {
-            let allocator = Allocator::default();
-            let mut parser = ParserImpl::new(
-                &allocator,
-                source,
-                SourceType::ts(),
-                ParseOptions::default(),
-                NoTokensParserConfig,
-                UniquePromise::new_for_tests_and_benchmarks(),
-            );
-            parser.token = parser.lexer.first_token();
-            assert!(parser.parse_possible_parenthesized_arrow_function_expression(false).is_none());
-            let used_bytes = allocator.used_bytes();
-            // Repeating the rejected speculation must not allocate another speculative AST.
-            assert!(parser.parse_possible_parenthesized_arrow_function_expression(false).is_none());
-            assert_eq!(allocator.used_bytes(), used_bytes);
-            // The cached rejection must not prevent parsing in the unrestricted context.
-            assert!(parser.parse_possible_parenthesized_arrow_function_expression(true).is_some());
-            assert!(parser.fatal_error.is_none(), "{source}");
-            assert!(parser.errors.is_empty());
-        }
-    }
-}

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -352,8 +352,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         allow_return_type_in_arrow_function: bool,
     ) -> Option<Expression<'a>> {
-        let pos = self.cur_token().start();
-        if self.state.not_parenthesized_arrow.contains(&pos) {
+        let key = (self.cur_token().start(), allow_return_type_in_arrow_function);
+        if self.state.not_parenthesized_arrow.contains(&key) {
             return None;
         }
 
@@ -361,7 +361,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let head = self.parse_parenthesized_arrow_function_head();
         if self.has_fatal_error() {
-            self.state.not_parenthesized_arrow.insert(pos);
+            self.state.not_parenthesized_arrow.insert(key);
             self.rewind(checkpoint);
             return None;
         }
@@ -395,14 +395,47 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
             // A colon reached after a fatal body error does not validate the speculation.
             if self.has_fatal_error() || !self.at(Kind::Colon) {
-                // This rejection depends on the enclosing conditional, not the arrow head.
-                // An outer speculation can rewind and revisit this position where a return
-                // type is allowed, so do not cache it as a non-arrow.
+                // Cache this rejection only for the current return-type context. An outer
+                // speculation can rewind and revisit this position where a return type is allowed.
+                self.state.not_parenthesized_arrow.insert(key);
                 self.rewind(checkpoint);
                 return None;
             }
         }
 
         Some(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+    use oxc_span::SourceType;
+
+    use crate::{ParseOptions, ParserImpl, UniquePromise, config::NoTokensParserConfig};
+
+    #[test]
+    fn failed_speculation_cache_respects_return_type_context() {
+        for source in ["(): any => b", "(c): y => x ? (c) : y => (): any => b"] {
+            let allocator = Allocator::default();
+            let mut parser = ParserImpl::new(
+                &allocator,
+                source,
+                SourceType::ts(),
+                ParseOptions::default(),
+                NoTokensParserConfig,
+                UniquePromise::new_for_tests_and_benchmarks(),
+            );
+            parser.token = parser.lexer.first_token();
+            assert!(parser.parse_possible_parenthesized_arrow_function_expression(false).is_none());
+            let used_bytes = allocator.used_bytes();
+            // Repeating the rejected speculation must not allocate another speculative AST.
+            assert!(parser.parse_possible_parenthesized_arrow_function_expression(false).is_none());
+            assert_eq!(allocator.used_bytes(), used_bytes);
+            // The cached rejection must not prevent parsing in the unrestricted context.
+            assert!(parser.parse_possible_parenthesized_arrow_function_expression(true).is_some());
+            assert!(parser.fatal_error.is_none(), "{source}");
+            assert!(parser.errors.is_empty());
+        }
     }
 }

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -393,8 +393,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // the conditional expression. It's okay to do this because this code would
             // be a syntax error in JavaScript (as the second colon shouldn't be there).
 
-            if !self.at(Kind::Colon) {
-                self.state.not_parenthesized_arrow.insert(pos);
+            // A colon reached after a fatal body error does not validate the speculation.
+            if self.has_fatal_error() || !self.at(Kind::Colon) {
+                // This rejection depends on the enclosing conditional, not the arrow head.
+                // An outer speculation can rewind and revisit this position where a return
+                // type is allowed, so do not cache it as a non-arrow.
                 self.rewind(checkpoint);
                 return None;
             }

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -6,7 +6,8 @@ use oxc_span::Span;
 use crate::cursor::ParserCheckpoint;
 
 pub struct ParserState<'a> {
-    pub not_parenthesized_arrow: FxHashSet<u32>,
+    /// Failed arrow speculations keyed by position and whether a return type is allowed.
+    pub not_parenthesized_arrow: FxHashSet<(u32, bool)>,
 
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.

--- a/tasks/coverage/misc/pass/conditional-arrow-cache.ts
+++ b/tasks/coverage/misc/pass/conditional-arrow-cache.ts
@@ -1,0 +1,11 @@
+const a = true, b = 1, c = 2;
+const f: number | ((x: number) => any) = a ? (b) : x => x ? c : (): any => b;
+
+// The first colon ends the consequent; the alternate contains a typed arrow.
+a ? (b) : x => x ? c : (): number => b;
+a ? (b) : x => x ? c : y => y ? c : (): any => b;
+
+// Keep colons that terminate conditional consequents distinct from return types.
+a ? (b) : x => x;
+a ? x => ({ b }) : y => ({ c });
+a ? (x): any => x : b;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 104/104 (100.00%)
-Positive Passed: 104/104 (100.00%)
+AST Parsed     : 105/105 (100.00%)
+Positive Passed: 105/105 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 104/104 (100.00%)
-Positive Passed: 104/104 (100.00%)
+AST Parsed     : 105/105 (100.00%)
+Positive Passed: 105/105 (100.00%)

--- a/tasks/coverage/snapshots/lexer_misc.snap
+++ b/tasks/coverage/snapshots/lexer_misc.snap
@@ -1,3 +1,3 @@
 lexer_misc Summary:
-AST Parsed     : 314/314 (100.00%)
-Positive Passed: 314/314 (100.00%)
+AST Parsed     : 315/315 (100.00%)
+Positive Passed: 315/315 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 104/104 (100.00%)
-Positive Passed: 104/104 (100.00%)
+AST Parsed     : 105/105 (100.00%)
+Positive Passed: 105/105 (100.00%)
 Negative Passed: 210/210 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 104/104 (100.00%)
-Positive Passed: 100/104 (96.15%)
+AST Parsed     : 105/105 (100.00%)
+Positive Passed: 101/105 (96.19%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 104/104 (100.00%)
-Positive Passed: 104/104 (100.00%)
+AST Parsed     : 105/105 (100.00%)
+Positive Passed: 105/105 (100.00%)


### PR DESCRIPTION
The parser rejects valid nested conditional arrows such as:

```ts
a ? (b) : x => x ? c : (): any => b;
```

Rewind conditional-arrow speculation when its body hits a fatal error, even if parsing stops at a colon. Cache failed speculation by source position and whether a return type is allowed, so a rejection in a conditional consequent does not prevent a later parse in the unrestricted context. Keeping context-aware memoization avoids repeatedly parsing and allocating the same nested suffix after rewinds.
