### PR TITLE
fix(formatter): unify suppress behavior (plan A)

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -138,7 +138,7 @@ JS-side mechanics of the shared "never cross" invariants:
   - Both are structural guarantees, keep them
   - One known violation, kept for Prettier compat: an own-line comment claimed mid-line inlines onto that line (`const // c` + break), see the NOTE in `FormatLeadingComments` (`formatter/trivia.rs`)
 - User content: attachment artifacts that relocate a comment across tokens are divergences to pin, never rules to emulate (e.g. DIVERGENCES.md#array-hole-trailing-comment)
-- Suppression: when hiding comments from a node (`limit_comments_up_to`), check `has_trailing_suppression_comment` first, or the node loses its suppression
+- Suppression: when hiding comments from a node (`limit_comments_up_to`), check `is_trailing_suppressed` first, or the node loses its suppression
 
 Head-body comment policy ("never cross user content" applied to statement/declaration heads):
 a body's `{` `}` and a head's `(` `)` are delimiters, and an empty-statement body's `;` is content, not a terminator (the verbatim empty-statement note in "Statement terminators and suppression"), so a comment between a head and its body keeps its side of each, uniformly across constructs:
@@ -171,21 +171,26 @@ deciding on the spot, we encode the same policy per site, so keep them in step:
 - return/throw: the same-line-prefix dangling split in `ReturnAndThrowStatement`
 - capture side: `Comments::get_trailing_comments` lets deferred own-line comments escape when the statement shares its distant `;` with the enclosing statement
   (a single-statement body, `if (1) foo\n// c\n;`); a block's last statement keeps them inside instead
-- suppressed side: `suppressed_statement_content_end` (`print/mod.rs`) ends the ignored range at the content,
-  so even a `prettier-ignore`d statement gets the formatter's terminator (per `semi`) instead of its source one
+- suppressed side: a suppressed node prints its source text as written, `;` or no `;`, whatever `semi` says
+  (`write_suppressed_node` in `print/mod.rs`; the generated `Statement` fmt and `FormatClassElementWithSemicolon` gate a trailing suppression comment the same way);
+  the formatter neither adds nor strips a terminator, the line the user marked is untouched (DIVERGENCES.md#suppressed-node-verbatim).
+  Prettier's `locEnd` override table re-adds or strips the `;` of statements and prints class members whole; ours is the one rule
+  - The exception is a `;` the parser attached from a LATER line (`foo() // prettier-ignore` + `;[].sort()`, the `semi: false` style's guard):
+    `Comments::suppressed_range` leaves it out and it is the formatter's again, re-printed where its own rules put it
+    (the next statement's ASI guard, a class member's own `;`); keeping it would double it with the guard on every pass
 - suppressed expression side: `write_suppressed_expression` (`utils/suppressed.rs`) owns the whole sequence
   for expression-shaped nodes (the generated `fmt` and the arrow sequence-body site call it before anything of the node is printed), so a cast target keeps its source cast parens (excluded from its span, `utils/typecast.rs`'s `write_suppressed_cast_target`) and in-paren comments print in place via the verbatim range
 
-Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
+The ASI guard (`write_leading_comments_with_asi_guard`) prints when the statement starts with a token that would continue an expression
+and the previous statement's terminator is not there: per `semi` after a formatted statement, per its source text after a verbatim one
+(`previous_statement_terminated`, read back through `JsFormatContext::last_verbatim_node`).
+A verbatim statement without `;` is the only case the guard prints under `semi: true` (DIVERGENCES.md#suppressed-unterminated-asi-guard):
+the source parsed the two apart, so only a first token the reprint introduces (`a => a` -> `(a) => a`) can merge them.
 
-- Whether a suppressed statement re-adds `;` is a compat table, not a principle:
-  keyword statements (`debugger`/`break`/`continue`) and variable declarations (ignored range ends at the last declarator) always re-add;
-  content-terminated ones, including `export const` (measured, keep the asymmetry), only when a source `;` was stripped.
-  A `for` head declaration instead stays verbatim (DIVERGENCES.md#suppressed-for-head-declaration)
-- The `semi: false` ASI guard is decided from the guarded statement alone,
-  never from the previous statement's output;
-  sound because no statement leaves its own trailing `;`,
-  except a verbatim empty-statement body (`with (1) ;`, that `;` IS the body, i.e. content), where guard plus verbatim `;` re-parse as one extra inert `EmptyStatement`
+Accepted edges (semantically inert, idempotent):
+
+- A `for` head declaration has no terminator of its own; Prettier re-adds one anyway (DIVERGENCES.md#suppressed-for-head-declaration)
+- A verbatim empty-statement body (`with (1) ;`, that `;` IS the body, i.e. content) plus the guard re-parse as one extra inert `EmptyStatement`
 
 ## Verification
 

--- a/crates/oxc_formatter/DIVERGENCES.md
+++ b/crates/oxc_formatter/DIVERGENCES.md
@@ -453,7 +453,69 @@ for (/* prettier-ignore */ var i   =   1;; ;) [].sort();
 
 Prettier's `shouldIgnoredNodePrintSemicolon` lists `VariableDeclaration` unconditionally,
 so a suppressed declaration in a `for` head gets an extra `;` and the head no longer parses (a `for (;;)` head admits exactly two semicolons).
-In the head the declaration has no terminator of its own; we keep it verbatim and let the `for` statement print its separators.
+In the head the declaration has no terminator of its own; we keep it verbatim (the rule for every suppressed node, see #suppressed-node-verbatim) and let the `for` statement print its separators.
+
+## suppressed-node-verbatim
+
+- Why: uniform-rule (same construct, same output: suppressed class member)
+- Pin: `tests/fixtures/js/semicolons/suppressed-statement.js`, `tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js`, `tests/fixtures/ts/ignore/class-member-trailing.ts`
+
+```js
+// input
+// prettier-ignore
+const noSemi   =   1
+// prettier-ignore
+stmt(   );
+
+// ours (semi: true and semi: false alike)
+// prettier-ignore
+const noSemi   =   1
+// prettier-ignore
+stmt(   );
+
+// prettier (semi: true)
+// prettier-ignore
+const noSemi   =   1;
+// prettier-ignore
+stmt(   );
+
+// prettier (semi: false)
+// prettier-ignore
+const noSemi   =   1
+// prettier-ignore
+stmt(   )
+```
+
+A suppressed node prints its source text as written: the formatter neither adds nor strips its `;`, whatever `semi` says.
+Prettier prints a suppressed class member, interface member, type alias or `declare function` that way, but its `locEnd` override table ends a statement's ignored range before the `;`
+and `shouldIgnoredNodePrintSemicolon` re-adds one per `semi` (always for `debugger`/`break`/`continue`/variable declarations, else only when a source `;` was stripped);
+`debugger ;` even loses its space.
+One rule instead: the line the user marked is untouched.
+A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style) is the one exception: it is left out and re-printed as the next statement's ASI guard (or a class member's own `;`), the same place the source had it.
+
+Conformance failures owned by this entry: `js/comments/break-continue-statements-3.js`, and the `semi: true` variant of `js/no-semi/{debugger,do-while,for,for-in,for-of,if,labeled,return,while,with}-statement.js`.
+
+## suppressed-unterminated-asi-guard
+
+- Why: semantics (Prettier's output re-parses as a call and no longer parses)
+- Pin: `tests/fixtures/js/semicolons/suppressed-unterminated-asi-guard.js`
+
+```js
+// input (semi: true)
+foo(  ) // prettier-ignore
+a => a
+
+// ours
+foo(  ) // prettier-ignore
+;(a) => a;
+
+// prettier
+foo(  ) // prettier-ignore
+(a) => a;
+```
+
+The verbatim statement keeps every token, so the source's statement boundary survives unless the reprint of the next statement introduces a first token that continues an expression (`arrowParens: "always"` here).
+That statement takes the ASI guard the `semi: false` output always has; Prettier's output re-parses as `foo(  )(a) => a`.
 
 ## suppressed-source-paren-asi-guard
 
@@ -496,13 +558,14 @@ We check the verbatim range's first byte instead and print the guard.
 
 // ours
 // prettier-ignore
-;/** @type {string[]} */ (cast).sort()
+;/** @type {string[]} */ (cast).sort();
 
 // prettier
 // prettier-ignore
 /** @type {string[]} */ ;(cast).sort()
 ```
 
+(The source `;` staying is #suppressed-node-verbatim.)
 A cast comment types its parenthesized expression only when directly adjacent:
 with Prettier's placement tsc reports the target as its uncast type again.
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -15,7 +15,7 @@ use crate::{
     parentheses::NeedsParentheses,
     print::FormatWrite,
     utils::{
-        suppressed::{FormatSuppressedNode, write_suppressed_expression},
+        suppressed::{FormatSuppressedNode, write_suppressed_expression, write_suppressed_node},
         typecast::{
             format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren,
             format_type_cast_comment_node,
@@ -32,7 +32,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Program<'a>> {
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Expression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if f.comments().has_trailing_suppression_comment(self.span().end) {
+        if f.comments().is_trailing_suppressed(self.span()) {
             format_leading_comments(self.span()).fmt(f);
             FormatSuppressedNode(self.span()).fmt(f);
             format_trailing_comments(
@@ -476,7 +476,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -520,7 +520,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -533,7 +533,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -649,7 +649,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -723,7 +723,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectProperty<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -839,7 +839,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateElement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -1109,7 +1109,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SpreadElement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1503,7 +1503,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1516,7 +1516,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1529,7 +1529,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetRest<'a
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1573,7 +1573,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetWithDef
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1616,7 +1616,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1629,7 +1629,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -1837,10 +1837,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Statement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         if !matches!(self.inner, Statement::ExpressionStatement(_))
-            && f.comments().has_trailing_suppression_comment(self.span().end)
+            && f.comments().is_trailing_suppressed(self.span())
         {
             format_leading_comments(self.span()).fmt(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            write_suppressed_node(self.span(), f);
             format_trailing_comments(
                 self.parent.span(),
                 self.inner.span(),
@@ -2063,7 +2063,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2076,7 +2076,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2089,7 +2089,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BlockStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2212,7 +2212,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2225,7 +2225,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2238,7 +2238,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2251,7 +2251,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2264,7 +2264,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2277,7 +2277,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2290,7 +2290,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2303,7 +2303,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2347,7 +2347,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForInStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2391,7 +2391,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2404,7 +2404,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2417,7 +2417,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2430,7 +2430,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2443,7 +2443,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2456,7 +2456,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2469,7 +2469,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2482,7 +2482,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2495,7 +2495,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2508,7 +2508,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2521,7 +2521,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2534,7 +2534,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2547,7 +2547,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DebuggerStatement> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2610,7 +2610,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2623,7 +2623,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2636,7 +2636,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2649,7 +2649,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2662,7 +2662,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2706,7 +2706,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2719,7 +2719,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2732,7 +2732,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2745,7 +2745,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FunctionBody<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2882,7 +2882,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2895,7 +2895,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassBody<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2968,7 +2968,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2981,7 +2981,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -2994,7 +2994,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3007,7 +3007,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticBlock<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3110,7 +3110,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3154,7 +3154,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclaration<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3207,7 +3207,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3220,7 +3220,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3233,7 +3233,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifie
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3246,7 +3246,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3259,7 +3259,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttribute<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3302,7 +3302,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3315,7 +3315,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3328,7 +3328,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3341,7 +3341,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaratio
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3354,7 +3354,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3367,7 +3367,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportSpecifier<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3704,7 +3704,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3717,7 +3717,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingElement<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3746,7 +3746,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3759,7 +3759,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingFragment> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3832,7 +3832,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3845,7 +3845,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpression<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3898,7 +3898,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpressionContainer<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3942,7 +3942,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXEmptyExpression> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3985,7 +3985,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -3998,7 +3998,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadAttribute<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4091,7 +4091,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXIdentifier<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4164,7 +4164,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4177,7 +4177,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4190,7 +4190,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4203,7 +4203,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4216,7 +4216,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4229,7 +4229,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMember<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4292,7 +4292,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4305,7 +4305,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSLiteralType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4804,7 +4804,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
         format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             self.write_suppressed_leading_comments(f);
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4851,7 +4851,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4895,7 +4895,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4908,7 +4908,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4921,7 +4921,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4934,7 +4934,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4947,7 +4947,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -4960,7 +4960,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSRestType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5014,7 +5014,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5027,7 +5027,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5040,7 +5040,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5053,7 +5053,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5066,7 +5066,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5079,7 +5079,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5092,7 +5092,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5105,7 +5105,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5118,7 +5118,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5131,7 +5131,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5144,7 +5144,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5157,7 +5157,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5170,7 +5170,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5183,7 +5183,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5196,7 +5196,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeReference<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5249,7 +5249,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5262,7 +5262,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstanti
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5275,7 +5275,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5288,7 +5288,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclarat
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5301,7 +5301,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5314,7 +5314,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5327,7 +5327,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5340,7 +5340,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5353,7 +5353,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSPropertySignature<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5426,7 +5426,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5439,7 +5439,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclarat
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5452,7 +5452,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5465,7 +5465,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDec
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5478,7 +5478,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5491,7 +5491,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5504,7 +5504,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicate<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5547,7 +5547,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclara
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5560,7 +5560,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclaration<
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5603,7 +5603,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5616,7 +5616,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5629,7 +5629,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5735,7 +5735,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5778,7 +5778,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedNa
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5853,7 +5853,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5866,7 +5866,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -5972,7 +5972,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportEqualsDeclarati
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6025,7 +6025,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReferen
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6069,7 +6069,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6082,7 +6082,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>>
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6095,7 +6095,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclar
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6139,7 +6139,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> 
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6152,7 +6152,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }
@@ -6165,7 +6165,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocUnknownType> {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            self.write_suppressed(f);
+            write_suppressed_node(self.suppressed_span(), f);
         } else {
             self.write(f);
         }

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -549,6 +549,44 @@ impl<'a> Comments<'a> {
             .any(|comment| self.is_suppression_comment(comment))
     }
 
+    /// Whether a trailing suppression comment suppresses the node ([`Self::has_trailing_suppression_comment`]
+    /// at the end of its [`Self::suppressed_range`]: `foo() // prettier-ignore` + `;[].sort()` counts).
+    pub fn is_trailing_suppressed(&self, span: Span) -> bool {
+        self.has_trailing_suppression_comment(self.suppressed_range(span).end)
+    }
+
+    /// The range a suppressed node prints verbatim: its span, minus a `;` the parser attached from a later line
+    /// (`foo() // prettier-ignore` + `;[].sort()`: the `semi: false` style's guard belongs to the next line).
+    /// That `;` is the formatter's terminator again, re-printed where its own rules put it
+    /// (the next statement's ASI guard, a class member's own `;`).
+    pub fn suppressed_range(&self, span: Span) -> Span {
+        // Detached only through trivia: the byte before the `;` is whitespace or a comment's `/`
+        if span.size() < 2
+            || !self.source_text.text_for(&span).ends_with(';')
+            || !matches!(
+                self.source_text.bytes_range(span.end - 2, span.end - 1),
+                b" " | b"\t" | b"\n" | b"\r" | b"/"
+            )
+        {
+            return span;
+        }
+        let semicolon = span.end - 1;
+        let comments = self.all_comments_before(semicolon);
+        let comments =
+            &comments[comments.partition_point(|comment| comment.span.start < span.start)..];
+        let run = self.comment_run_before(comments, semicolon);
+        let end = run.first().map_or(semicolon, |comment| comment.span.start);
+        let content = self.source_text.slice_range(span.start, end).trim_end();
+        #[expect(clippy::cast_possible_truncation)]
+        let content_end = span.start + content.len() as u32;
+        // An empty statement is its `;`: content, not a terminator
+        if !content.is_empty() && self.source_text.bytes_contain(content_end, semicolon, b'\n') {
+            Span::new(span.start, content_end)
+        } else {
+            span
+        }
+    }
+
     /// Whether the range holds a `;` or a `)` outside comments (`foo /* ; */` doesn't count).
     /// Why a `)` counts as a statement terminator: see `trailing_comments_to_move_behind_semicolon`
     /// (a lexical byte scan, see the module doc).
@@ -697,6 +735,23 @@ impl<'a> Comments<'a> {
         let run = self.comment_run_after(comments, pos);
         let end = run.last()?.span.end;
         self.source_text.next_non_whitespace_byte_is(end, b')').then_some(run)
+    }
+
+    /// The mirror of [`Self::comment_run_after`]: the run ending at `pos` (a suffix of `comments`).
+    fn comment_run_before(&self, comments: &'a [Comment], pos: u32) -> &'a [Comment] {
+        let mut cursor = pos;
+        let mut count = 0;
+        for comment in comments.iter().rev() {
+            if !self
+                .source_text
+                .all_bytes_match(comment.span.end, cursor, |b| b.is_ascii_whitespace())
+            {
+                break;
+            }
+            count += 1;
+            cursor = comment.span.start;
+        }
+        &comments[comments.len() - count..]
     }
 
     /// The run of comments after `pos` separated only by whitespace (a prefix of `comments`).

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -109,6 +109,10 @@ pub struct JsFormatContext<'ast> {
     /// Stack tracking whether we're inside a Tailwind class context.
     /// When non-empty, StringLiterals should be sorted as Tailwind classes.
     tailwind_context_stack: Vec<TailwindContextEntry>,
+
+    /// The last node printed verbatim (`write_suppressed_node`): its span end and whether its text ends with `;`.
+    /// The next statement's ASI guard asks whether the statement before it was that node (`previous_statement_terminated`).
+    last_verbatim_node: Option<(u32, bool)>,
 }
 
 impl std::fmt::Debug for JsFormatContext<'_> {
@@ -167,6 +171,7 @@ impl<'ast> JsFormatContext<'ast> {
             quote_needed_stack: Vec::new(),
             tailwind_classes: Vec::new(),
             tailwind_context_stack: Vec::new(),
+            last_verbatim_node: None,
         }
     }
 
@@ -228,6 +233,21 @@ impl<'ast> JsFormatContext<'ast> {
     /// `write` (a suppressed arrow prints its source verbatim instead).
     pub(crate) fn clear_arrow_assignment_layout(&mut self) {
         self.arrow_assignment_layout = None;
+    }
+
+    pub(crate) fn set_last_verbatim_node(&mut self, span_end: u32, terminated: bool) {
+        self.last_verbatim_node = Some((span_end, terminated));
+    }
+
+    pub(crate) fn has_verbatim_node(&self) -> bool {
+        self.last_verbatim_node.is_some()
+    }
+
+    /// Whether the node ending at `span_end` printed verbatim, and then whether its text ends with `;`
+    /// (a suppressed statement's rightmost body ends where the statement does).
+    pub(crate) fn verbatim_node_terminated(&self, span_end: u32) -> Option<bool> {
+        self.last_verbatim_node
+            .and_then(|(end, terminated)| (end == span_end).then_some(terminated))
     }
 
     /// Pushes a new quote needed state onto the stack.

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -31,6 +31,7 @@ use crate::{
         is_keyword_property_key,
         object::{format_property_key, should_preserve_quote},
         statement_body::write_head_body_separator,
+        suppressed::write_trailing_suppressed_node,
     },
     write,
 };
@@ -602,19 +603,32 @@ impl<'a, 'b> FormatClassElementWithSemicolon<'a, 'b> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatClassElementWithSemicolon<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
+        let span = self.element.span();
+        let leading_suppressed = f.comments().is_suppressed(span.start);
+        // A trailing suppression comment (`p = 1; // prettier-ignore`) suppresses like a leading one;
+        // the element kinds' generated `fmt` only see a leading one, so the gate is here.
+        if leading_suppressed || f.comments().is_trailing_suppressed(span) {
+            // A suppressed element prints its source text, `;` included, and the formatter adds none.
+            if leading_suppressed {
+                write!(f, self.element);
+            } else {
+                write_trailing_suppressed_node(span, f);
+            }
+            // Only a `;` its range left on a later line (`p = 1 // prettier-ignore` + `;[k] = 2`)
+            // is the formatter's again, printed where a class member's `;` goes
+            if f.comments().suppressed_range(span).end < span.end {
+                write!(f, ";");
+            }
+            return;
+        }
+
         let needs_semi = matches!(
             self.element.as_ref(),
             ClassElement::PropertyDefinition(_) | ClassElement::AccessorProperty(_)
-        );
-
-        let needs_semi = needs_semi
-            && match f.options().semicolons {
-                Semicolons::Always => true,
-                Semicolons::AsNeeded => self.needs_semicolon(),
-            }
-            // Don't add semicolon if the element is suppressed (has `oxfmt-ignore`),
-            // because the suppressed source text already includes the original semicolon.
-            && !f.comments().is_suppressed(self.element.span().start);
+        ) && match f.options().semicolons {
+            Semicolons::Always => true,
+            Semicolons::AsNeeded => self.needs_semicolon(),
+        };
 
         if needs_semi {
             // Same-line comments between the content end and the source semicolon

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -75,7 +75,7 @@ use crate::{
         format_node_without_trailing_comments::{
             FormatNodeWithoutTrailingComments, format_content_without_comments_after,
         },
-        is_keyword_property_key,
+        is_dropped_statement, is_keyword_property_key,
         object::{
             format_property_key, is_quoted_new_method_signature, should_preserve_quote,
             should_preserve_quote_for_enum_member,
@@ -86,7 +86,7 @@ use crate::{
             write_trailing_comments_before,
         },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
-        suppressed::FormatSuppressedNode,
+        suppressed::{FormatSuppressedNode, write_suppressed_node, write_trailing_suppressed_node},
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
         typecast::is_cast_target,
     },
@@ -132,22 +132,9 @@ pub trait FormatWrite<'ast> {
     {
         self.span().start
     }
-    /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`):
-    /// prints `suppressed_span` verbatim.
-    /// Expression-shaped nodes don't route here: the generated `fmt` hands them to
-    /// `write_suppressed_expression`, which keeps a cast target's source parentheses.
-    ///
-    /// NOTE: Extend the overrides one statement at a time with verifying each.
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'ast>)
-    where
-        Self: GetSpan,
-    {
-        FormatSuppressedNode(self.suppressed_span()).fmt(f);
-    }
-
     /// The leading-comments step of the suppressed path,
     /// for nodes whose generated `fmt` leaves leading comments to the node;
-    /// it calls this, then [`Self::write_suppressed`].
+    /// it calls this, then `write_suppressed_node`.
     /// Override to interleave with the comments (`ExpressionStatement`'s ASI guard).
     fn write_suppressed_leading_comments(&self, f: &mut JsFormatter<'_, 'ast>)
     where
@@ -668,7 +655,68 @@ fn expression_statement_needs_semicolon<'a>(
     })
 }
 
-/// Prints the statement's leading comments with the `semi: false` ASI guard spliced in
+/// Whether the statement before `stmt` (empty statements aside) printed its terminator:
+/// per `semi` after a formatted statement, per its source text after a verbatim one
+/// (`write_suppressed_node`; a suppressed statement's rightmost body ends where the statement does).
+/// The source parsed the two apart and the verbatim text keeps every token,
+/// so the only new hazard is a first token the reprint introduces (`a => a` -> `(a) => a`);
+/// the `semi: true` output then needs the ASI guard the `semi: false` output always has.
+/// Prettier prints the merged `foo()(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+fn previous_statement_terminated<'a>(
+    stmt: &AstNode<'a, ExpressionStatement<'a>>,
+    f: &JsFormatter<'_, 'a>,
+) -> bool {
+    let per_semi = f.options().semicolons == Semicolons::Always;
+    let siblings: &[Statement<'a>] = match stmt.parent() {
+        AstNodes::Program(program) => &program.body,
+        AstNodes::BlockStatement(block) => &block.body,
+        AstNodes::FunctionBody(body) => &body.statements,
+        AstNodes::StaticBlock(block) => &block.body,
+        AstNodes::SwitchCase(case) => &case.consequent,
+        AstNodes::TSModuleBlock(block) => &block.body,
+        _ => return per_semi,
+    };
+    let index = siblings.partition_point(|sibling| sibling.span().start < stmt.span().start);
+    let Some(previous) =
+        siblings[..index].iter().rev().find(|sibling| !is_dropped_statement(sibling))
+    else {
+        return per_semi;
+    };
+    // Keyword-ended (`debugger`, `break`) and body-ended (`}`) leaves are boundaries by grammar,
+    // and `do ... while ()` takes its `;` by the special ASI rule
+    let leaf = rightmost_statement(previous);
+    if !matches!(
+        leaf,
+        Statement::ExpressionStatement(_)
+            | Statement::VariableDeclaration(_)
+            | Statement::ReturnStatement(_)
+            | Statement::ThrowStatement(_)
+            | Statement::ExportDefaultDeclaration(_)
+            | Statement::ExportNamedDeclaration(_)
+            | Statement::TSExportAssignment(_)
+    ) {
+        return per_semi;
+    }
+    f.context().verbatim_node_terminated(leaf.span().end).unwrap_or(per_semi)
+}
+
+/// The statement a statement ends with: itself, or its rightmost single-statement body.
+fn rightmost_statement<'a, 'b>(mut stmt: &'b Statement<'a>) -> &'b Statement<'a> {
+    loop {
+        stmt = match stmt {
+            Statement::IfStatement(s) => s.alternate.as_ref().unwrap_or(&s.consequent),
+            Statement::WhileStatement(s) => &s.body,
+            Statement::WithStatement(s) => &s.body,
+            Statement::ForStatement(s) => &s.body,
+            Statement::ForInStatement(s) => &s.body,
+            Statement::ForOfStatement(s) => &s.body,
+            Statement::LabeledStatement(s) => &s.body,
+            _ => return stmt,
+        };
+    }
+}
+
+/// Prints the statement's leading comments with the ASI guard spliced in
 /// before a trailing type cast comment: `;/** @type {string[]} */ ([]).forEach(...)`.
 /// `/** @type {string[]} */ ;([]).forEach(...)` form breaks type cast.
 /// For `verbatim`, see [`expression_statement_needs_semicolon`].
@@ -678,8 +726,12 @@ fn write_leading_comments_with_asi_guard<'a>(
     f: &mut JsFormatter<'_, 'a>,
 ) {
     let start = stmt.span().start;
-    let needs_semicolon = f.options().semicolons == Semicolons::AsNeeded
-        && expression_statement_needs_semicolon(stmt, f, verbatim);
+    // The guard prints when the previous statement's terminator is not there;
+    // under `semi: true` that takes a verbatim statement, so the cheap check goes first
+    let needs_semicolon = (f.options().semicolons == Semicolons::AsNeeded
+        || f.context().has_verbatim_node())
+        && expression_statement_needs_semicolon(stmt, f, verbatim)
+        && !previous_statement_terminated(stmt, f);
     let leading_comments = f.context().comments().comments_before(start);
     let split = if needs_semicolon
         && leading_comments.last().is_some_and(|last| f.comments().is_type_cast_comment(last))
@@ -702,21 +754,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
         write_leading_comments_with_asi_guard(self, true, f);
     }
 
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the expression (plus source parens)
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.expression().span().end, self.span(), f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let span = self.span();
-        write_leading_comments_with_asi_guard(self, false, f);
-
-        if f.comments().has_trailing_suppression_comment(span.end) {
-            // Preserve original text when the statement has an inline suppression comment:
-            // `stmt(); // prettier-ignore` or `stmt(); /* prettier-ignore */`
-            write!(f, [FormatSuppressedNode(span)]);
+        // A trailing suppression comment (`stmt(); // prettier-ignore`) suppresses like a leading one
+        let suppressed = f.comments().is_trailing_suppressed(self.span());
+        write_leading_comments_with_asi_guard(self, suppressed, f);
+        if suppressed {
+            write_suppressed_node(self.span(), f);
             return;
         }
 
@@ -732,135 +775,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-/// Prints a suppressed statement whose ignored range excludes the trailing semicolon:
-/// the source from `start` up to `content_end` verbatim,
-/// then the formatter's own terminator, like Prettier (prettier#18678).
-/// Comments between `content_end` and the end of the statement are left
-/// for the next node's leading-comments pass.
-fn write_suppressed_statement_with_semicolon(
-    start: u32,
-    content_end: u32,
-    f: &mut JsFormatter<'_, '_>,
-) {
-    write!(f, [FormatSuppressedNode(Span::new(start, content_end)), OptionalSemicolon]);
-}
-
-/// Prints a suppressed statement whose ignored range may or may not have had
-/// its trailing `;` stripped (see [`suppressed_statement_content_end`]).
-fn write_suppressed_statement(
-    span: Span,
-    content_end: u32,
-    print_semicolon: bool,
-    f: &mut JsFormatter<'_, '_>,
-) {
-    if print_semicolon {
-        write_suppressed_statement_with_semicolon(span.start, content_end, f);
-    } else {
-        debug_assert_eq!(content_end, span.end);
-        FormatSuppressedNode(span).fmt(f);
-    }
-}
-
-/// The ignored range end for a statement terminated by a (possibly distant) source `;`,
-/// and whether one was actually stripped (so the formatter must print its own).
-fn semicolon_terminated_content_end(
-    content_end: u32,
-    span: Span,
-    f: &JsFormatter<'_, '_>,
-) -> (u32, bool) {
-    let end = f.comments().end_including_source_parens(content_end, span.end);
-    (end, end < span.end)
-}
-
-#[expect(clippy::cast_possible_truncation)]
-const RETURN_KEYWORD_LEN: u32 = "return".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const DEBUGGER_KEYWORD_LEN: u32 = "debugger".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const BREAK_KEYWORD_LEN: u32 = "break".len() as u32;
-#[expect(clippy::cast_possible_truncation)]
-const CONTINUE_KEYWORD_LEN: u32 = "continue".len() as u32;
-
-/// The ignored range end for `return` (the argument or the keyword),
-/// and whether a source `;` was stripped.
-fn return_statement_content_end(s: &ReturnStatement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
-    s.argument.as_ref().map_or_else(
-        || {
-            let keyword_end = s.span.start + RETURN_KEYWORD_LEN;
-            (keyword_end, keyword_end < s.span.end)
-        },
-        |argument| semicolon_terminated_content_end(argument.span().end, s.span, f),
-    )
-}
-
-/// The ignored range end for `break`/`continue`: the label, or the keyword.
-fn break_or_continue_content_end(
-    span: Span,
-    keyword_len: u32,
-    label: Option<&LabelIdentifier<'_>>,
-) -> u32 {
-    label.map_or(span.start + keyword_len, |label| label.span.end)
-}
-
-/// The ignored range end for a variable declaration: the last declarator,
-/// extended over a cast's source parens.
-/// The source `;` is always outside (Prettier's `locEnd` override lists `VariableDeclaration`).
-fn variable_declaration_content_end(
-    declaration: &VariableDeclaration<'_>,
-    f: &JsFormatter<'_, '_>,
-) -> u32 {
-    // `VariableDeclaration` always has at least one declarator
-    let declarations_end = declaration.declarations.last().unwrap().span.end;
-    // The stripped-`;` flag is discarded: a declaration re-adds its terminator unconditionally
-    semicolon_terminated_content_end(declarations_end, declaration.span, f).0
-}
-
-/// The ignored range end of a suppressed statement and whether the formatter prints its own terminator after it,
-/// mirroring Prettier's `locEnd` overrides (`language-js/location/overrides.js`) + `shouldIgnoredNodePrintSemicolon`:
-/// the trailing `;` (and anything between it and the content) is excluded from the verbatim range,
-/// keyword statements (`debugger`/`break`/`continue`) and variable declarations always re-add `;`,
-/// content-terminated ones only when a source `;` was stripped, and statements ending in a body recurse into the rightmost body.
-fn suppressed_statement_content_end(stmt: &Statement<'_>, f: &JsFormatter<'_, '_>) -> (u32, bool) {
-    match stmt {
-        Statement::ExpressionStatement(s) => {
-            semicolon_terminated_content_end(s.expression.span().end, s.span, f)
-        }
-        Statement::ReturnStatement(s) => return_statement_content_end(s, f),
-        Statement::ThrowStatement(s) => {
-            semicolon_terminated_content_end(s.argument.span().end, s.span, f)
-        }
-        Statement::DoWhileStatement(s) => {
-            semicolon_terminated_content_end(s.test.span().end, s.span, f)
-        }
-        Statement::DebuggerStatement(s) => (s.span.start + DEBUGGER_KEYWORD_LEN, true),
-        Statement::BreakStatement(s) => {
-            (break_or_continue_content_end(s.span, BREAK_KEYWORD_LEN, s.label.as_ref()), true)
-        }
-        Statement::ContinueStatement(s) => {
-            (break_or_continue_content_end(s.span, CONTINUE_KEYWORD_LEN, s.label.as_ref()), true)
-        }
-        Statement::VariableDeclaration(s) => (variable_declaration_content_end(s, f), true),
-        Statement::IfStatement(s) => {
-            suppressed_statement_content_end(s.alternate.as_ref().unwrap_or(&s.consequent), f)
-        }
-        Statement::WhileStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::WithStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForInStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::ForOfStatement(s) => suppressed_statement_content_end(&s.body, f),
-        Statement::LabeledStatement(s) => suppressed_statement_content_end(&s.body, f),
-        _ => (stmt.span().end, false),
-    }
-}
-
 impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the closing paren
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.test().span().end, self.span(), f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         let is_block_body = matches!(body.as_ref(), Statement::BlockStatement(_));
@@ -945,11 +860,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatParenHeadExpression<'a, '_> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -1001,11 +911,6 @@ where
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let init = self.init();
         let test = self.test();
@@ -1065,11 +970,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         let left = self.left();
@@ -1110,11 +1010,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
 
@@ -1156,14 +1051,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(
-            self.alternate.as_ref().unwrap_or(&self.consequent),
-            f,
-        );
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let test = self.test();
         let consequent = self.consequent();
@@ -1175,9 +1062,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
             // leave everything after it for the split below.
             // A trailing suppression comment must stay visible to the consequent,
             // so it preserves its original text.
-            if alternate.is_some()
-                && !f.comments().has_trailing_suppression_comment(consequent.span().end)
-            {
+            if alternate.is_some() && !f.comments().is_trailing_suppressed(consequent.span()) {
                 format_content_without_comments_after(&body, consequent.span().end, f);
             } else {
                 body.fmt(f);
@@ -1225,13 +1110,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the label (or the keyword)
-        let content_end =
-            break_or_continue_content_end(self.span(), CONTINUE_KEYWORD_LEN, self.label.as_ref());
-        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["continue", space(), label]));
@@ -1243,13 +1121,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the label (or the keyword)
-        let content_end =
-            break_or_continue_content_end(self.span(), BREAK_KEYWORD_LEN, self.label.as_ref());
-        write_suppressed_statement_with_semicolon(self.span().start, content_end, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         if let Some(label) = self.label() {
             let content = format_with(|f| write!(f, ["break", space(), label]));
@@ -1261,11 +1132,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -1286,11 +1152,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
-        write_suppressed_statement(self.span(), content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let label = self.label();
         let body = self.body();
@@ -1307,15 +1168,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, DebuggerStatement> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the keyword
-        write_suppressed_statement_with_semicolon(
-            self.span.start,
-            self.span.start + DEBUGGER_KEYWORD_LEN,
-            f,
-        );
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(f, ["debugger", OptionalSemicolon]);
     }
@@ -1984,11 +1836,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTSSignature<'a, '_> {
             return write!(f, [self.signature]);
         }
 
-        if f.comments().has_trailing_suppression_comment(self.signature.span().end) {
-            write!(f, [FormatSuppressedNode(self.signature.span())]);
-            let comments =
-                f.context().comments().end_of_line_comments_after(self.signature.span().end);
-            write!(f, FormatTrailingComments::Comments(comments));
+        if f.comments().is_trailing_suppressed(self.signature.span()) {
+            write_trailing_suppressed_node(self.signature.span(), f);
             return;
         }
 

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -152,7 +152,7 @@ fn format_import_decls_with_sort<'a, 'iter>(
 fn is_import_suppressed(stmt: &AstNode<'_, Statement<'_>>, f: &JsFormatter<'_, '_>) -> bool {
     let span = stmt.span();
     let comments = f.comments();
-    comments.is_suppressed(span.start) || comments.has_trailing_suppression_comment(span.end)
+    comments.is_suppressed(span.start) || comments.is_trailing_suppressed(span)
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Directive<'a>>> {

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -10,9 +10,8 @@ use crate::{
         trivia::{DanglingIndentMode, FormatDanglingComments},
     },
     print::{
-        ExpressionLeftSide, return_statement_content_end,
+        ExpressionLeftSide,
         semicolon::{OptionalSemicolon, assignment_chain_leaf_end},
-        semicolon_terminated_content_end, write_suppressed_statement,
     },
     utils::{
         format_node_without_trailing_comments::format_content_without_comments_after,
@@ -24,25 +23,12 @@ use crate::{
 use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        // The ignored range ends at the argument (or the keyword),
-        // excluding a stripped trailing `;`
-        let (content_end, print_semicolon) = return_statement_content_end(self, f);
-        write_suppressed_statement(self.span, content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ReturnStatement(self).fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        let (content_end, print_semicolon) =
-            semicolon_terminated_content_end(self.argument().span().end, self.span, f);
-        write_suppressed_statement(self.span, content_end, print_semicolon, f);
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         ReturnAndThrowStatement::ThrowStatement(self).fmt(f);
     }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -15,11 +15,7 @@ use crate::{
     write,
 };
 
-use crate::utils::suppressed::FormatSuppressedNode;
-
-use super::{
-    FormatWrite, variable_declaration_content_end, write_suppressed_statement_with_semicolon,
-};
+use super::FormatWrite;
 
 /// Whether the declaration is a `for`/`for-in`/`for-of` head,
 /// terminated by the head itself (the head-vs-body test is by span: a declaration can also be the body).
@@ -37,21 +33,6 @@ fn is_for_head_declaration(decl: &AstNode<'_, VariableDeclaration<'_>>) -> bool 
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
-    fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
-        if is_for_head_declaration(self) {
-            // No terminator of its own to re-add:
-            // Prettier appends one anyway and corrupts the head (DIVERGENCES.md#suppressed-for-head-declaration)
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            // The ignored range ends at the last declarator; the terminator is always the formatter's
-            write_suppressed_statement_with_semicolon(
-                self.span().start,
-                variable_declaration_content_end(self, f),
-                f,
-            );
-        }
-    }
-
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let semicolon = !is_for_head_declaration(self);
 

--- a/crates/oxc_formatter/src/utils/suppressed.rs
+++ b/crates/oxc_formatter/src/utils/suppressed.rs
@@ -3,7 +3,10 @@ use oxc_span::Span;
 
 use crate::{
     Buffer, Format,
-    formatter::prelude::*,
+    formatter::{
+        prelude::*,
+        trivia::{FormatTrailingComments, format_leading_comments},
+    },
     utils::typecast::{format_leading_comments_and_open_paren, write_suppressed_cast_target},
     write,
 };
@@ -36,6 +39,8 @@ pub fn write_suppressed_expression(
     }
 }
 
+/// Prints the given range of source text and marks its comments printed.
+/// Nodes go through [`write_suppressed_node`] / [`write_suppressed_expression`]; this is the bytes primitive.
 pub struct FormatSuppressedNode(pub Span);
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatSuppressedNode {
@@ -49,4 +54,31 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatSuppressedNode {
         // The suppressed node contains comments that should be marked as printed.
         f.context_mut().comments_mut().skip_comments_before(self.0.end);
     }
+}
+
+/// Prints a non-expression node's source text (`Comments::suppressed_range`)
+/// and records it for the next statement's ASI guard (`previous_statement_terminated`).
+/// Expression-shaped nodes go through [`write_suppressed_expression`] and never record:
+/// a statement ending in a verbatim expression still prints its own `;`.
+pub fn write_suppressed_node(span: Span, f: &mut JsFormatter<'_, '_>) {
+    let range = f.comments().suppressed_range(span);
+    FormatSuppressedNode(range).fmt(f);
+    let terminated = f.source_text().text_for(&range).ends_with(';');
+    f.context_mut().set_last_verbatim_node(span.end, terminated);
+    // The `;` left out sits on a later line; the same-line comments before it
+    // (the suppression comment itself) stay on the content's line
+    if range.end < span.end {
+        let comments = f.context().comments().end_of_line_comments_after(range.end);
+        FormatTrailingComments::Comments(comments).fmt(f);
+    }
+}
+
+/// Prints a member suppressed by a trailing comment (`p = 1; // prettier-ignore`)
+/// from a container whose generated `fmt` only sees a leading one:
+/// its leading comments, the source text, and the comments on its line.
+pub fn write_trailing_suppressed_node(span: Span, f: &mut JsFormatter<'_, '_>) {
+    format_leading_comments(span).fmt(f);
+    write_suppressed_node(span, f);
+    let comments = f.context().comments().end_of_line_comments_after(span.end);
+    FormatTrailingComments::Comments(comments).fmt(f);
 }

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-cast-comment-asi-guard.js.snap
@@ -42,7 +42,7 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 // the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
 
 // prettier-ignore
-;/** @type {string[]} */ (cast).sort()
+;/** @type {string[]} */ (cast).sort();
 
 --------------------------------
 { printWidth: 100, semi: false }
@@ -53,6 +53,6 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 // the guarded line deviates (DIVERGENCES.md#suppressed-cast-comment-asi-guard).
 
 // prettier-ignore
-;/** @type {string[]} */ (cast).sort()
+;/** @type {string[]} */ (cast).sort();
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-source-paren-asi-guard.js.snap
@@ -50,7 +50,7 @@ let x = 1;
 let x = 1
 
 // prettier-ignore
-;(sourceParen).sort()
+;(sourceParen).sort();
 
 --------------------------------
 { printWidth: 100, semi: false }
@@ -63,6 +63,6 @@ let x = 1
 let x = 1
 
 // prettier-ignore
-;(sourceParen).sort()
+;(sourceParen).sort();
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js
@@ -1,6 +1,8 @@
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
 do;   while(   1)
@@ -28,9 +30,7 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
 const noSemi   =   1
@@ -58,9 +58,8 @@ export const exported   =   1
 
 foo()
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
 stmt(   );

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-statement.js.snap
@@ -2,9 +2,11 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
 do;   while(   1)
@@ -32,9 +34,7 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
 const noSemi   =   1
@@ -62,9 +62,8 @@ export const exported   =   1
 
 foo()
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
 stmt(   );
@@ -76,12 +75,14 @@ stmt(   );
 ------------------------------
 { printWidth: 80, semi: true }
 ------------------------------
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
-do;   while(   1);
+do;   while(   1)
 
 [].sort();
 
@@ -90,7 +91,7 @@ do  {}   while(   two  );
 
 lbl: for (;;) {
   // prettier-ignore
-  continue                   lbl;
+  continue                   lbl
 
   // breaking comment
   (possibleArray || []).sort();
@@ -103,17 +104,15 @@ lbl2: for (;;) {
 
 lbl3: for (;;) {
   // prettier-ignore
-  break   lbl3;
+  break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
-const noSemi   =   1;
+const noSemi   =   1
 
-[].sort();
+;[].sort();
 
 // prettier-ignore
 let cast = /** @type {string} */ (   value  );
@@ -121,24 +120,23 @@ let cast = /** @type {string} */ (   value  );
 [].sort();
 
 // prettier-ignore
-var multi   =   1,   multi2   =   2;
+var multi   =   1,   multi2   =   2
 
-[].sort();
+;[].sort();
 
 // The rightmost-body recursion reaches the declaration
 // prettier-ignore
-if (cond) var inBody   =   1;
+if (cond) var inBody   =   1
 
-[].sort();
+;[].sort();
 
 // prettier-ignore
 export const exported   =   1
 
 foo();
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
 stmt(   );
@@ -149,12 +147,14 @@ stmt(   );
 -------------------------------
 { printWidth: 100, semi: true }
 -------------------------------
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
-do;   while(   1);
+do;   while(   1)
 
 [].sort();
 
@@ -163,7 +163,7 @@ do  {}   while(   two  );
 
 lbl: for (;;) {
   // prettier-ignore
-  continue                   lbl;
+  continue                   lbl
 
   // breaking comment
   (possibleArray || []).sort();
@@ -176,17 +176,15 @@ lbl2: for (;;) {
 
 lbl3: for (;;) {
   // prettier-ignore
-  break   lbl3;
+  break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
-const noSemi   =   1;
+const noSemi   =   1
 
-[].sort();
+;[].sort();
 
 // prettier-ignore
 let cast = /** @type {string} */ (   value  );
@@ -194,24 +192,23 @@ let cast = /** @type {string} */ (   value  );
 [].sort();
 
 // prettier-ignore
-var multi   =   1,   multi2   =   2;
+var multi   =   1,   multi2   =   2
 
-[].sort();
+;[].sort();
 
 // The rightmost-body recursion reaches the declaration
 // prettier-ignore
-if (cond) var inBody   =   1;
+if (cond) var inBody   =   1
 
-[].sort();
+;[].sort();
 
 // prettier-ignore
 export const exported   =   1
 
 foo();
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
 stmt(   );
@@ -222,9 +219,11 @@ stmt(   );
 -------------------------------
 { printWidth: 80, semi: false }
 -------------------------------
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
 do;   while(   1)
@@ -232,7 +231,7 @@ do;   while(   1)
 ;[].sort()
 
 // prettier-ignore
-do  {}   while(   two  )
+do  {}   while(   two  );
 
 lbl: for (;;) {
   // prettier-ignore
@@ -244,7 +243,7 @@ lbl: for (;;) {
 
 lbl2: for (;;) {
   // prettier-ignore
-  break                   lbl2
+  break                   lbl2;
 }
 
 lbl3: for (;;) {
@@ -252,9 +251,7 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
 const noSemi   =   1
@@ -262,9 +259,9 @@ const noSemi   =   1
 ;[].sort()
 
 // prettier-ignore
-let cast = /** @type {string} */ (   value  )
+let cast = /** @type {string} */ (   value  );
 
-;[].sort()
+[].sort()
 
 // prettier-ignore
 var multi   =   1,   multi2   =   2
@@ -282,22 +279,23 @@ export const exported   =   1
 
 foo()
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
-stmt(   )
+stmt(   );
 
 // prettier-ignore
-;[breaking].sort()
+[breaking].sort();
 
 --------------------------------
 { printWidth: 100, semi: false }
 --------------------------------
-// A suppressed statement keeps its source text up to the content end;
-// the terminator is printed by the formatter (`;` added or removed per options),
-// and comments between the content and the source `;` lead the next statement.
+// A suppressed statement prints its source text as-is, `;` or no `;`, whatever `semi` says:
+// nothing is added to or removed from the line the user marked.
+// A `;` the parser attached from a later line (`;[].sort()`, the `semi: false` style)
+// is left out and re-printed as the next statement's ASI guard.
+// Prettier re-adds or strips the `;` per its `locEnd` table (DIVERGENCES.md#suppressed-node-verbatim).
 
 // prettier-ignore
 do;   while(   1)
@@ -305,7 +303,7 @@ do;   while(   1)
 ;[].sort()
 
 // prettier-ignore
-do  {}   while(   two  )
+do  {}   while(   two  );
 
 lbl: for (;;) {
   // prettier-ignore
@@ -317,7 +315,7 @@ lbl: for (;;) {
 
 lbl2: for (;;) {
   // prettier-ignore
-  break                   lbl2
+  break                   lbl2;
 }
 
 lbl3: for (;;) {
@@ -325,9 +323,7 @@ lbl3: for (;;) {
   break   lbl3
 }
 
-// A suppressed variable declaration always gets the formatter's terminator:
-// the ignored range ends at the last declarator, source `;` or not
-// (unlike content-terminated statements, and unlike `export const`).
+// A variable declaration is no different (Prettier always re-adds its `;`).
 
 // prettier-ignore
 const noSemi   =   1
@@ -335,9 +331,9 @@ const noSemi   =   1
 ;[].sort()
 
 // prettier-ignore
-let cast = /** @type {string} */ (   value  )
+let cast = /** @type {string} */ (   value  );
 
-;[].sort()
+[].sort()
 
 // prettier-ignore
 var multi   =   1,   multi2   =   2
@@ -355,14 +351,13 @@ export const exported   =   1
 
 foo()
 
-// A suppressed expression statement also ends its ignored range at the content
-// (`;` re-added only when a source `;` was stripped),
-// and still gets its `semi: false` ASI guard.
+// A suppressed expression statement keeps its source `;` under `semi: false` too,
+// and still gets its ASI guard.
 
 // prettier-ignore
-stmt(   )
+stmt(   );
 
 // prettier-ignore
-;[breaking].sort()
+[breaking].sort();
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js
@@ -1,7 +1,9 @@
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
 debugger
@@ -37,7 +39,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-trailing-semicolon.js.snap
@@ -2,10 +2,12 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
 debugger
@@ -41,7 +43,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -52,46 +54,48 @@ with   (   1)   ;
 ------------------------------
 { printWidth: 80, semi: true }
 ------------------------------
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
-debugger;
+debugger
 
 [].sort();
 
 // oxfmt-ignore
-while   (   1)   foo (   );
+while   (   1)   foo (   )
 
-[].sort();
-
-// oxfmt-ignore
-if (   1) ; else    foo;
-
-[].sort();
+;[].sort();
 
 // oxfmt-ignore
-label: for (   a of   b) while   (   1)   foo (   );
+if (   1) ; else    foo
 
-[].sort();
+;[].sort();
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort();
 
 function f() {
   // oxfmt-ignore
-  return;
+  return
 
-  [].sort();
+  ;[].sort();
 }
 
 function g() {
   // oxfmt-ignore
-  throw    err;
+  throw    err
 
-  [].sort();
+  ;[].sort();
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -101,46 +105,48 @@ with   (   1)   ;
 -------------------------------
 { printWidth: 100, semi: true }
 -------------------------------
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
-debugger;
+debugger
 
 [].sort();
 
 // oxfmt-ignore
-while   (   1)   foo (   );
+while   (   1)   foo (   )
 
-[].sort();
-
-// oxfmt-ignore
-if (   1) ; else    foo;
-
-[].sort();
+;[].sort();
 
 // oxfmt-ignore
-label: for (   a of   b) while   (   1)   foo (   );
+if (   1) ; else    foo
 
-[].sort();
+;[].sort();
+
+// oxfmt-ignore
+label: for (   a of   b) while   (   1)   foo (   )
+
+;[].sort();
 
 function f() {
   // oxfmt-ignore
-  return;
+  return
 
-  [].sort();
+  ;[].sort();
 }
 
 function g() {
   // oxfmt-ignore
-  throw    err;
+  throw    err
 
-  [].sort();
+  ;[].sort();
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -150,10 +156,12 @@ with   (   1)   ;
 -------------------------------
 { printWidth: 80, semi: false }
 -------------------------------
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
 debugger
@@ -189,7 +197,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 
@@ -199,10 +207,12 @@ with   (   1)   ;
 --------------------------------
 { printWidth: 100, semi: false }
 --------------------------------
-// The ignored range of a suppressed statement excludes a (possibly distant)
-// trailing `;` — even one owned by a nested single-statement body — and the
-// formatter prints its own terminator only when one was stripped, never
-// doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// A `;` the parser attached to a suppressed statement from a later line,
+// even through a nested single-statement body, is left out of the verbatim text:
+// the next statement's ASI guard re-prints it where the `semi: false` style put it,
+// never doubling it (a doubled `;` would re-parse as an extra EmptyStatement).
+// Under `semi: true` the guard prints only when the next statement needs it
+// (DIVERGENCES.md#suppressed-unterminated-asi-guard).
 
 // oxfmt-ignore
 debugger
@@ -238,7 +248,7 @@ function g() {
   ;[].sort()
 }
 
-// No source `;` at the end — nothing is stripped, nothing is added.
+// No source `;` at the end: nothing is added.
 // oxfmt-ignore
 while   (   1)   { foo (   ) }
 

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-unterminated-asi-guard.js
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-unterminated-asi-guard.js
@@ -1,0 +1,54 @@
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+a => a
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+b => b
+
+// prettier-ignore
+const c   = 1
+d => d
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;
+e => e
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+g => g
+
+// prettier-ignore
+debugger
+h => h
+
+function f() {
+  // prettier-ignore
+  return   1
+  i => i
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    j => j
+}
+
+export default   x // prettier-ignore
+k => k
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+l => l
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  )
+n => n

--- a/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-unterminated-asi-guard.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/semicolons/suppressed-unterminated-asi-guard.js.snap
@@ -1,0 +1,289 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+a => a
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+b => b
+
+// prettier-ignore
+const c   = 1
+d => d
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;
+e => e
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+g => g
+
+// prettier-ignore
+debugger
+h => h
+
+function f() {
+  // prettier-ignore
+  return   1
+  i => i
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    j => j
+}
+
+export default   x // prettier-ignore
+k => k
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+l => l
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  )
+n => n
+
+==================== Output ====================
+------------------------------
+{ printWidth: 80, semi: true }
+------------------------------
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+;(a) => a;
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+;(b) => b;
+
+// prettier-ignore
+const c   = 1
+;(d) => d;
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;(e) => e;
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+(g) => g;
+
+// prettier-ignore
+debugger
+(h) => h;
+
+function f() {
+  // prettier-ignore
+  return   1
+  ;(i) => i;
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    ;(j) => j;
+}
+
+export default   x // prettier-ignore
+;(k) => k;
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+(l) => l;
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  );
+(n) => n;
+
+-------------------------------
+{ printWidth: 100, semi: true }
+-------------------------------
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+;(a) => a;
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+;(b) => b;
+
+// prettier-ignore
+const c   = 1
+;(d) => d;
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;(e) => e;
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+(g) => g;
+
+// prettier-ignore
+debugger
+(h) => h;
+
+function f() {
+  // prettier-ignore
+  return   1
+  ;(i) => i;
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    ;(j) => j;
+}
+
+export default   x // prettier-ignore
+;(k) => k;
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+(l) => l;
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  );
+(n) => n;
+
+-------------------------------
+{ printWidth: 80, semi: false }
+-------------------------------
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+;(a) => a
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+;(b) => b
+
+// prettier-ignore
+const c   = 1
+;(d) => d
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;(e) => e
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+;(g) => g
+
+// prettier-ignore
+debugger
+;(h) => h
+
+function f() {
+  // prettier-ignore
+  return   1
+  ;(i) => i
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    ;(j) => j
+}
+
+export default   x // prettier-ignore
+;(k) => k
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+(l) => l
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  )
+;(n) => n
+
+--------------------------------
+{ printWidth: 100, semi: false }
+--------------------------------
+// A suppressed statement whose source has no `;` prints none, under `semi: true` too.
+// The source parsed the two statements apart and the verbatim text keeps every token,
+// so only a first token the reprint introduces can merge them: `a => a` -> `(a) => a`.
+// That statement takes the ASI guard whatever `semi` says; Prettier prints the merged
+// `foo(  )(a) => a` (DIVERGENCES.md#suppressed-unterminated-asi-guard).
+
+foo(  ) // prettier-ignore
+;(a) => a
+
+// The rightmost single-statement body is the unterminated one
+if (x) bar(  ) // prettier-ignore
+;(b) => b
+
+// prettier-ignore
+const c   = 1
+;(d) => d
+
+// A `;` from the next line belongs to the guard, not to the verbatim text
+foo(  ) // prettier-ignore
+;(e) => e
+
+// A body's `}` and a keyword statement end are boundaries by grammar: no guard
+// prettier-ignore
+class K {}
+;(g) => g
+
+// prettier-ignore
+debugger
+;(h) => h
+
+function f() {
+  // prettier-ignore
+  return   1
+  ;(i) => i
+}
+
+switch (x) {
+  case 1:
+    foo(  ) // prettier-ignore
+    ;(j) => j
+}
+
+export default   x // prettier-ignore
+;(k) => k
+
+// A source `;` terminates: no guard under `semi: true`
+foo(  ); // prettier-ignore
+(l) => l
+
+// A leading-suppressed expression ending a `;`-less statement is verbatim as well;
+// the guard errs on its side (the statement printed its `;`, the guard is inert)
+m = /* prettier-ignore */ foo(  )
+;(n) => n
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/class-member-trailing.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/class-member-trailing.ts
@@ -1,0 +1,35 @@
+// A trailing suppression comment suppresses a class member like a leading one:
+// the source text prints as-is, `;` included, and the formatter adds none.
+// Same for interface members, whose leading comment is printed too.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // own-line
+  t   = 4; // prettier-ignore
+  z() {}
+}
+
+// A `;` the parser attached from the next line (`;[k] = 2`, the `semi: false` style)
+// is the formatter's again and goes where a class member's `;` goes
+class D {
+  p   = 1 // prettier-ignore
+  ;[k] = 2
+  // prettier-ignore
+  q   = 3
+  ;[j] = 4
+}
+
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/class-member-trailing.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/class-member-trailing.ts.snap
@@ -1,0 +1,120 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A trailing suppression comment suppresses a class member like a leading one:
+// the source text prints as-is, `;` included, and the formatter adds none.
+// Same for interface members, whose leading comment is printed too.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // own-line
+  t   = 4; // prettier-ignore
+  z() {}
+}
+
+// A `;` the parser attached from the next line (`;[k] = 2`, the `semi: false` style)
+// is the formatter's again and goes where a class member's `;` goes
+class D {
+  p   = 1 // prettier-ignore
+  ;[k] = 2
+  // prettier-ignore
+  q   = 3
+  ;[j] = 4
+}
+
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A trailing suppression comment suppresses a class member like a leading one:
+// the source text prints as-is, `;` included, and the formatter adds none.
+// Same for interface members, whose leading comment is printed too.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // own-line
+  t   = 4; // prettier-ignore
+  z() {}
+}
+
+// A `;` the parser attached from the next line (`;[k] = 2`, the `semi: false` style)
+// is the formatter's again and goes where a class member's `;` goes
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2;
+  // prettier-ignore
+  q   = 3;
+  [j] = 4;
+}
+
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A trailing suppression comment suppresses a class member like a leading one:
+// the source text prints as-is, `;` included, and the formatter adds none.
+// Same for interface members, whose leading comment is printed too.
+
+abstract class C {
+  m(  ) {} // prettier-ignore
+  p   = 1; // prettier-ignore
+  q   = 2 // prettier-ignore
+  accessor a   = 1; // prettier-ignore
+  static s   = 2 // prettier-ignore
+  abstract n(  ): void; // prettier-ignore
+  abstract o(  ): void // prettier-ignore
+  [k: string]:   any; // prettier-ignore
+  static {  } // prettier-ignore
+  /* leading */ r   = 3; // prettier-ignore
+  // own-line
+  t   = 4; // prettier-ignore
+  z() {}
+}
+
+// A `;` the parser attached from the next line (`;[k] = 2`, the `semi: false` style)
+// is the formatter's again and goes where a class member's `;` goes
+class D {
+  p   = 1; // prettier-ignore
+  [k] = 2;
+  // prettier-ignore
+  q   = 3;
+  [j] = 4;
+}
+
+interface I {
+  /* leading */ p:   1; // prettier-ignore
+  m(  ): void // prettier-ignore
+  z: 0;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semicolons/trailing-comments.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_formatter/tests/fixtures/mod.rs
-assertion_line: 43
 ---
 ==================== Input ====================
 // https://github.com/oxc-project/oxc/issues/23110
@@ -149,7 +148,7 @@ beforeExport = 5;
 export default quux;
 
 // A trailing suppression comment keeps the statement's original text
-suppressed  =  ugly(   1); // prettier-ignore
+suppressed  =  ugly(   1) // prettier-ignore
 notSuppressed3();
 
 // The `;` on a later line still moves the comment: in the output the semicolon
@@ -236,7 +235,7 @@ beforeExport = 5;
 export default quux;
 
 // A trailing suppression comment keeps the statement's original text
-suppressed  =  ugly(   1); // prettier-ignore
+suppressed  =  ugly(   1) // prettier-ignore
 notSuppressed3();
 
 // The `;` on a later line still moves the comment: in the output the semicolon

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
-assertion_line: 172
 expression: report
 ---
-js compatibility: 765/810 (94.44%), 23 files skipped
+js compatibility: 754/810 (93.09%), 23 files skipped
 
 # Failed
 
@@ -17,6 +16,7 @@ js compatibility: 765/810 (94.44%), 23 files skipped
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/class-comment/misc.js | 💥 | 66.67% |
 | js/class-comment/superclass.js | 💥 | 70.33% |
+| js/comments/break-continue-statements-3.js | 💥💥 | 97.14% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
 | js/comments/return-statement-2.js | 💥💥 | 87.32% |
@@ -46,6 +46,16 @@ js compatibility: 765/810 (94.44%), 23 files skipped
 | js/label/comment.js | 💥 | 58.82% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
+| js/no-semi/debugger-statement.js | 💥✨ | 46.88% |
+| js/no-semi/do-while-statement.js | 💥✨ | 47.37% |
+| js/no-semi/for-in-statement.js | 💥✨ | 43.75% |
+| js/no-semi/for-of-statement.js | 💥✨ | 40.48% |
+| js/no-semi/for-statement.js | 💥✨ | 43.75% |
+| js/no-semi/if-statement.js | 💥✨ | 44.44% |
+| js/no-semi/labeled-statement.js | 💥✨ | 43.75% |
+| js/no-semi/return-statement.js | 💥✨ | 44.44% |
+| js/no-semi/while-statement.js | 💥✨ | 43.75% |
+| js/no-semi/with-statement.js | 💥✨ | 43.75% |
 | js/sequence-expression/parenthesized-trailing-comment-unstable.js | 💥 | 66.67% |
 | js/sequence-expression/parenthesized.js | 💥 | 85.71% |
 | js/switch/comments.js | 💥 | 94.74% |

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -4,9 +4,9 @@
 //!
 //! - The node lists here decide which fragments of the `fmt` skeleton are EMITTED (comment-printing ownership, parentheses frames)
 //!   - they change the shape of the generated code, nothing else
-//! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `suppressed_span`, `write_suppressed`)
+//! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `suppressed_span`, `write_suppressed_leading_comments`)
 //!   - defaults cover the common case, overrides sit next to the node's `write` and need no regeneration
-//!   - EXCEPT: expression-shaped nodes bypass `write_suppressed` entirely
+//!   - EXCEPT: expression-shaped nodes bypass the suppressed hooks entirely
 //!     (their suppressed path goes to `write_suppressed_expression`, see below),
 //!     so an override on such a node would silently never be called
 //!
@@ -96,7 +96,7 @@ impl Generator for FormatterFormatGenerator {
                 formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
-                utils::{suppressed::{FormatSuppressedNode, write_suppressed_expression}, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
+                utils::{suppressed::{FormatSuppressedNode, write_suppressed_expression, write_suppressed_node}, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
                 print::FormatWrite,
             };
 
@@ -190,8 +190,7 @@ fn generate_struct_implementation(
         // The check, the suppressed leading comments, and the printed range are all bounded by
         // `FormatWrite::suppressed_span` (default: the node's span),
         // which nodes override when the ignored range starts before their span (class decorators before `export`).
-        // `FormatWrite::write_suppressed` (default: print `suppressed_span` verbatim) is overridden by
-        // statements whose ignored range excludes the trailing semicolon.
+        // The range prints verbatim through `write_suppressed_node`, the same for every node.
         let suppressed_check = (!matches!(struct_name, "Program" | "JSXElement" | "JSXFragment"))
             .then(|| {
                 quote! {
@@ -202,7 +201,7 @@ fn generate_struct_implementation(
         // Expression-shaped nodes (formatter parens + own comment printing) hand the whole
         // suppressed sequence to one owner, so the cast-target decision is made once
         // while every comment is still unprinted (see `write_suppressed_expression`).
-        // These nodes have no `suppressed_span`/`write_suppressed` overrides (those are statements).
+        // These nodes have no `suppressed_span` overrides (those are statements).
         let suppressed_expression_return =
             (suppressed_check.is_some() && needs_parentheses && !do_not_print_leading_comment)
                 .then(|| {
@@ -230,11 +229,11 @@ fn generate_struct_implementation(
                 let suppressed_write_call = if do_not_print_leading_comment {
                     quote! {
                         self.write_suppressed_leading_comments(f);
-                        self.write_suppressed(f);
+                        write_suppressed_node(self.suppressed_span(), f);
                     }
                 } else {
                     quote! {
-                        self.write_suppressed(f);
+                        write_suppressed_node(self.suppressed_span(), f);
                     }
                 };
                 let suppressed_trailing_comments = do_not_print_comment.then(|| {
@@ -359,10 +358,10 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
             // `AstNode<ExpressionStatement>::write`.
             quote! {
                 if !matches!(self.inner, Statement::ExpressionStatement(_))
-                    && f.comments().has_trailing_suppression_comment(self.span().end)
+                    && f.comments().is_trailing_suppressed(self.span())
                 {
                     format_leading_comments(self.span()).fmt(f);
-                    FormatSuppressedNode(self.span()).fmt(f);
+                    write_suppressed_node(self.span(), f);
                     format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
                         .fmt(f);
                     return;
@@ -371,7 +370,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
         }
         "Expression" => {
             quote! {
-                if f.comments().has_trailing_suppression_comment(self.span().end) {
+                if f.comments().is_trailing_suppressed(self.span()) {
                     format_leading_comments(self.span()).fmt(f);
                     FormatSuppressedNode(self.span()).fmt(f);
                     format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)


### PR DESCRIPTION
Another plan to unify suppress comment behavior, against #26547.

Completely untouch suppressed node may feel better, but it requires more codes to handle ASI, across nodes.