### PR TITLE
fix(formatter): unify suppress comment behavior

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -164,27 +164,28 @@ that is FORMATTER_POLICY's uniform-rule ground (reason 3): one rule over the emu
 ### Statement terminators and suppression
 
 The formatter owns statement terminators (and the trivia up to them); the user owns content.
-Prettier encodes "the trailing `;` is outside the statement" once, in `locEnd`;
-deciding on the spot, we encode the same policy per site, so keep them in step:
 
 - print side: `FormatContentWithSemicolon` and the move-behind table above
 - return/throw: the same-line-prefix dangling split in `ReturnAndThrowStatement`
 - capture side: `Comments::get_trailing_comments` lets deferred own-line comments escape when the statement shares its distant `;` with the enclosing statement
   (a single-statement body, `if (1) foo\n// c\n;`); a block's last statement keeps them inside instead
-- suppressed side: `suppressed_statement_content_end` (`print/mod.rs`) ends the ignored range at the content,
-  so even a `prettier-ignore`d statement gets the formatter's terminator (per `semi`) instead of its source one
+- suppressed side: a suppressed node keeps the token classes above: content verbatim, terminator per `semi`
+  (`write_suppressed_statement`, `FormatClassElementWithSemicolon`); a node without a terminator of its own prints its whole span.
+  Prettier re-adds a statement's `;` only when the source had one and prints class members whole (DIVERGENCES.md#suppressed-terminator-per-semi)
+  - A statement is decided before its own generated `fmt`, so leading and trailing comments take one path and a pre-`export` decorator is inside the ignored range (`statement_span`)
+  - Any site printing a statement outside the generated `Statement` fmt (an `if` consequent before `else`) must ask `write_suppressed_statement` first,
+    or the generic verbatim path prints the source `;` regardless of `semi`
+  - The import sorter's partition test and the printer share `is_node_suppressed`: a suppressed import must be a boundary to both
+  - Keep `suppressed_statement_content_end` in step with the reprint's `;`-printing sites (`FormatContentWithSemicolon` / `OptionalSemicolon`): same content end, same terminator
+  - A `for` head declaration has no terminator of its own and stays verbatim (DIVERGENCES.md#suppressed-for-head-declaration)
 - suppressed expression side: `write_suppressed_expression` (`utils/suppressed.rs`) owns the whole sequence
-  for expression-shaped nodes (the generated `fmt` and the arrow sequence-body site call it before anything of the node is printed), so a cast target keeps its source cast parens (excluded from its span, `utils/typecast.rs`'s `write_suppressed_cast_target`) and in-paren comments print in place via the verbatim range
+  for expression-shaped nodes (the generated `fmt` and the arrow sequence-body site call it before anything of the node is printed),
+  so a cast target keeps its source cast parens (excluded from its span, `utils/typecast.rs`'s `write_suppressed_cast_target`) and in-paren comments print in place via the verbatim range
 
-Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
+Accepted edges (semantically inert, idempotent):
 
-- Whether a suppressed statement re-adds `;` is a compat table, not a principle:
-  keyword statements (`debugger`/`break`/`continue`) and variable declarations (ignored range ends at the last declarator) always re-add;
-  content-terminated ones, including `export const` (measured, keep the asymmetry), only when a source `;` was stripped.
-  A `for` head declaration instead stays verbatim (DIVERGENCES.md#suppressed-for-head-declaration)
-- The `semi: false` ASI guard is decided from the guarded statement alone,
-  never from the previous statement's output;
-  sound because no statement leaves its own trailing `;`,
+- The `semi: false` ASI guard is decided from the guarded statement alone, never from the previous statement's output;
+  sound because no statement leaves its own trailing `;` (a suppressed one hands it back to the formatter),
   except a verbatim empty-statement body (`with (1) ;`, that `;` IS the body, i.e. content), where guard plus verbatim `;` re-parse as one extra inert `EmptyStatement`
 
 ## Verification

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -455,6 +455,39 @@ Prettier's `shouldIgnoredNodePrintSemicolon` lists `VariableDeclaration` uncondi
 so a suppressed declaration in a `for` head gets an extra `;` and the head no longer parses (a `for (;;)` head admits exactly two semicolons).
 In the head the declaration has no terminator of its own; we keep it verbatim and let the `for` statement print its separators.
 
+## suppressed-terminator-per-semi
+
+- Why: uniform-rule (same construct, same output: suppressed statement)
+- Pin: `tests/fixtures/js/semicolons/suppressed-statement.js`, `tests/fixtures/ts/semicolons/suppressed-class-member.ts`
+
+```js
+// input (semi: true)
+stmt(   ) // prettier-ignore
+a => a
+class C {
+  q   = 2 // prettier-ignore
+}
+
+// ours
+stmt(   ); // prettier-ignore
+(a) => a;
+class C {
+  q   = 2; // prettier-ignore
+}
+
+// prettier
+stmt(   ) // prettier-ignore
+(a) => a;
+class C {
+  q   = 2 // prettier-ignore
+}
+```
+
+A suppression comment protects content; a terminator the formatter owns (a statement's or class member's `;`, the token-class table in AGENTS.md) follows `semi` as it does everywhere else.
+Prettier prints that way for statements whose source had a `;` (its `__contentEnd`), but leaves a `;`-less statement alone (the output above re-parses as `stmt(   )(a) => a`, a syntax error),
+and prints class members, type aliases and `declare function`s whole, `;` included, so `semi: false` keeps a `;` there and `semi: true` never adds one.
+One rule instead, the statement's, for every terminator-owned node.
+
 ## suppressed-source-paren-asi-guard
 
 - Why: semantics (Prettier's output re-parses as a call)
@@ -506,7 +539,8 @@ We check the verbatim range's first byte instead and print the guard.
 A cast comment types its parenthesized expression only when directly adjacent:
 with Prettier's placement tsc reports the target as its uncast type again.
 
-Prettier's `printIgnored` prepends the guard to the ignored slice, which starts after the leading comments; we reuse the reprint path's split (`ExpressionStatement::write`), so the guard, the cast comment, and the verbatim content print in that order.
+Prettier's `printIgnored` prepends the guard to the ignored slice, which starts after the leading comments;
+we reuse the reprint path's split (`write_leading_comments_with_asi_guard`, called from `write_suppressed_statement`), so the guard, the cast comment, and the verbatim content print in that order.
 
 ## cast-comment-inside-added-parens
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -13,7 +13,7 @@ use crate::{
         trivia::{format_leading_comments, format_trailing_comments},
     },
     parentheses::NeedsParentheses,
-    print::FormatWrite,
+    print::{FormatWrite, semicolon::write_suppressed_statement},
     utils::{
         suppressed::{FormatSuppressedNode, write_suppressed_expression},
         typecast::{
@@ -473,10 +473,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Expression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -486,7 +486,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -517,10 +517,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -530,10 +530,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -543,7 +543,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -574,7 +574,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -646,10 +646,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpressionElement<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -659,7 +659,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -720,10 +720,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPropertyKind<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -774,7 +774,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyKey<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -805,7 +805,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -836,10 +836,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -889,7 +889,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -920,7 +920,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -951,7 +951,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -982,7 +982,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1013,7 +1013,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1044,7 +1044,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1075,7 +1075,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1106,10 +1106,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SpreadElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1150,7 +1150,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Argument<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1181,7 +1181,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1212,7 +1212,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1243,7 +1243,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1274,7 +1274,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1305,7 +1305,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1336,7 +1336,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1500,10 +1500,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPattern
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1513,10 +1513,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1526,10 +1526,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1570,10 +1570,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetMaybeDe
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1613,10 +1613,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1626,10 +1626,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1639,7 +1639,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1670,7 +1670,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1701,7 +1701,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1732,7 +1732,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1804,7 +1804,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1836,11 +1836,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Statement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if !matches!(self.inner, Statement::ExpressionStatement(_))
-            && f.comments().has_trailing_suppression_comment(self.span().end)
-        {
-            format_leading_comments(self.span()).fmt(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+        if write_suppressed_statement(self, f) {
             format_trailing_comments(
                 self.parent.span(),
                 self.inner.span(),
@@ -2060,10 +2056,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Statement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2073,10 +2069,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2086,10 +2082,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BlockStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2209,10 +2205,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Declaration<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2222,10 +2218,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2235,10 +2231,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2248,10 +2244,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2261,10 +2257,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2274,10 +2270,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2287,10 +2283,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2300,10 +2296,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2344,10 +2340,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementInit<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForInStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2388,10 +2384,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementLeft<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2401,10 +2397,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2414,10 +2410,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2427,10 +2423,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2440,10 +2436,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2453,10 +2449,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2466,10 +2462,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2479,10 +2475,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2492,10 +2488,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2505,10 +2501,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2518,10 +2514,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2531,10 +2527,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2544,10 +2540,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DebuggerStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2607,10 +2603,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2620,10 +2616,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2633,10 +2629,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2646,10 +2642,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2659,10 +2655,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2672,7 +2668,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2703,10 +2699,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2716,10 +2712,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2729,10 +2725,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2742,10 +2738,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FunctionBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2786,7 +2782,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionBody<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2817,7 +2813,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2848,7 +2844,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2879,10 +2875,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2892,10 +2888,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2965,10 +2961,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2978,10 +2974,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2991,10 +2987,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3004,10 +3000,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3107,10 +3103,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3120,7 +3116,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3151,10 +3147,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3204,10 +3200,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclarationSpecif
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3217,10 +3213,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3230,10 +3226,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3243,10 +3239,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifie
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3256,10 +3252,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3299,23 +3295,16 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttributeKey<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
-            self.format_trailing_comments(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
     }
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3325,10 +3314,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3338,23 +3327,16 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
-            self.format_trailing_comments(f);
-        } else {
-            self.write(f);
-        }
+        self.write(f);
     }
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3364,10 +3346,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3468,7 +3450,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleExportName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3499,7 +3481,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3530,7 +3512,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3561,7 +3543,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3592,7 +3574,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3623,7 +3605,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3654,7 +3636,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3701,10 +3683,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3714,10 +3696,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3743,10 +3725,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXFragment<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3756,10 +3738,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3829,10 +3811,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElementName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3842,10 +3824,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3895,10 +3877,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpressionObje
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpressionContainer<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3939,10 +3921,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXEmptyExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3982,10 +3964,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeItem<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3995,10 +3977,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4088,10 +4070,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeValue<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4161,10 +4143,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4174,10 +4156,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4187,10 +4169,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4200,10 +4182,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4213,10 +4195,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4226,10 +4208,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4289,10 +4271,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMemberName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4302,10 +4284,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4765,7 +4747,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4796,15 +4778,15 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4817,7 +4799,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4848,10 +4830,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4861,7 +4843,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4892,10 +4874,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4905,10 +4887,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4918,10 +4900,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4931,10 +4913,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4944,10 +4926,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4957,10 +4939,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSRestType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5011,10 +4993,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5024,10 +5006,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5037,10 +5019,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5050,10 +5032,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5063,10 +5045,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5076,10 +5058,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5089,10 +5071,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5102,10 +5084,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5115,10 +5097,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5128,10 +5110,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5141,10 +5123,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5154,10 +5136,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5167,10 +5149,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5180,10 +5162,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5193,10 +5175,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5246,10 +5228,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5259,10 +5241,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5272,10 +5254,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstanti
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5285,10 +5267,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5298,10 +5280,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5311,10 +5293,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5324,10 +5306,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5337,10 +5319,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5350,10 +5332,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSPropertySignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5423,10 +5405,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5436,10 +5418,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5449,10 +5431,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5462,10 +5444,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5475,10 +5457,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDec
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5488,10 +5470,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5501,10 +5483,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5544,10 +5526,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicateName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5557,10 +5539,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclara
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5600,10 +5582,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclarationB
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5613,10 +5595,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5626,10 +5608,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5639,7 +5621,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5670,7 +5652,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5732,10 +5714,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQueryExprName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5775,10 +5757,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifier<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5788,7 +5770,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedNa
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5819,7 +5801,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5850,10 +5832,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5863,10 +5845,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5876,7 +5858,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5907,7 +5889,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5938,7 +5920,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5969,10 +5951,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6022,10 +6004,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleReference<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6035,7 +6017,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReferen
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -6066,10 +6048,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6079,10 +6061,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6092,10 +6074,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6105,7 +6087,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclar
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -6136,10 +6118,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6149,10 +6131,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -6162,10 +6144,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocUnknownType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            FormatSuppressedNode(self.span()).fmt(f);
         } else {
             self.write(f);
         }

--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -8,9 +8,7 @@ use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use crate::utils::{
-    export_declaration_span, export_default_declaration_span, is_dropped_statement,
-};
+use crate::utils::{is_dropped_statement, statement_span};
 
 use super::{AstNode, AstNodes};
 
@@ -50,13 +48,7 @@ fn get_statement_span(stmt: &Statement<'_>) -> Option<u32> {
     if is_dropped_statement(stmt) {
         return None;
     }
-    Some(match stmt {
-        Statement::ExportDefaultDeclaration(export) => {
-            export_default_declaration_span(export).start
-        }
-        Statement::ExportDeclaration(export) => export_declaration_span(export).start,
-        _ => stmt.span().start,
-    })
+    Some(statement_span(stmt).start)
 }
 
 macro_rules! impl_ast_node_vec {

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -107,6 +107,12 @@ impl<'a, T> AstNode<'a, T> {
         &self.parent
     }
 
+    /// The start of the following sibling node (0 if none), the bound of this node's trailing comments.
+    #[inline]
+    pub fn following_span_start(&self) -> u32 {
+        self.following_span_start
+    }
+
     /// Returns the grandparent node (parent's parent).
     ///
     /// This is a convenience method equivalent to `self.parent().parent()`.

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -291,8 +291,7 @@ impl<'a> Comments<'a> {
     /// Returns comments that end at or after the given position.
     pub fn comments_after(&self, pos: u32) -> &'a [Comment] {
         let comments = self.unprinted_comments();
-        let start_index = comments.iter().take_while(|c| c.span.end < pos).count();
-        &comments[start_index..]
+        &comments[comments.partition_point(|c| c.span.end < pos)..]
     }
 
     /// Returns comments between the given positions.
@@ -547,6 +546,28 @@ impl<'a> Comments<'a> {
         self.end_of_line_comments_after(pos)
             .iter()
             .any(|comment| self.is_suppression_comment(comment))
+    }
+
+    /// Whether a node whose terminator the formatter owns is suppressed by a leading comment or a trailing one:
+    /// on its line after the `;` (`foo(); // prettier-ignore`),
+    /// or after the content when the source `;` sits on a later line (`foo() // prettier-ignore` + `;[].sort()`, the `semi: false` style).
+    /// `content_end` is asked only for that last shape (the span's last comment is a suppression comment).
+    pub fn is_node_suppressed(
+        &self,
+        span: Span,
+        content_end: impl FnOnce() -> Option<u32>,
+    ) -> bool {
+        // The common case, every statement pays this check
+        if self.unprinted_comments().is_empty() {
+            return false;
+        }
+        if self.is_suppressed(span.start) || self.has_trailing_suppression_comment(span.end) {
+            return true;
+        }
+        let Some(last) = self.all_comments_before(span.end).last() else { return false };
+        last.span.start >= span.start
+            && self.is_suppression_comment(last)
+            && content_end().is_some_and(|end| self.has_trailing_suppression_comment(end))
     }
 
     /// Whether the range holds a `;` or a `)` outside comments (`foo /* ; */` doesn't count).

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -12,11 +12,16 @@ use crate::{
     formatter::{
         prelude::*,
         separated::FormatSeparatedIter,
-        trivia::{FormatLeadingComments, FormatTrailingComments},
+        trivia::{
+            FormatLeadingComments, FormatTrailingComments, format_leading_comments,
+            format_trailing_comments,
+        },
     },
     parentheses::NeedsParentheses,
     print::{
-        function::should_group_function_parameters,
+        function::{
+            function_content_end, function_signature_end, should_group_function_parameters,
+        },
         semicolon::{
             OptionalSemicolon, assignment_chain_leaf_end,
             trailing_comments_to_move_behind_semicolon,
@@ -31,6 +36,7 @@ use crate::{
         is_keyword_property_key,
         object::{format_property_key, should_preserve_quote},
         statement_body::write_head_body_separator,
+        suppressed::write_suppressed_content,
     },
     write,
 };
@@ -146,10 +152,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
         let node_end = self.span.end;
         let comments = f.context().comments().comments_before(node_end);
         if !comments.is_empty() {
-            let content_end = f.comments().end_including_source_parens(
-                value.return_type().map_or_else(|| value.params().span.end, |rt| rt.span.end),
-                node_end,
-            );
+            let content_end = function_signature_end(value, f);
             if let Some(trailing_comments) =
                 trailing_comments_to_move_behind_semicolon(f, content_end, node_end)
             {
@@ -600,46 +603,77 @@ impl<'a, 'b> FormatClassElementWithSemicolon<'a, 'b> {
     }
 }
 
+impl FormatClassElementWithSemicolon<'_, '_> {
+    /// Where the element's content ends and its `;` takes over, for the kinds that take one:
+    /// a property's value (the chain leaf, like an expression statement), type annotation or key,
+    /// a bodyless method's signature, an index signature's type.
+    /// A definite/optional marker may sit between it and the `;` (`z? /* e */;`);
+    /// a comment there still ends up behind the semicolon like Prettier.
+    fn content_end(&self, f: &JsFormatter<'_, '_>) -> Option<u32> {
+        let (value, type_annotation, key) = match self.element.as_ref() {
+            ClassElement::PropertyDefinition(def) => (&def.value, &def.type_annotation, &def.key),
+            ClassElement::AccessorProperty(def) => (&def.value, &def.type_annotation, &def.key),
+            ClassElement::MethodDefinition(def) => return function_content_end(&def.value, f),
+            ClassElement::TSIndexSignature(def) => return Some(def.type_annotation.span.end),
+            ClassElement::StaticBlock(_) => return None,
+        };
+        Some(
+            value
+                .as_ref()
+                .map(|value| assignment_chain_leaf_end(value, f))
+                .or_else(|| type_annotation.as_ref().map(|ta| ta.span.end))
+                .unwrap_or_else(|| key.span().end),
+        )
+    }
+}
+
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let needs_semi = matches!(
-            self.element.as_ref(),
+        let element = self.element;
+        let span = element.span();
+        let is_property = matches!(
+            element.as_ref(),
             ClassElement::PropertyDefinition(_) | ClassElement::AccessorProperty(_)
         );
-
-        let needs_semi = needs_semi
+        let needs_semi = is_property
             && match f.options().semicolons {
                 Semicolons::Always => true,
                 Semicolons::AsNeeded => self.needs_semicolon(),
-            }
-            // Don't add semicolon if the element is suppressed (has `oxfmt-ignore`),
-            // because the suppressed source text already includes the original semicolon.
-            && !f.comments().is_suppressed(self.element.span().start);
+            };
 
-        if needs_semi {
+        // A suppressed element (leading or trailing comment) prints its content verbatim
+        // and its terminator stays the formatter's, like a statement (`write_suppressed_statement`).
+        // The element kinds' generated `fmt` only see a leading comment, so the gate is here.
+        let suppressed = f.comments().is_node_suppressed(span, || self.content_end(f));
+        if !suppressed && !needs_semi {
+            return write!(f, element);
+        }
+
+        if suppressed {
+            format_leading_comments(span).fmt(f);
+            // The verbatim range keeps the source parens the reprint would drop (`p = (q = 1)`),
+            // which the comment-move boundary `content_end` stops short of.
+            let verbatim_end = self
+                .content_end(f)
+                .map(|end| f.comments().end_including_source_parens(end, span.end));
+            if write_suppressed_content(span, verbatim_end, f) {
+                if is_property {
+                    if needs_semi {
+                        write!(f, ";");
+                    }
+                } else {
+                    // A bodyless method / index signature: the formatter's `;`, per `semi`
+                    OptionalSemicolon.fmt(f);
+                }
+            }
+        } else {
             // Same-line comments between the content end and the source semicolon
             // move behind it like Prettier: `x = 1 /* c */;` -> `x = 1; /* c */`
             // (the class element owns its own semicolon machinery,
             // so this cannot go through `FormatContentWithSemicolon`)
-            let node_end = self.element.span().end;
-            let (value, type_annotation, key) = match self.element.as_ref() {
-                ClassElement::PropertyDefinition(def) => {
-                    (&def.value, &def.type_annotation, &def.key)
-                }
-                ClassElement::AccessorProperty(def) => (&def.value, &def.type_annotation, &def.key),
-                _ => {
-                    unreachable!("Only `PropertyDefinition` and `AccessorProperty` can reach here");
-                }
-            };
-            // The value end is the chain leaf's, like an expression statement.
-            // A definite/optional marker may sit between `content_end` and the `;`
-            // (`z? /* e */;` -> `content_end` is after `z`);
-            // the comment still ends up behind the semicolon like Prettier.
-            let content_end = value
-                .as_ref()
-                .map(|value| assignment_chain_leaf_end(value, f))
-                .or_else(|| type_annotation.as_ref().map(|ta| ta.span.end))
-                .unwrap_or_else(|| key.span().end);
+            let node_end = span.end;
+            // A property always has a content end
+            let content_end = self.content_end(f).unwrap();
             // `node_end` bound: the element may have no source `;` at all
             // (a dropped-paren terminator, `p = (q = 1 /* c */)`).
             // The gate's same-line run moves behind the `;`,
@@ -647,25 +681,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a,
             if let Some(trailing_comments) =
                 trailing_comments_to_move_behind_semicolon(f, content_end, node_end)
             {
-                format_content_without_comments_after(self.element, content_end, f);
+                format_content_without_comments_after(element, content_end, f);
                 write!(f, [";", FormatTrailingComments::Comments(trailing_comments)]);
             } else {
-                write!(f, [FormatNodeWithoutTrailingComments(self.element), ";"]);
+                write!(f, [FormatNodeWithoutTrailingComments(element), ";"]);
             }
-            match self.element.as_ast_nodes() {
-                AstNodes::PropertyDefinition(prop) => {
-                    prop.format_trailing_comments(f);
-                }
-                AstNodes::AccessorProperty(prop) => {
-                    prop.format_trailing_comments(f);
-                }
-                _ => {
-                    unreachable!("Only `PropertyDefinition` and `AccessorProperty` can reach here");
-                }
-            }
-        } else {
-            write!(f, self.element);
         }
+        format_trailing_comments(element.parent().span(), span, element.following_span_start())
+            .fmt(f);
     }
 }
 

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -19,9 +19,7 @@ use crate::{
             semicolon_terminated_expression_content_end,
         },
     },
-    utils::{
-        decorators_before_export_start, export_declaration_span, export_default_declaration_span,
-    },
+    utils::decorators_before_export_start,
     write,
 };
 
@@ -122,10 +120,6 @@ fn format_export_specifiers_block<'a>(
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
-    fn suppressed_span(&self) -> Span {
-        export_default_declaration_span(self)
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let declaration = self.declaration();
         format_export_keyword_with_class_decorators(
@@ -172,10 +166,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportDeclaration<'a>> {
-    fn suppressed_span(&self) -> Span {
-        export_declaration_span(self)
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let declaration = self.declaration();
         format_export_keyword_with_class_decorators(

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -197,3 +197,16 @@ where
         }
     }
 }
+
+/// A bodyless function (`declare function f(): void;`, an overload, an abstract method) ends at its signature,
+/// extended over dropped source parens; one with a body has no terminator.
+pub fn function_content_end(function: &Function<'_>, f: &JsFormatter<'_, '_>) -> Option<u32> {
+    function.body.is_none().then(|| function_signature_end(function, f))
+}
+
+/// The end of a function's signature (its return type, else its parameters), extended over dropped source parens.
+pub fn function_signature_end(function: &Function<'_>, f: &JsFormatter<'_, '_>) -> u32 {
+    let signature_end =
+        function.return_type.as_ref().map_or(function.params.span.end, |rt| rt.span.end);
+    f.comments().end_including_source_parens(signature_end, function.span.end)
+}

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -54,8 +54,13 @@ pub fn format_source_with_clause_and_semicolon<'a>(
             write!(f, [with_clause]);
         }
     });
-    let content_end = with_clause.map_or(source.span.end, |with| with.span.end);
+    let content_end = module_source_end(source, with_clause.map(AsRef::as_ref));
     write!(f, FormatContentWithSemicolon::new(&content, content_end, span_end));
+}
+
+/// Where an import/export's content ends: its with-clause, else its source.
+pub fn module_source_end(source: &StringLiteral, with_clause: Option<&WithClause>) -> u32 {
+    with_clause.map_or(source.span.end, |with| with.span.end)
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -24,7 +24,7 @@ mod object_pattern_like;
 mod parameters;
 mod program;
 mod return_or_throw_statement;
-mod semicolon;
+pub mod semicolon;
 mod sequence_expression;
 mod switch_statement;
 mod template;
@@ -86,7 +86,7 @@ use crate::{
             write_trailing_comments_before,
         },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
-        suppressed::FormatSuppressedNode,
+        suppressed::{FormatSuppressedNode, write_suppressed_content},
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
         typecast::is_cast_target,
     },
@@ -110,16 +110,7 @@ use self::{
 
 pub trait FormatWrite<'ast> {
     fn write(&self, f: &mut JsFormatter<'_, 'ast>);
-    /// The source range printed verbatim when the node is suppressed (`oxfmt-ignore` / `prettier-ignore`),
-    /// also the bound for the suppression check and the suppressed leading comments in the generated `fmt`.
-    /// Defaults to the node's span; overridden when the range starts earlier
-    /// (class decorators before export (`@deco export class X {}`) sit outside the export node's span).
-    fn suppressed_span(&self) -> Span
-    where
-        Self: GetSpan,
-    {
-        self.span()
-    }
+
     /// Position bounding the node's leading comments in the generated `fmt`:
     /// pending comments ending at or before it print as the node's leading comments,
     /// OUTSIDE any formatter-added parentheses.
@@ -131,29 +122,6 @@ pub trait FormatWrite<'ast> {
         Self: GetSpan,
     {
         self.span().start
-    }
-    /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`):
-    /// prints `suppressed_span` verbatim.
-    /// Expression-shaped nodes don't route here: the generated `fmt` hands them to
-    /// `write_suppressed_expression`, which keeps a cast target's source parentheses.
-    ///
-    /// NOTE: Extend the overrides one statement at a time with verifying each.
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'ast>)
-    where
-        Self: GetSpan,
-    {
-        FormatSuppressedNode(self.suppressed_span()).fmt(f);
-    }
-
-    /// The leading-comments step of the suppressed path,
-    /// for nodes whose generated `fmt` leaves leading comments to the node;
-    /// it calls this, then [`Self::write_suppressed`].
-    /// Override to interleave with the comments (`ExpressionStatement`'s ASI guard).
-    fn write_suppressed_leading_comments(&self, f: &mut JsFormatter<'_, 'ast>)
-    where
-        Self: GetSpan,
-    {
-        format_leading_comments(self.suppressed_span()).fmt(f);
     }
 }
 
@@ -696,29 +664,8 @@ fn write_leading_comments_with_asi_guard<'a>(
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
-    fn write_suppressed_leading_comments(&self, f: &mut JsFormatter<'_, 'a>) {
-        // Prettier's `printIgnored` puts the guard after the cast comment and breaks the cast;
-        // ours goes before it (DIVERGENCES.md#suppressed-cast-comment-asi-guard)
-        write_leading_comments_with_asi_guard(self, true, f);
-    }
-
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the expression (plus source parens)
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.expression().span().end, self.span(), f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let span = self.span();
         write_leading_comments_with_asi_guard(self, false, f);
-
-        if f.comments().has_trailing_suppression_comment(span.end) {
-            // Preserve original text when the statement has an inline suppression comment:
-            // `stmt(); // prettier-ignore` or `stmt(); /* prettier-ignore */`
-            write!(f, [FormatSuppressedNode(span)]);
-            return;
-        }
 
         let expression = self.expression();
         let content_end = semicolon_terminated_expression_content_end(
@@ -732,135 +679,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-/// Prints a suppressed statement whose ignored range excludes the trailing semicolon:
-/// the source from `start` up to `content_end` verbatim,
-/// then the formatter's own terminator, like Prettier (prettier#18678).
-/// Comments between `content_end` and the end of the statement are left
-/// for the next node's leading-comments pass.
-fn write_suppressed_statement_with_semicolon(
-    start: u32,
-    content_end: u32,
-    f: &mut JsFormatter<'_, '_>,
-) {
-    write!(f, [FormatSuppressedNode(Span::new(start, content_end)), OptionalSemicolon]);
-}
-
-/// Prints a suppressed statement whose ignored range may or may not have had
-/// its trailing `;` stripped (see [`suppressed_statement_content_end`]).
-fn write_suppressed_statement(
-    span: Span,
-    content_end: u32,
-    print_semicolon: bool,
-    f: &mut JsFormatter<'_, '_>,
-) {
-    if print_semicolon {
-        write_suppressed_statement_with_semicolon(span.start, content_end, f);
-    } else {
-        debug_assert_eq!(content_end, span.end);
-        FormatSuppressedNode(span).fmt(f);
-    }
-}
-
-/// The ignored range end for a statement terminated by a (possibly distant) source `;`,
-/// and whether one was actually stripped (so the formatter must print its own).
-fn semicolon_terminated_content_end(
-    content_end: u32,
-    span: Span,
-    f: &JsFormatter<'_, '_>,
-) -> (u32, bool) {
-    let end = f.comments().end_including_source_parens(content_end, span.end);
-    (end, end < span.end)
-}
-
-#[expect(clippy::cast_possible_truncation)]
-const RETURN_KEYWORD_LEN: u32 = "return".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const DEBUGGER_KEYWORD_LEN: u32 = "debugger".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
-
-/// The ignored range end for `return` (the argument or the keyword),
-/// and whether a source `;` was stripped.
-fn return_statement_content_end(s: &ReturnStatement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
-    s.argument.as_ref().map_or_else(
-        || {
-            let keyword_end = s.span.start + RETURN_KEYWORD_LEN;
-            (keyword_end, keyword_end < s.span.end)
-        },
-        |argument| semicolon_terminated_content_end(argument.span().end, s.span, f),
-    )
-}
-
-/// The ignored range end for `break`/`continue`: the label, or the keyword.
-fn break_or_continue_content_end(
-    span: Span,
-    keyword_len: u32,
-    label: Option<&LabelIdentifier<'_>>,
-) -> u32 {
-    label.map_or(span.start + keyword_len, |label| label.span.end)
-}
-
-/// The ignored range end for a variable declaration: the last declarator,
-/// extended over a cast's source parens.
-/// The source `;` is always outside (Prettier's `locEnd` override lists `VariableDeclaration`).
-fn variable_declaration_content_end(
-    declaration: &VariableDeclaration<'_>,
-    f: &JsFormatter<'_, '_>,
-) -> u32 {
-    // `VariableDeclaration` always has at least one declarator
-    let declarations_end = declaration.declarations.last().unwrap().span.end;
-    // The stripped-`;` flag is discarded: a declaration re-adds its terminator unconditionally
-    semicolon_terminated_content_end(declarations_end, declaration.span, f).0
-}
-
-/// The ignored range end of a suppressed statement and whether the formatter prints its own terminator after it,
-/// mirroring Prettier's `locEnd` overrides (`language-js/location/overrides.js`) + `shouldIgnoredNodePrintSemicolon`:
-/// the trailing `;` (and anything between it and the content) is excluded from the verbatim range,
-/// keyword statements (`debugger`/`break`/`continue`) and variable declarations always re-add `;`,
-/// content-terminated ones only when a source `;` was stripped, and statements ending in a body recurse into the rightmost body.
-fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
-    match stmt {
-        Statement::ExpressionStatement(s) => {
-            semicolon_terminated_content_end(s.expression.span().end, s.span, f)
-        }
-        Statement::ReturnStatement(s) => return_statement_content_end(s, f),
-        Statement::ThrowStatement(s) => {
-            semicolon_terminated_content_end(s.argument.span().end, s.span, f)
-        }
-        Statement::DoWhileStatement(s) => {
-            semicolon_terminated_content_end(s.test.span().end, s.span, f)
-        }
-        Statement::DebuggerStatement(s) => (s.span.start + DEBUGGER_KEYWORD_LEN, true),
-        Statement::BreakStatement(s) => {
-            (break_or_continue_content_end(s.span, BREAK_KEYWORD_LEN, s.label.as_ref()), true)
-        }
-        Statement::ContinueStatement(s) => {
-            (break_or_continue_content_end(s.span, CONTINUE_KEYWORD_LEN, s.label.as_ref()), true)
-        }
-        Statement::VariableDeclaration(s) => (variable_declaration_content_end(s, f), true),
-        Statement::IfStatement(s) => {
-            suppressed_statement_content_end(s.alternate.as_ref().unwrap_or(&s.consequent), f)
-        }
-        Statement::WhileStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::WithStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForInStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForOfStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::LabeledStatement(s) => suppressed_statement_content_end(&s.body, f),
-        _ => (stmt.span().end, false),
-    }
-}
-
 impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the closing paren
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.test().span().end, self.span(), f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         let is_block_body = matches!(body.as_ref(), Statement::BlockStatement(_));
@@ -945,11 +764,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatParenHeadExpression<'a, '_> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -1001,11 +815,6 @@ where
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let init = self.init();
         let test = self.test();
@@ -1065,11 +874,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         let left = self.left();
@@ -1110,11 +914,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
 
@@ -1156,14 +955,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(
-            self.alternate.as_ref().unwrap_or(&self.consequent),
-            f,
-        );
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let test = self.test();
         let consequent = self.consequent();
@@ -1173,8 +964,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
             let body = FormatStatementBody::new(consequent);
             // The consequent's trailing pass would claim a comment past the `else` keyword;
             // leave everything after it for the split below.
-            // A trailing suppression comment must stay visible to the consequent,
-            // so it preserves its original text.
+            // A trailing suppression comment must stay visible to the consequent's own gate
+            // (`write_suppressed_statement`).
             if alternate.is_some()
                 && !f.comments().has_trailing_suppression_comment(consequent.span().end)
             {
@@ -1225,13 +1016,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the label (or the keyword)
-        let content_end =
-            break_or_continue_content_end(self.span(), CONTINUE_KEYWORD_LEN, self.label.as_ref());
-        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["continue", space(), label]));
@@ -1243,13 +1027,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the label (or the keyword)
-        let content_end =
-            break_or_continue_content_end(self.span(), BREAK_KEYWORD_LEN, self.label.as_ref());
-        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["break", space(), label]));
@@ -1261,11 +1038,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -1286,11 +1058,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let label = self.label();
         let body = self.body();
@@ -1307,15 +1074,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, DebuggerStatement> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the keyword
-        write_suppressed_statement_with_semicolon(
-            self.span.start,
-            self.span.start + DEBUGGER_KEYWORD_LEN,
-            f,
-        );
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(f, ["debugger", OptionalSemicolon]);
     }
@@ -1985,7 +1743,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTSSignature<'a, '_> {
         }
 
         if f.comments().has_trailing_suppression_comment(self.signature.span().end) {
-            write!(f, [FormatSuppressedNode(self.signature.span())]);
+            format_leading_comments(self.signature.span()).fmt(f);
+            write_suppressed_content(self.signature.span(), None, f);
             let comments =
                 f.context().comments().end_of_line_comments_after(self.signature.span().end);
             write!(f, FormatTrailingComments::Comments(comments));

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -9,9 +9,9 @@ use crate::{
     ast_nodes::AstNode,
     formatter::{prelude::*, trivia::FormatTrailingComments},
     ir_transform::sort_imports_chunk,
-    print::semicolon::OptionalSemicolon,
+    print::semicolon::{OptionalSemicolon, suppressed_statement_content_end},
     utils::{
-        export_declaration_span, export_default_declaration_span, is_dropped_statement,
+        is_dropped_statement, statement_span,
         string::{FormatLiteralStringToken, StringLiteralParentKind},
     },
     write,
@@ -79,16 +79,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementsWithImports<'a, '_>
                 }
             }
 
-            let span = match stmt.as_ref() {
-                // `@decorator export class A {}`: Start the span at the decorator
-                Statement::ExportDeclaration(export) => export_declaration_span(export),
-                Statement::ExportDefaultDeclaration(export) => {
-                    export_default_declaration_span(export)
-                }
-                _ => stmt.span(),
-            };
-
-            join.entry(span, stmt);
+            join.entry(statement_span(stmt.as_ref()), stmt);
         }
     }
 }
