### PR TITLE
perf(linter/react/jsx-pascal-case): avoid temporary name segment vector

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -145,13 +145,14 @@ impl Rule for JsxPascalCase {
             return;
         }
 
-        let check_names: Vec<&str> = if is_namespaced_name {
-            name.split(':').collect()
+        let separator = if is_namespaced_name {
+            Some(':')
         } else if is_member_expression {
-            name.split('.').collect()
+            Some('.')
         } else {
-            vec![name]
+            None
         };
+        let check_names = name.split(|ch| Some(ch) == separator);
 
         for split_name in check_names {
             if split_name.len() == 1 {


### PR DESCRIPTION
Iterate JSX name segments directly instead of collecting them into a temporary vector. Namespaced names still split on `:`, member expressions on `.`, and simple names remain a single segment.
