### PR TITLE
refactor(formatter): decide trailing suppression in the generated fmt

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -172,6 +172,8 @@ The formatter owns statement terminators (and the trivia up to them); the user o
 - suppressed side: a suppressed node keeps the token classes above: content verbatim, terminator per `semi`
   (`write_suppressed_statement`, `FormatClassElementWithSemicolon`); a node without a terminator of its own prints its whole span.
   Prettier re-adds a statement's `;` only when the source had one and prints class members whole (DIVERGENCES.md#suppressed-terminator-per-semi)
+  - A trailing suppression comment counts like a leading one for every node (`is_span_suppressed` in the generated `fmt`);
+    the outermost node ending there claims it, except a union, whose member does
   - A statement is decided before its own generated `fmt`, so leading and trailing comments take one path and a pre-`export` decorator is inside the ignored range (`statement_span`)
   - Any site printing a statement outside the generated `Statement` fmt (an `if` consequent before `else`) must ask `write_suppressed_statement` first,
     or the generic verbatim path prints the source `;` regardless of `semi`

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -32,17 +32,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Program<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Expression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if f.comments().has_trailing_suppression_comment(self.span().end) {
-            format_leading_comments(self.span()).fmt(f);
-            FormatSuppressedNode(self.span()).fmt(f);
-            format_trailing_comments(
-                self.parent.span(),
-                self.inner.span(),
-                self.following_span_start,
-            )
-            .fmt(f);
-            return;
-        }
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
@@ -473,7 +462,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Expression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -486,7 +475,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -517,7 +506,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -530,7 +519,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -543,7 +532,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -574,7 +563,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -646,7 +635,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpressionElement<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -659,7 +648,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -720,7 +709,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPropertyKind<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -774,7 +763,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyKey<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -805,7 +794,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -836,7 +825,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -889,7 +878,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -920,7 +909,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -951,7 +940,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -982,7 +971,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1013,7 +1002,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1044,7 +1033,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1075,7 +1064,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1106,7 +1095,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SpreadElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1150,7 +1139,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Argument<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1181,7 +1170,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1212,7 +1201,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1243,7 +1232,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1274,7 +1263,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1305,7 +1294,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1336,7 +1325,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1500,7 +1489,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPattern
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1513,7 +1502,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1526,7 +1515,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1570,7 +1559,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetMaybeDe
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1613,7 +1602,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1626,7 +1615,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -1639,7 +1628,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1670,7 +1659,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1701,7 +1690,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1732,7 +1721,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -1804,7 +1793,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2056,7 +2045,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Statement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2069,7 +2058,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2082,7 +2071,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BlockStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2205,7 +2194,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Declaration<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2218,7 +2207,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2231,7 +2220,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2244,7 +2233,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2257,7 +2246,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2270,7 +2259,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2283,7 +2272,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2296,7 +2285,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2340,7 +2329,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementInit<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForInStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2384,7 +2373,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementLeft<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2397,7 +2386,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2410,7 +2399,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2423,7 +2412,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2436,7 +2425,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2449,7 +2438,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2462,7 +2451,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2475,7 +2464,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2488,7 +2477,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2501,7 +2490,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2514,7 +2503,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2527,7 +2516,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2540,7 +2529,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DebuggerStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2603,7 +2592,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2616,7 +2605,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2629,7 +2618,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2642,7 +2631,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2655,7 +2644,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2668,7 +2657,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2699,7 +2688,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2712,7 +2701,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2725,7 +2714,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2738,7 +2727,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FunctionBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2782,7 +2771,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionBody<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2813,7 +2802,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2844,7 +2833,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -2875,7 +2864,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2888,7 +2877,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2961,7 +2950,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2974,7 +2963,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -2987,7 +2976,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3000,7 +2989,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3103,7 +3092,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3116,7 +3105,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3147,7 +3136,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3200,7 +3189,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclarationSpecif
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3213,7 +3202,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3226,7 +3215,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3239,7 +3228,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifie
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3252,7 +3241,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3301,7 +3290,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3314,7 +3303,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3333,7 +3322,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaratio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3346,7 +3335,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3450,7 +3439,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleExportName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3481,7 +3470,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3512,7 +3501,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3543,7 +3532,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3574,7 +3563,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3605,7 +3594,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3636,7 +3625,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -3683,7 +3672,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3696,7 +3685,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3725,7 +3714,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXFragment<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3738,7 +3727,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3811,7 +3800,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElementName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3824,7 +3813,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3877,7 +3866,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpressionObje
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpressionContainer<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3921,7 +3910,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXEmptyExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3964,7 +3953,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeItem<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -3977,7 +3966,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4070,7 +4059,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeValue<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4143,7 +4132,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4156,7 +4145,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4169,7 +4158,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4182,7 +4171,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4195,7 +4184,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4208,7 +4197,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4271,7 +4260,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMemberName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4284,7 +4273,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4747,7 +4736,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4799,7 +4788,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4830,7 +4819,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4843,7 +4832,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -4874,7 +4863,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4887,7 +4876,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4900,7 +4889,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4913,7 +4902,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4926,7 +4915,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4939,7 +4928,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSRestType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -4993,7 +4982,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5006,7 +4995,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5019,7 +5008,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5032,7 +5021,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5045,7 +5034,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5058,7 +5047,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5071,7 +5060,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5084,7 +5073,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5097,7 +5086,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5110,7 +5099,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5123,7 +5112,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5136,7 +5125,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5149,7 +5138,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5162,7 +5151,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5175,7 +5164,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5228,7 +5217,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5241,7 +5230,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5254,7 +5243,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstanti
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5267,7 +5256,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5280,7 +5269,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5293,7 +5282,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5306,7 +5295,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5319,7 +5308,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5332,7 +5321,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSPropertySignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5405,7 +5394,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5418,7 +5407,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5431,7 +5420,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5444,7 +5433,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5457,7 +5446,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDec
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5470,7 +5459,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5483,7 +5472,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5526,7 +5515,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicateName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5539,7 +5528,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclara
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5582,7 +5571,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclarationB
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5595,7 +5584,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5608,7 +5597,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5621,7 +5610,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5652,7 +5641,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5714,7 +5703,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQueryExprName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5757,7 +5746,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifier<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5770,7 +5759,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedNa
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5801,7 +5790,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5832,7 +5821,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5845,7 +5834,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -5858,7 +5847,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5889,7 +5878,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5920,7 +5909,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -5951,7 +5940,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6004,7 +5993,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleReference<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6017,7 +6006,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReferen
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -6048,7 +6037,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6061,7 +6050,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6074,7 +6063,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6087,7 +6076,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclar
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         if is_suppressed {
             write_suppressed_expression(
                 self.span(),
@@ -6118,7 +6107,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6131,7 +6120,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);
@@ -6144,7 +6133,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocUnknownType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
         self.format_leading_comments(f);
         if is_suppressed {
             FormatSuppressedNode(self.span()).fmt(f);

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -289,6 +289,7 @@ impl<'a> Comments<'a> {
     }
 
     /// Returns comments that end at or after the given position.
+    #[inline]
     pub fn comments_after(&self, pos: u32) -> &'a [Comment] {
         let comments = self.unprinted_comments();
         &comments[comments.partition_point(|c| c.span.end < pos)..]
@@ -306,9 +307,7 @@ impl<'a> Comments<'a> {
     pub fn end_of_line_comments_after(&self, mut pos: u32) -> &'a [Comment] {
         let comments = self.comments_after(pos);
         for (index, comment) in comments.iter().enumerate() {
-            if self.source_text.all_bytes_match(pos, comment.span.start, |b| {
-                matches!(b, b'\t' | b' ' | b'=' | b':' | b',')
-            }) {
+            if self.source_text.all_bytes_match(pos, comment.span.start, is_end_of_line_gap_byte) {
                 if comment.is_line() || comment.followed_by_newline() {
                     return &comments[..=index];
                 }
@@ -542,16 +541,27 @@ impl<'a> Comments<'a> {
     /// `statement(); // prettier-ignore`
     /// `statement(); /* prettier-ignore */`
     /// `value, // prettier-ignore`
+    #[inline]
     pub fn has_trailing_suppression_comment(&self, pos: u32) -> bool {
-        self.end_of_line_comments_after(pos)
-            .iter()
-            .any(|comment| self.is_suppression_comment(comment))
+        // Asked once per node: gate on the (cache-hot) source bytes before searching the comment array.
+        // A same-line comment follows only the gap bytes and starts with `/`
+        self.source_text.next_byte_skipping(pos, is_end_of_line_gap_byte) == Some(b'/')
+            && self
+                .end_of_line_comments_after(pos)
+                .iter()
+                .any(|comment| self.is_suppression_comment(comment))
     }
 
-    /// Whether a node whose terminator the formatter owns is suppressed by a leading comment or a trailing one:
-    /// on its line after the `;` (`foo(); // prettier-ignore`),
-    /// or after the content when the source `;` sits on a later line (`foo() // prettier-ignore` + `;[].sort()`, the `semi: false` style).
-    /// `content_end` is asked only for that last shape (the span's last comment is a suppression comment).
+    /// Whether a leading comment or one trailing the node's end suppresses it
+    /// (`A = 1, // prettier-ignore`); the check every generated `fmt` runs.
+    #[inline]
+    pub fn is_span_suppressed(&self, span: Span) -> bool {
+        self.is_suppressed(span.start) || self.has_trailing_suppression_comment(span.end)
+    }
+
+    /// [`Self::is_span_suppressed`], plus the shape a formatter-owned terminator adds: a trailing comment after the content
+    /// when the source `;` sits on a later line (`foo() // prettier-ignore` + `;[].sort()`, the `semi: false` style).
+    /// `content_end` is asked only for that shape (the span's last comment is a suppression comment).
     pub fn is_node_suppressed(
         &self,
         span: Span,
@@ -561,7 +571,7 @@ impl<'a> Comments<'a> {
         if self.unprinted_comments().is_empty() {
             return false;
         }
-        if self.is_suppressed(span.start) || self.has_trailing_suppression_comment(span.end) {
+        if self.is_span_suppressed(span) {
             return true;
         }
         let Some(last) = self.all_comments_before(span.end).last() else { return false };
@@ -737,6 +747,12 @@ impl<'a> Comments<'a> {
         }
         &comments[..count]
     }
+}
+
+/// The bytes that may sit between a node's end and a comment still on its line
+/// (`a = // c`, `key: // c`, `x, // c`).
+fn is_end_of_line_gap_byte(byte: u8) -> bool {
+    matches!(byte, b'\t' | b' ' | b'=' | b':' | b',')
 }
 
 /// Byte segments between `start` and `bound` lying outside the given comment spans:

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -641,9 +641,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a,
                 Semicolons::AsNeeded => self.needs_semicolon(),
             };
 
-        // A suppressed element (leading or trailing comment) prints its content verbatim
-        // and its terminator stays the formatter's, like a statement (`write_suppressed_statement`).
-        // The element kinds' generated `fmt` only see a leading comment, so the gate is here.
+        // A suppressed element prints its content verbatim and its terminator stays the formatter's,
+        // like a statement (`write_suppressed_statement`); the element's own `fmt` would print the `;` as content.
         let suppressed = f.comments().is_node_suppressed(span, || self.content_end(f));
         if !suppressed && !needs_semi {
             return write!(f, element);

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -124,7 +124,7 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AnyJsxTagWithChildren<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_span_suppressed(self.span());
 
         let format_tag = format_with(|f| {
             if is_suppressed {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -86,7 +86,6 @@ use crate::{
             write_trailing_comments_before,
         },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
-        suppressed::{FormatSuppressedNode, write_suppressed_content},
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
         typecast::is_cast_target,
     },
@@ -212,11 +211,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, ObjectProp
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        if f.comments().has_trailing_suppression_comment(self.span().end) {
-            write!(f, [FormatSuppressedNode(self.span())]);
-            return;
-        }
-
         let is_accessor = match &self.kind() {
             PropertyKind::Init => false,
             PropertyKind::Get => {
@@ -1315,13 +1309,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSEnumMemb
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        // A trailing suppression comment (`A = 1, // prettier-ignore`) suppresses like a leading one;
-        // the `,` is a separator the list prints, so the member prints whole
-        if f.comments().has_trailing_suppression_comment(self.span().end) {
-            write!(f, [FormatSuppressedNode(self.span())]);
-            return;
-        }
-
         let id = self.id();
         let is_computed = matches!(id.as_ref(), TSEnumMemberName::ComputedTemplateString(_));
 
@@ -1745,17 +1732,9 @@ impl GetSpan for FormatTSSignature<'_, '_> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatTSSignature<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if f.comments().is_suppressed(self.signature.span().start) {
+        // A suppressed member prints whole: its `;`/`,` is a separator, not a terminator
+        if f.comments().is_span_suppressed(self.signature.span()) {
             return write!(f, [self.signature]);
-        }
-
-        if f.comments().has_trailing_suppression_comment(self.signature.span().end) {
-            format_leading_comments(self.signature.span()).fmt(f);
-            write_suppressed_content(self.signature.span(), None, f);
-            let comments =
-                f.context().comments().end_of_line_comments_after(self.signature.span().end);
-            write!(f, FormatTrailingComments::Comments(comments));
-            return;
         }
 
         write!(f, [&self.signature]);

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     parentheses::NeedsParentheses,
     print::FormatWrite,
-    utils::{suppressed::FormatSuppressedNode, typescript::should_hug_type},
+    utils::{suppressed::write_suppressed_expression, typescript::should_hug_type},
     write,
 };
 
@@ -367,20 +367,15 @@ fn format_union_types<'a>(
     let mut node_iter = node.iter().peekable();
     while let Some(element) = node_iter.next() {
         let element_span = element.span();
-        let has_trailing_suppression_comment =
-            f.comments().has_trailing_suppression_comment(element_span.end);
-
-        if suppressed_node_span == element_span || has_trailing_suppression_comment {
-            let comments = f.context().comments().comments_before(element_span.start);
-            FormatLeadingComments::Comments(comments).fmt(f);
-            let needs_parentheses = element.needs_parentheses(f);
-            if needs_parentheses {
-                write!(f, "(");
-            }
-            write!(f, [FormatSuppressedNode(element_span)]);
-            if needs_parentheses {
-                write!(f, ")");
-            }
+        if suppressed_node_span == element_span
+            || f.comments().has_trailing_suppression_comment(element_span.end)
+        {
+            write_suppressed_expression(
+                element_span,
+                element_span.start,
+                element.needs_parentheses(f),
+                f,
+            );
         } else if should_hug {
             write!(f, [element]);
         } else {

--- a/crates/oxc_formatter_core/src/source/text.rs
+++ b/crates/oxc_formatter_core/src/source/text.rs
@@ -68,7 +68,13 @@ impl<'a> SourceText<'a> {
     // Byte checking
     /// First non-whitespace byte at or after position
     pub fn next_non_whitespace_byte(&self, position: u32) -> Option<u8> {
-        self.bytes_from(position).find(|byte| !byte.is_ascii_whitespace())
+        self.next_byte_skipping(position, |byte| byte.is_ascii_whitespace())
+    }
+
+    /// First byte at or after position that `skip` rejects
+    #[inline]
+    pub fn next_byte_skipping(&self, position: u32, skip: impl Fn(u8) -> bool) -> Option<u8> {
+        self.bytes_from(position).find(|&byte| !skip(byte))
     }
 
     /// Check if first non-whitespace byte at position matches expected

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -49,6 +49,10 @@ const AST_NODE_WITHOUT_PRINTING_COMMENTS_LIST: &[&str] = &[
 const AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST: &[&str] =
     &["TSUnionType", "ExpressionStatement"];
 
+// A trailing suppression comment counts like a leading one, and the outermost node ending there claims it.
+// A union leaves it to its member instead, like Prettier (`handleUnionTypeComments`); see `format_union_types`.
+const AST_NODE_WITHOUT_TRAILING_SUPPRESSION_LIST: &[&str] = &["TSUnionType"];
+
 const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSTypeAssertion",
     "TSInferType",
@@ -198,8 +202,10 @@ fn generate_struct_implementation(
                 | "ExportDefaultDeclaration"
         ))
         .then(|| {
-            quote! {
-                let is_suppressed = f.comments().is_suppressed(self.span().start);
+            if AST_NODE_WITHOUT_TRAILING_SUPPRESSION_LIST.contains(&struct_name) {
+                quote! { let is_suppressed = f.comments().is_suppressed(self.span().start); }
+            } else {
+                quote! { let is_suppressed = f.comments().is_span_suppressed(self.span()); }
             }
         });
 
@@ -359,17 +365,6 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
             // and hands its terminator back to the formatter, decided once per statement here.
             quote! {
                 if write_suppressed_statement(self, f) {
-                    format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
-                        .fmt(f);
-                    return;
-                }
-            }
-        }
-        "Expression" => {
-            quote! {
-                if f.comments().has_trailing_suppression_comment(self.span().end) {
-                    format_leading_comments(self.span()).fmt(f);
-                    FormatSuppressedNode(self.span()).fmt(f);
                     format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
                         .fmt(f);
                     return;


### PR DESCRIPTION
Now, leading and trailing suppress comments are handled samely.