@@ -150,9 +141,8 @@ fn format_import_decls_with_sort<'a, 'iter>(
 /// An `ImportDeclaration` is suppressed if it has a leading or trailing suppression comment,
 /// which causes it to be emitted verbatim and act as a partition boundary, excluding it from the sortable run.
 fn is_import_suppressed(stmt: &AstNode<'_, Statement<'_>>, f: &JsFormatter<'_, '_>) -> bool {
-    let span = stmt.span();
-    let comments = f.comments();
-    comments.is_suppressed(span.start) || comments.has_trailing_suppression_comment(span.end)
+    f.comments()
+        .is_node_suppressed(stmt.span(), || suppressed_statement_content_end(stmt.as_ref(), f))
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Directive<'a>>> {

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -10,9 +10,8 @@ use crate::{
         trivia::{DanglingIndentMode, FormatDanglingComments},
     },
     print::{
-        ExpressionLeftSide, return_statement_content_end,
+        ExpressionLeftSide,
         semicolon::{OptionalSemicolon, assignment_chain_leaf_end},
-        semicolon_terminated_content_end, write_suppressed_statement,
     },
     utils::{
         format_node_without_trailing_comments::format_content_without_comments_after,
@@ -24,25 +23,12 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the argument (or the keyword),
-        // excluding a stripped trailing `;`
-        let (content_end, print_semicolon) = return_statement_content_end(self, f);
-        write_suppressed_statement(self.span, content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ReturnStatement(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.argument().span().end, self.span, f);
-        write_suppressed_statement(self.span, content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ThrowStatement(self).fmt(f);
     }

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -1,16 +1,24 @@
-use oxc_ast::ast::{Comment, Expression};
+use oxc_ast::ast::{Comment, Declaration, ExportDefaultDeclarationKind, Expression, Statement};
 use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::{
-    ast_nodes::AstNodes,
-    formatter::{JsFormatContext, JsFormatter, trivia::FormatTrailingComments},
+    ast_nodes::{AstNode, AstNodes},
+    formatter::{
+        JsFormatContext, JsFormatter, JsFormatterExt as _,
+        trivia::{FormatTrailingComments, format_leading_comments},
+    },
     options::Semicolons,
     utils::{
         format_node_without_trailing_comments::format_content_without_comments_after,
-        typecast::cast_target_end,
+        statement_span, suppressed::write_suppressed_content, typecast::cast_target_end,
     },
     write,
+};
+
+use super::{
+    function::function_content_end, import_declaration::module_source_end,
+    write_leading_comments_with_asi_guard,
 };
 
 pub struct OptionalSemicolon;
@@ -242,5 +250,125 @@ where
         format_content_without_comments_after(self.content, self.content_end, f);
 
         write!(f, [OptionalSemicolon, FormatTrailingComments::Comments(trailing_comments)]);
+    }
+}
+
+/// Prints a statement when it is suppressed (`oxfmt-ignore` / `prettier-ignore`, leading or trailing comment)
+/// and returns whether it was: its leading comments, then the source text up to its content end,
+/// then the formatter's terminator per `semi` like every other statement (the token-class table in AGENTS.md).
+/// A statement without a terminator of its own prints its whole span.
+/// Same-line comments between the content end and a later-line source `;` stay on the content's line,
+/// own-line ones are left for the next node's leading pass;
+/// the caller (the generated `Statement` fmt) prints the trailing comments.
+pub fn write_suppressed_statement<'a>(
+    stmt: &AstNode<'a, Statement<'a>>,
+    f: &mut JsFormatter<'_, 'a>,
+) -> bool {
+    let span = statement_span(stmt.as_ref());
+    if !f.comments().is_node_suppressed(span, || suppressed_statement_content_end(stmt.as_ref(), f))
+    {
+        return false;
+    }
+    match stmt.as_ast_nodes() {
+        // The `semi: false` ASI guard goes before a leading type cast comment, verbatim or not:
+        // Prettier's `printIgnored` puts it after and breaks the cast (DIVERGENCES.md#suppressed-cast-comment-asi-guard)
+        AstNodes::ExpressionStatement(stmt) => write_leading_comments_with_asi_guard(stmt, true, f),
+        _ => format_leading_comments(span).fmt(f),
+    }
+    if write_suppressed_content(span, suppressed_statement_content_end(stmt.as_ref(), f), f) {
+        OptionalSemicolon.fmt(f);
+    }
+    true
+}
+
+#[expect(clippy::cast_possible_truncation)]
+const RETURN_KEYWORD_LEN: u32 = "return".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const DEBUGGER_KEYWORD_LEN: u32 = "debugger".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
+#[expect(clippy::cast_possible_truncation)]
+const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
+
+/// Where a suppressed statement's content ends and the formatter's terminator takes over:
+/// the last content token (extended over dropped source parens), the keyword for a bare `return`/`break`/`continue`/`debugger`.
+/// `None` for a statement without a terminator of its own (a block, a declaration with a body, ...);
+/// a statement ending in a body answers for its rightmost body.
+/// Mirrors the `;`-printing sites of the reprint (`FormatContentWithSemicolon` / `OptionalSemicolon`): keep them in step.
+pub fn suppressed_statement_content_end(
+    stmt: &Statement<'_>,
+    f: &JsFormatter<'_, '_>,
+) -> Option<u32> {
+    let span = stmt.span();
+    let with_parens =
+        |content_end: u32| f.comments().end_including_source_parens(content_end, span.end);
+    match stmt {
+        Statement::ExpressionStatement(s) => Some(with_parens(s.expression.span().end)),
+        Statement::ReturnStatement(s) => {
+            Some(s.argument.as_ref().map_or(span.start + RETURN_KEYWORD_LEN, |argument| {
+                with_parens(argument.span().end)
+            }))
+        }
+        Statement::ThrowStatement(s) => Some(with_parens(s.argument.span().end)),
+        Statement::DoWhileStatement(s) => Some(with_parens(s.test.span().end)),
+        Statement::DebuggerStatement(_) => Some(span.start + DEBUGGER_KEYWORD_LEN),
+        Statement::BreakStatement(s) => {
+            Some(s.label.as_ref().map_or(span.start + BREAK_KEYWORD_LEN, |label| label.span.end))
+        }
+        Statement::ContinueStatement(s) => {
+            Some(s.label.as_ref().map_or(span.start + CONTINUE_KEYWORD_LEN, |label| label.span.end))
+        }
+        Statement::ImportDeclaration(s) => {
+            Some(module_source_end(&s.source, s.with_clause.as_deref()))
+        }
+        Statement::ExportAllDeclaration(s) => {
+            Some(module_source_end(&s.source, s.with_clause.as_deref()))
+        }
+        Statement::ExportFromDeclaration(s) => {
+            Some(module_source_end(&s.source, s.with_clause.as_deref()))
+        }
+        Statement::ExportNamedDeclaration(s) => {
+            // `export { a }`: the `}` after the last specifier (or the `{`)
+            let from = s.specifiers.last().map_or(span.start, |specifier| specifier.span.end);
+            Some(f.comments().position_after_character(from, b'}'))
+        }
+        Statement::ExportDefaultDeclaration(s) => match &s.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                function_content_end(function, f)
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(_)
+            | ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => None,
+            expression => Some(with_parens(expression.span().end)),
+        },
+        Statement::ExportDeclaration(s) => declaration_content_end(&s.declaration, f),
+        Statement::TSExportAssignment(s) => Some(with_parens(s.expression.span().end)),
+        Statement::TSNamespaceExportDeclaration(s) => Some(s.id.span.end),
+        Statement::IfStatement(s) => {
+            suppressed_statement_content_end(s.alternate.as_ref().unwrap_or(&s.consequent), f)
+        }
+        Statement::WhileStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::WithStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForInStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::ForOfStatement(s) => suppressed_statement_content_end(&s.body, f),
+        Statement::LabeledStatement(s) => suppressed_statement_content_end(&s.body, f),
+        _ => stmt.as_declaration().and_then(|declaration| declaration_content_end(declaration, f)),
+    }
+}
+
+/// [`suppressed_statement_content_end`] for a declaration (also behind `export`):
+/// the last declarator, a type alias's type, a bodyless (`declare`) function's signature, a bodyless `declare module "m"`.
+fn declaration_content_end(declaration: &Declaration<'_>, f: &JsFormatter<'_, '_>) -> Option<u32> {
+    match declaration {
+        Declaration::VariableDeclaration(s) => {
+            // `VariableDeclaration` always has at least one declarator
+            let declarations_end = s.declarations.last().unwrap().span.end;
+            Some(f.comments().end_including_source_parens(declarations_end, s.span.end))
+        }
+        Declaration::FunctionDeclaration(function) => function_content_end(function, f),
+        Declaration::TSTypeAliasDeclaration(s) => Some(s.type_annotation.span().end),
+        Declaration::TSImportEqualsDeclaration(s) => Some(s.module_reference.span().end),
+        Declaration::TSExternalModuleDeclaration(s) if s.body.is_none() => Some(s.id.span.end),
+        _ => None,
     }
 }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -15,11 +15,7 @@ use crate::{
     write,
 };
 
