### PR TITLE
fix(formatter): keep an enum member's trailing suppress comment

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1315,6 +1315,13 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSEnumMemb
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
+        // A trailing suppression comment (`A = 1, // prettier-ignore`) suppresses like a leading one;
+        // the `,` is a separator the list prints, so the member prints whole
+        if f.comments().has_trailing_suppression_comment(self.span().end) {
+            write!(f, [FormatSuppressedNode(self.span())]);
+            return;
+        }
+
         let id = self.id();
         let is_computed = matches!(id.as_ref(), TSEnumMemberName::ComputedTemplateString(_));
 

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/enum-member-trailing.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/enum-member-trailing.ts
@@ -1,0 +1,12 @@
+// A trailing suppression comment suppresses an enum member like a leading one;
+// the `,` is a separator the list prints.
+enum E {
+  A   = 1, // prettier-ignore
+  B   = 2 // prettier-ignore
+}
+
+enum F {
+  // prettier-ignore
+  A   = 1,
+  B   = 2, // prettier-ignore
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/enum-member-trailing.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/enum-member-trailing.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A trailing suppression comment suppresses an enum member like a leading one;
+// the `,` is a separator the list prints.
+enum E {
+  A   = 1, // prettier-ignore
+  B   = 2 // prettier-ignore
+}
+
+enum F {
+  // prettier-ignore
+  A   = 1,
+  B   = 2, // prettier-ignore
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A trailing suppression comment suppresses an enum member like a leading one;
+// the `,` is a separator the list prints.
+enum E {
+  A   = 1, // prettier-ignore
+  B   = 2, // prettier-ignore
+}
+
+enum F {
+  // prettier-ignore
+  A   = 1,
+  B   = 2, // prettier-ignore
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A trailing suppression comment suppresses an enum member like a leading one;
+// the `,` is a separator the list prints.
+enum E {
+  A   = 1, // prettier-ignore
+  B   = 2, // prettier-ignore
+}
+
+enum F {
+  // prettier-ignore
+  A   = 1,
+  B   = 2, // prettier-ignore
+}
+
+===================== End =====================


### PR DESCRIPTION
There was a bug that suppress comment is removed.