-use crate::utils::suppressed::FormatSuppressedNode;
-
-use super::{
-    FormatWrite, variable_declaration_content_end, write_suppressed_statement_with_semicolon,
-};
+use super::FormatWrite;
 
 /// Whether the declaration is a `for`/`for-in`/`for-of` head,
 /// terminated by the head itself (the head-vs-body test is by span: a declaration can also be the body).
@@ -37,21 +33,6 @@ fn is_for_head_declaration(decl: &AstNode<'_, VariableDeclaration<'_>>) -> bool 
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        if is_for_head_declaration(self) {
-            // No terminator of its own to re-add:
-            // Prettier appends one anyway and corrupts the head (DIVERGENCES.md#suppressed-for-head-declaration)
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            // The ignored range ends at the last declarator; the terminator is always the formatter's
-            write_suppressed_statement_with_semicolon(
-                self.span().start,
-                variable_declaration_content_end(self, f),
-                f,
-            );
-        }
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let semicolon = !is_for_head_declaration(self);
 

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -18,7 +18,7 @@ use oxc_ast::ast::{
     CallExpression, Declaration, Decorator, ExportDeclaration, ExportDefaultDeclaration,
     ExportDefaultDeclarationKind, PropertyKey, Statement,
 };
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::ast_nodes::{AstNode, AstNodes};
 
@@ -35,6 +35,16 @@ pub fn export_declaration_span(export: &ExportDeclaration<'_>) -> Span {
         span_with_decorators_before_export(&class.decorators, export.span)
     } else {
         export.span
+    }
+}
+
+/// A statement's span as the statement lists and the suppression check see it:
+/// extended over pre-`export` class decorators (see [`export_declaration_span`]).
+pub fn statement_span(stmt: &Statement<'_>) -> Span {
+    match stmt {
+        Statement::ExportDeclaration(export) => export_declaration_span(export),
+        Statement::ExportDefaultDeclaration(export) => export_default_declaration_span(export),
+        _ => stmt.span(),
     }
 }
 

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -9,6 +9,7 @@ use crate::{
         prelude::{empty_line, format_once, hard_line_break, soft_line_indent_or_space, space},
         trivia::{FormatCommentBeforeContent, FormatLeadingComments, FormatTrailingComments},
     },
+    print::semicolon::write_suppressed_statement,
     utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
     write,
 };
@@ -207,7 +208,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
                         if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
                     );
                     if is_consequent_of_if_statement_parent {
-                        write!(f, FormatNodeWithoutTrailingComments(self.body));
+                        // A suppressed consequent still hands its terminator to the formatter
+                        if !write_suppressed_statement(self.body, f) {
+                            write!(f, FormatNodeWithoutTrailingComments(self.body));
+                        }
                         let comments =
                             f.context().comments().end_of_line_comments_after(body_span.end);
                         FormatTrailingComments::Comments(comments).fmt(f);

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -3,7 +3,7 @@ use oxc_span::Span;
 
 use crate::{
     Buffer, Format,
-    formatter::prelude::*,
+    formatter::{prelude::*, trivia::FormatTrailingComments},
     utils::typecast::{format_leading_comments_and_open_paren, write_suppressed_cast_target},
     write,
 };
@@ -34,6 +34,25 @@ pub fn write_suppressed_expression(
     if needs_parentheses {
         write!(f, ")");
     }
+}
+
+/// Prints a suppressed node whose terminator the formatter owns: the source text up to `content_end`,
+/// then the same-line comments before a later-line source `;` (they stay on the content's line),
+/// and returns `true` so the caller prints its terminator per `semi`.
+/// Without a content end (no terminator of its own) the whole span prints and nothing follows.
+pub fn write_suppressed_content(
+    span: Span,
+    content_end: Option<u32>,
+    f: &mut JsFormatter<'_, '_>,
+) -> bool {
+    let Some(content_end) = content_end else {
+        FormatSuppressedNode(span).fmt(f);
+        return false;
+    };
+    FormatSuppressedNode(Span::new(span.start, content_end)).fmt(f);
+    let comments = f.context().comments().end_of_line_comments_after(content_end);
+    FormatTrailingComments::Comments(comments).fmt(f);
+    true
 }
 
 pub struct FormatSuppressedNode(pub Span);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
@@ -182,7 +182,7 @@ if (a) {
 
 // A trailing suppression comment keeps the consequent's original text
 if (a)
-  ugly(  1  ) // prettier-ignore
+  ugly(  1  ); // prettier-ignore
 else b();
 
 // No `else`: every consequent shape stays inline in both formatters
@@ -285,7 +285,7 @@ if (a) {
 
 // A trailing suppression comment keeps the consequent's original text
 if (a)
-  ugly(  1  ) // prettier-ignore
+  ugly(  1  ); // prettier-ignore
 else b();
 
 // No `else`: every consequent shape stays inline in both formatters

--- a/crates/oxc_formatter/tests/fixtures/js/crlf/ignore.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/crlf/ignore.js.snap
@@ -23,7 +23,7 @@ else done();
 
 // prettier-ignore
 Object.defineProperties    (    exports    , {
-})
+});
 
 if (ok)
   logger(  payload  ); // prettier-ignore
@@ -38,7 +38,7 @@ else done();
 
 // prettier-ignore
 Object.defineProperties    (    exports    , {
-})
+});
 
 if (ok)
   logger(  payload  ); // prettier-ignore
@@ -53,7 +53,7 @@ else done();
 
 // prettier-ignore
 Object.defineProperties    (    exports    , {
-})
+});
 
 if (ok)
   logger(  payload  ); // prettier-ignore
@@ -68,7 +68,7 @@ else done();
 
 // prettier-ignore
 Object.defineProperties    (    exports    , {
-})
+});
 
 if (ok)
   logger(  payload  ); // prettier-ignore

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/expression-statement.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/expression-statement.js.snap
@@ -40,7 +40,7 @@ Object.defineProperties    (    exports    , {
   c +
     b +
   d
-)
+);
 
 logger({ level: 'debug', message: `Really long debugging message about how ${user} called a certain part of our application with a certain ${payload}` }); // prettier-ignore
 
@@ -71,7 +71,7 @@ Object.defineProperties    (    exports    , {
   c +
     b +
   d
-)
+);
 
 logger({ level: 'debug', message: `Really long debugging message about how ${user} called a certain part of our application with a certain ${payload}` }); // prettier-ignore
 

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/issue-18595.js
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/issue-18595.js
@@ -1,4 +1,5 @@
-// prettier-ignore on class property should not add extra semicolon
+// prettier-ignore on class property: the value prints verbatim, the `;` is the formatter's
+// (never doubled, added per `semi` when the source has none)
 export class Counter {
 	// prettier-ignore
 	'count' = $state(0);

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/issue-18595.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/issue-18595.js.snap
@@ -2,7 +2,8 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// prettier-ignore on class property should not add extra semicolon
+// prettier-ignore on class property: the value prints verbatim, the `;` is the formatter's
+// (never doubled, added per `semi` when the source has none)
 export class Counter {
 	// prettier-ignore
 	'count' = $state(0);
@@ -37,7 +38,8 @@ export class Counter4 {
 ------------------
 { printWidth: 80 }
 ------------------
-// prettier-ignore on class property should not add extra semicolon
+// prettier-ignore on class property: the value prints verbatim, the `;` is the formatter's
+// (never doubled, added per `semi` when the source has none)
 export class Counter {
   // prettier-ignore
   'count' = $state(0);
@@ -48,7 +50,7 @@ export class Counter {
 
 export class Counter2 {
   // prettier-ignore
-  'count' = $state(0)
+  'count' = $state(0);
   constructor() {
     this["count"] = $state(0);
   }
@@ -71,7 +73,8 @@ export class Counter4 {
 -------------------
 { printWidth: 100 }
 -------------------
-// prettier-ignore on class property should not add extra semicolon
+// prettier-ignore on class property: the value prints verbatim, the `;` is the formatter's
+// (never doubled, added per `semi` when the source has none)
 export class Counter {
   // prettier-ignore
   'count' = $state(0);
@@ -82,7 +85,7 @@ export class Counter {
 
 export class Counter2 {
   // prettier-ignore
-  'count' = $state(0)
+  'count' = $state(0);
   constructor() {
     this["count"] = $state(0);
   }

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/empty-line.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/empty-line.js.snap
@@ -64,10 +64,10 @@ const a = 1
 })()
 
 foo()
-;[1,2,3]; // prettier-ignore
+;[1,2,3] // prettier-ignore
 
 bar()
-;[4,5,6]; // oxfmt-ignore
+;[4,5,6] // oxfmt-ignore
 
 baz()
 ;[7, 8, 9]
@@ -82,10 +82,10 @@ const a = 1
 })()
 
 foo()
-;[1,2,3]; // prettier-ignore
+;[1,2,3] // prettier-ignore
 
 bar()
-;[4,5,6]; // oxfmt-ignore
+;[4,5,6] // oxfmt-ignore
 
 baz()
 ;[7, 8, 9]

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
@@ -1,6 +1,8 @@
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1)
@@ -28,9 +30,8 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1
@@ -59,7 +60,6 @@ export const exported   =   1
 foo()
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -67,3 +67,22 @@ stmt(   );
 
 // prettier-ignore
 [breaking].sort();
+
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ) // prettier-ignore
+;[].sort()
+
+stmt(   ) // prettier-ignore
+a => a
+
+stmt(   ); // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond) stmt(   ); // prettier-ignore
+else other()
+
+if (cond) stmt(   ) // prettier-ignore
+; else other()

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
@@ -3,8 +3,10 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1)
@@ -32,9 +34,8 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1
@@ -63,7 +64,6 @@ export const exported   =   1
 foo()
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -71,14 +71,35 @@ stmt(   );
 
 // prettier-ignore
 [breaking].sort();
+
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ) // prettier-ignore
+;[].sort()
+
+stmt(   ) // prettier-ignore
+a => a
+
+stmt(   ); // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond) stmt(   ); // prettier-ignore
+else other()
+
+if (cond) stmt(   ) // prettier-ignore
+; else other()
 
 ==================== Output ====================
 ------------------------------
 { printWidth: 80, semi: true }
 ------------------------------
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1);
@@ -106,9 +127,8 @@ lbl3: for (;;) {
   break   lbl3;
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1;
@@ -132,12 +152,11 @@ if (cond) var inBody   =   1;
 [].sort();
 
 // prettier-ignore
-export const exported   =   1
+export const exported   =   1;
 
 foo();
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -145,13 +164,36 @@ stmt(   );
 
 // prettier-ignore
 [breaking].sort();
+
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ); // prettier-ignore
+[].sort();
+
+stmt(   ); // prettier-ignore
+(a) => a;
+
+stmt(   ); // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond)
+  stmt(   ); // prettier-ignore
+else other();
+
+if (cond)
+  stmt(   ); // prettier-ignore
+else other();
 
 -------------------------------
 { printWidth: 100, semi: true }
 -------------------------------
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1);
@@ -179,9 +221,8 @@ lbl3: for (;;) {
   break   lbl3;
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1;
@@ -205,12 +246,11 @@ if (cond) var inBody   =   1;
 [].sort();
 
 // prettier-ignore
-export const exported   =   1
+export const exported   =   1;
 
 foo();
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -219,12 +259,35 @@ stmt(   );
 // prettier-ignore
 [breaking].sort();
 
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ); // prettier-ignore
+[].sort();
+
+stmt(   ); // prettier-ignore
+(a) => a;
+
+stmt(   ); // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond)
+  stmt(   ); // prettier-ignore
+else other();
+
+if (cond)
+  stmt(   ); // prettier-ignore
+else other();
+
 -------------------------------
 { printWidth: 80, semi: false }
 -------------------------------
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1)
@@ -252,9 +315,8 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1
@@ -283,7 +345,6 @@ export const exported   =   1
 foo()
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -291,13 +352,36 @@ stmt(   )
 
 // prettier-ignore
 ;[breaking].sort()
+
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ) // prettier-ignore
+;[].sort()
+
+stmt(   ) // prettier-ignore
+;(a) => a
+
+stmt(   ) // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond)
+  stmt(   ) // prettier-ignore
+else other()
+
+if (cond)
+  stmt(   ) // prettier-ignore
+else other()
 
 --------------------------------
 { printWidth: 100, semi: false }
 --------------------------------
 // A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
+// the terminator stays the formatter's and follows `semi` (added or removed),
 // and comments between the content and the source `;` lead the next statement.
+// Prettier re-adds a content-terminated statement's `;` only when the source had one
+// (DIVERGENCES.md#suppressed-terminator-per-semi).
 
 // prettier-ignore
 do;   while(   1)
@@ -325,9 +409,8 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration's ignored range ends at the last declarator, source `;` or not,
+// behind `export` too.
 
 // prettier-ignore
 const noSemi   =   1
@@ -356,7 +439,6 @@ export const exported   =   1
 foo()
 
 // A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
 // and still gets its `semi: false` ASI guard.
 
 // prettier-ignore
@@ -364,5 +446,26 @@ stmt(   )
 
 // prettier-ignore
 ;[breaking].sort()
+
+// A trailing suppression comment suppresses the same way, whether the source `;`
+// follows it on the line or sits on the next line (`semi: false` style);
+// under `semi: true` the terminator makes the next statement's `(` safe
+// where Prettier's output merges into `stmt(  )(a) => a`.
+stmt(   ) // prettier-ignore
+;[].sort()
+
+stmt(   ) // prettier-ignore
+;(a) => a
+
+stmt(   ) // prettier-ignore
+
+// An `if` consequent before `else` goes the same way
+if (cond)
+  stmt(   ) // prettier-ignore
+else other()
+
+if (cond)
+  stmt(   ) // prettier-ignore
+else other()
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
@@ -1,7 +1,7 @@
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger
@@ -37,7 +37,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
@@ -3,9 +3,9 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger
@@ -41,7 +41,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -53,9 +53,9 @@ with   (   1)   ;
 { printWidth: 80, semi: true }
 ------------------------------
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger;
@@ -91,7 +91,7 @@ function g() {
   [].sort();
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -102,9 +102,9 @@ with   (   1)   ;
 { printWidth: 100, semi: true }
 -------------------------------
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger;
@@ -140,7 +140,7 @@ function g() {
   [].sort();
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -151,9 +151,9 @@ with   (   1)   ;
 { printWidth: 80, semi: false }
 -------------------------------
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger
@@ -189,7 +189,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -200,9 +200,9 @@ with   (   1)   ;
 { printWidth: 100, semi: false }
 --------------------------------
 // The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// trailing `;`, even one owned by a nested single-statement body, and the
+// formatter prints its own terminator per `semi`, never doubling it
+// (a doubled `;` would re-parse as an extra EmptyStatement).
 
 // oxfmt-ignore
 debugger
@@ -238,7 +238,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: the terminator is still the formatter's, but a `}` body has none.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/suppressed-class-member.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/suppressed-class-member.ts
@@ -1,0 +1,48 @@
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // prettier-ignore
+  t   = 4;
+  // prettier-ignore
+  u   = 5
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1 // prettier-ignore
+  ;[k] = 2
+  // prettier-ignore
+  q   = 3
+  ;[j] = 4
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1) // prettier-ignore
+  r   = (s = 2); // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3)
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/suppressed-class-member.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/suppressed-class-member.ts.snap
@@ -1,0 +1,263 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // prettier-ignore
+  t   = 4;
+  // prettier-ignore
+  u   = 5
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1 // prettier-ignore
+  ;[k] = 2
+  // prettier-ignore
+  q   = 3
+  ;[j] = 4
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1) // prettier-ignore
+  r   = (s = 2); // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3)
+}
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2; // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2; // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void; // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // prettier-ignore
+  t   = 4;
+  // prettier-ignore
+  u   = 5;
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2;
+  // prettier-ignore
+  q   = 3;
+  [j] = 4;
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1); // prettier-ignore
+  r   = (s = 2); // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3);
+}
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2; // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2; // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void; // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // prettier-ignore
+  t   = 4;
+  // prettier-ignore
+  u   = 5;
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2;
+  // prettier-ignore
+  q   = 3;
+  [j] = 4;
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1); // prettier-ignore
+  r   = (s = 2); // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3);
+}
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1 // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1 // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3 // prettier-ignore
+  // prettier-ignore
+  t   = 4
+  // prettier-ignore
+  u   = 5
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2
+  // prettier-ignore
+  q   = 3;
+  [j] = 4
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1) // prettier-ignore
+  r   = (s = 2) // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3)
+}
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A suppressed class member, by a leading or a trailing comment, prints its content verbatim;
+// its `;` stays the formatter's and follows `semi`, like a statement
+// (Prettier prints the member whole, DIVERGENCES.md#suppressed-terminator-per-semi).
+// A method with a body and a static block have no terminator: whole span.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1 // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1 // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3 // prettier-ignore
+  // prettier-ignore
+  t   = 4
+  // prettier-ignore
+  u   = 5
+  z() {}
+}
+
+// A source `;` on the next line (`;[k] = 2`, the `semi: false` style) is outside the content too;
+// under `semi: false` the member's own rule decides whether the next member needs one
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2
+  // prettier-ignore
+  q   = 3;
+  [j] = 4
+}
+
+// An interface member's `;` is a separator, not a terminator: the member prints whole,
+// leading comment included
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0
+}
+
+// The verbatim range keeps the value's source parens
+class E {
+  p   = (q = 1) // prettier-ignore
+  r   = (s = 2) // prettier-ignore
+  // prettier-ignore
+  t   = (u = 3)
+}
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -4,10 +4,9 @@
 //!
 //! - The node lists here decide which fragments of the `fmt` skeleton are EMITTED (comment-printing ownership, parentheses frames)
 //!   - they change the shape of the generated code, nothing else
-//! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `suppressed_span`, `write_suppressed`)
+//! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `leading_comments_start`)
 //!   - defaults cover the common case, overrides sit next to the node's `write` and need no regeneration
-//!   - EXCEPT: expression-shaped nodes bypass `write_suppressed` entirely
-//!     (their suppressed path goes to `write_suppressed_expression`, see below),
+//!   - EXCEPT: expression-shaped nodes bypass the suppressed hooks entirely (their suppressed path goes to `write_suppressed_expression`, see below),
 //!     so an override on such a node would silently never be called
 //!
 //! Add a new list only for a variation the emitted shape must express;
@@ -97,7 +96,7 @@ impl Generator for FormatterFormatGenerator {
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
                 utils::{suppressed::{FormatSuppressedNode, write_suppressed_expression}, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
-                print::FormatWrite,
+                print::{FormatWrite, semicolon::write_suppressed_statement},
             };
 
             #impls
@@ -186,23 +185,26 @@ fn generate_struct_implementation(
 
         // `Program` can't be suppressed.
         // `JSXElement` and `JSXFragment` implement suppression formatting in their formatting logic.
-        //
-        // The check, the suppressed leading comments, and the printed range are all bounded by
-        // `FormatWrite::suppressed_span` (default: the node's span),
-        // which nodes override when the ignored range starts before their span (class decorators before `export`).
-        // `FormatWrite::write_suppressed` (default: print `suppressed_span` verbatim) is overridden by
-        // statements whose ignored range excludes the trailing semicolon.
-        let suppressed_check = (!matches!(struct_name, "Program" | "JSXElement" | "JSXFragment"))
-            .then(|| {
-                quote! {
-                    let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-                }
-            });
+        // Statements are decided before their own `fmt`
+        // (the `Statement` fmt below hands them to `write_suppressed_statement` first, which owns their terminator);
+        // the two export kinds are skipped here as well because their ignored range starts at a pre-`export` decorator,
+        // which only `write_suppressed_statement` (via `statement_span`) knows.
+        let suppressed_check = (!matches!(
+            struct_name,
+            "Program"
+                | "JSXElement"
+                | "JSXFragment"
+                | "ExportDeclaration"
+                | "ExportDefaultDeclaration"
+        ))
+        .then(|| {
+            quote! {
+                let is_suppressed = f.comments().is_suppressed(self.span().start);
+            }
+        });
 
-        // Expression-shaped nodes (formatter parens + own comment printing) hand the whole
-        // suppressed sequence to one owner, so the cast-target decision is made once
-        // while every comment is still unprinted (see `write_suppressed_expression`).
-        // These nodes have no `suppressed_span`/`write_suppressed` overrides (those are statements).
+        // Expression-shaped nodes (formatter parens + own comment printing) hand the whole suppressed sequence to one owner,
+        // so the cast-target decision is made once while every comment is still unprinted (see `write_suppressed_expression`).
         let suppressed_expression_return =
             (suppressed_check.is_some() && needs_parentheses && !do_not_print_leading_comment)
                 .then(|| {
@@ -224,17 +226,15 @@ fn generate_struct_implementation(
             if suppressed_check.is_none() || suppressed_expression_return.is_some() {
                 write_call
             } else {
-                // When `fmt` doesn't print leading comments itself,
-                // the suppressed path delegates them to the node;
-                // see `FormatWrite::write_suppressed_leading_comments`.
+                // When `fmt` doesn't print leading comments itself, the suppressed path prints them here.
                 let suppressed_write_call = if do_not_print_leading_comment {
                     quote! {
-                        self.write_suppressed_leading_comments(f);
-                        self.write_suppressed(f);
+                        format_leading_comments(self.span()).fmt(f);
+                        FormatSuppressedNode(self.span()).fmt(f);
                     }
                 } else {
                     quote! {
-                        self.write_suppressed(f);
+                        FormatSuppressedNode(self.span()).fmt(f);
                     }
                 };
                 let suppressed_trailing_comments = do_not_print_comment.then(|| {
@@ -355,14 +355,10 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
 
     let inline_trailing_suppression = match enum_def.name() {
         "Statement" => {
-            // Expression statements need specialized ASI-safe suppression handling in
-            // `AstNode<ExpressionStatement>::write`.
+            // A suppressed statement (leading or trailing comment) prints its content verbatim
+            // and hands its terminator back to the formatter, decided once per statement here.
             quote! {
-                if !matches!(self.inner, Statement::ExpressionStatement(_))
-                    && f.comments().has_trailing_suppression_comment(self.span().end)
-                {
-                    format_leading_comments(self.span()).fmt(f);
-                    FormatSuppressedNode(self.span()).fmt(f);
+                if write_suppressed_statement(self, f) {
                     format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
                         .fmt(f);
                     return;

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1070155
+  arena allocs: 1070143
   arena reallocs: 927
   arena size: 90259056 # 90.26 MB
 
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
-  arena allocs: 211361
+  arena allocs: 210975
   arena reallocs: 364
-  arena size: 16936624 # 16.94 MB
+  arena size: 16925816 # 16.93 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
-  arena allocs: 432553
+  arena allocs: 432125
   arena reallocs: 428
-  arena size: 29572816 # 29.57 MB
+  arena size: 29560832 # 29.56 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 561600
+  arena allocs: 560906
   arena reallocs: 1041
-  arena size: 38563072 # 38.56 MB
+  arena size: 38543616 # 38.54 MB


### PR DESCRIPTION
Rules:

- Suppress comments act on the nodes themselves
- Since `;` is not a node, this is managed by the `semi` option
- There are no exceptions to nodes
