### PR TITLE
fix(oxlint): stop the root config search at a nested workspace root

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -24,6 +24,8 @@ use crate::{VITE_CONFIG_NAME, vp_version};
 
 const GIT_DIR: &str = ".git";
 const NODE_MODULES_DIR: &str = "node_modules";
+const PACKAGE_JSON_FILE: &str = "package.json";
+const PNPM_WORKSPACE_FILE: &str = "pnpm-workspace.yaml";
 
 #[cfg(feature = "napi")]
 use crate::js_config;
@@ -42,8 +44,29 @@ const OXLINT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     vite: VITE_CONFIG_NAME,
 };
 
+fn vite_plus_mode() -> bool {
+    cfg!(feature = "napi") && vp_version().is_some()
+}
+
 fn config_discovery() -> ConfigDiscovery {
-    ConfigDiscovery::new(OXLINT_CONFIG_FILE_NAMES, cfg!(feature = "napi") && vp_version().is_some())
+    ConfigDiscovery::new(OXLINT_CONFIG_FILE_NAMES, vite_plus_mode())
+}
+
+/// Does `dir` declare a package manager workspace of its own?
+///
+/// A directory that is itself a workspace root owns a complete dependency tree
+/// and configuration. A checkout nested inside another checkout (a git worktree
+/// under the repository it belongs to, for example) is therefore self-contained,
+/// and the outer checkout's configuration does not apply to it.
+fn is_workspace_root(dir: &Path) -> bool {
+    if dir.join(PNPM_WORKSPACE_FILE).is_file() {
+        return true;
+    }
+    let Ok(package_json) = std::fs::read_to_string(dir.join(PACKAGE_JSON_FILE)) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&package_json)
+        .is_ok_and(|package_json| package_json.get("workspaces").is_some())
 }
 
 pub fn config_file_names() -> Vec<&'static str> {
@@ -550,6 +573,23 @@ impl<'a> ConfigLoader<'a> {
         cwd: &Path,
         config_path: Option<&PathBuf>,
     ) -> Result<Oxlintrc, OxcDiagnostic> {
+        // Vite+ mode only: `vite.config.ts` outside the workspace belongs to a
+        // different project, so the search must not leave the workspace. Plain
+        // oxlint keeps the unbounded ESLint-compatible search.
+        self.load_root_config_with(cwd, config_path, config_discovery(), vite_plus_mode())
+    }
+
+    /// [`load_root_config`](Self::load_root_config) with the discovery settings passed in.
+    ///
+    /// `stop_at_workspace_root` bounds the upward search to the workspace the
+    /// files belong to.
+    fn load_root_config_with(
+        &self,
+        cwd: &Path,
+        config_path: Option<&PathBuf>,
+        discovery: ConfigDiscovery,
+        stop_at_workspace_root: bool,
+    ) -> Result<Oxlintrc, OxcDiagnostic> {
         // If an explicit config path is provided, use it directly
         if let Some(config_path) = config_path {
             return self.load_explicit_config(cwd, config_path);
@@ -558,8 +598,11 @@ impl<'a> ConfigLoader<'a> {
         // Search up the directory tree for a config file
         let mut current = Some(cwd);
         while let Some(dir) = current {
-            if let Some(config) = self.try_load_config_from_dir(&config_discovery(), dir)? {
+            if let Some(config) = self.try_load_config_from_dir(&discovery, dir)? {
                 return Ok(config);
+            }
+            if stop_at_workspace_root && is_workspace_root(dir) {
+                break;
             }
             // Move to parent directory
             current = dir.parent();
@@ -768,10 +811,10 @@ mod test {
 
     use oxc_linter::{ConfigStoreBuilder, ExternalPluginStore};
 
-    use super::{ConfigLoadError, ConfigLoader};
+    use super::{ConfigLoadError, ConfigLoader, OXLINT_CONFIG_FILE_NAMES};
     #[cfg(feature = "napi")]
     use crate::js_config::{JsConfigLoaderCb, JsConfigResult};
-    use oxc_config::DiscoveredConfigFile;
+    use oxc_config::{ConfigDiscovery, DiscoveredConfigFile};
 
     #[cfg(feature = "napi")]
     fn make_js_loader<F>(f: F) -> JsConfigLoaderCb
@@ -877,6 +920,85 @@ mod test {
         let result = loader.load_root_config(&temp_dir, None);
         assert!(result.is_ok(), "Expected default config when no config found");
         std::fs::remove_dir_all(&temp_dir).expect("Failed to cleanup temporary test directory");
+    }
+
+    /// A directory that declares its own workspace terminates the upward search:
+    /// a checkout nested inside another checkout is self-contained, and the outer
+    /// checkout's config must not be loaded for it.
+    #[test]
+    fn root_config_search_stops_at_a_nested_pnpm_workspace_root() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let outer = temp_dir.path();
+        let nested = outer.join("nested");
+        std::fs::create_dir_all(nested.join("src")).unwrap();
+        std::fs::write(outer.join(".oxlintrc.json"), r#"{ "rules": { "no-console": "error" } }"#)
+            .unwrap();
+        std::fs::write(nested.join("pnpm-workspace.yaml"), "packages:\n  - \"packages/*\"\n")
+            .unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+        let discovery = ConfigDiscovery::new(OXLINT_CONFIG_FILE_NAMES, false);
+
+        let bounded =
+            loader.load_root_config_with(&nested.join("src"), None, discovery, true).unwrap();
+        assert_eq!(
+            bounded.path,
+            PathBuf::new(),
+            "expected the default config, got the outer workspace's config"
+        );
+
+        let unbounded =
+            loader.load_root_config_with(&nested.join("src"), None, discovery, false).unwrap();
+        assert_eq!(unbounded.path, outer.join(".oxlintrc.json"));
+    }
+
+    #[test]
+    fn root_config_search_stops_at_a_nested_npm_workspace_root() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let outer = temp_dir.path();
+        let nested = outer.join("nested");
+        std::fs::create_dir_all(nested.join("src")).unwrap();
+        std::fs::write(outer.join(".oxlintrc.json"), r#"{ "rules": { "no-console": "error" } }"#)
+            .unwrap();
+        std::fs::write(
+            nested.join("package.json"),
+            r#"{ "name": "nested", "workspaces": ["packages/*"] }"#,
+        )
+        .unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+        let discovery = ConfigDiscovery::new(OXLINT_CONFIG_FILE_NAMES, false);
+
+        let bounded =
+            loader.load_root_config_with(&nested.join("src"), None, discovery, true).unwrap();
+        assert_eq!(
+            bounded.path,
+            PathBuf::new(),
+            "expected the default config, got the outer workspace's config"
+        );
+    }
+
+    /// A package inside the workspace still inherits the workspace root config.
+    #[test]
+    fn root_config_search_crosses_a_plain_package_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path();
+        let package = root.join("packages/a");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(root.join("pnpm-workspace.yaml"), "packages:\n  - \"packages/*\"\n")
+            .unwrap();
+        std::fs::write(root.join(".oxlintrc.json"), r#"{ "rules": { "no-console": "error" } }"#)
+            .unwrap();
+        std::fs::write(package.join("package.json"), r#"{ "name": "a" }"#).unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+        let discovery = ConfigDiscovery::new(OXLINT_CONFIG_FILE_NAMES, false);
+
+        let config = loader.load_root_config_with(&package, None, discovery, true).unwrap();
+        assert_eq!(config.path, root.join(".oxlintrc.json"));
     }
 
     #[test]


### PR DESCRIPTION
In Vite+ mode (`VP_VERSION` set), `ConfigLoader::load_root_config` walks up from the
current directory until it finds a config, without any boundary. When a workspace is
checked out *inside* another workspace — a git worktree placed under the repository it
belongs to, for example — the search leaves the inner workspace and loads the outer
checkout's `vite.config.ts`, even though the inner directory is a complete, self-contained
workspace root with its own `pnpm-workspace.yaml`, its own `vite.config.ts` and its own
`node_modules`.

The inner config is used as expected; the outer one is loaded *in addition*. This normally
goes unnoticed, because loading the ancestor config usually succeeds and its settings are
silently merged into the run. It becomes visible when the outer checkout's `node_modules`
is unusable — for instance when it holds another platform's binaries:

```
failed to load config from <outer>/vite.config.ts
Failed to parse oxlint configuration file.

  x Failed to load config: <outer>/vite.config.ts
  | Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite-plus' imported from <outer>/vite.config.ts.timestamp-<n>.mjs
```

The silent case is wrong too: a separate workspace's configuration should not be consulted
for a self-contained one.

## Reproduction

With `vite-plus` 0.3.1 (reproduced on macOS arm64; originally seen on linux/amd64 as well):

```bash
mkdir -p outer/nested/packages/a && cd outer
echo '{"name":"outer","private":true}' > package.json
printf 'packages:\n  - "packages/*"\n' > pnpm-workspace.yaml
echo 'throw new Error("OUTER-CONFIG-LOADED: " + import.meta.dirname);' > vite.config.ts

cd nested
echo '{"name":"nested","private":true,"devDependencies":{"vite-plus":"0.3.1"}}' > package.json
printf 'packages:\n  - "packages/*"\n' > pnpm-workspace.yaml
echo 'export default {};' > vite.config.ts
echo '{"name":"a","version":"0.0.0"}' > packages/a/package.json
mkdir -p packages/a/src && echo 'export const a = 1;' > packages/a/src/index.ts
pnpm install

vp lint   # fails with OUTER-CONFIG-LOADED, from outer/vite.config.ts
```

The same happens for a real `git worktree` created at `outer/.worktrees/<branch>` and
installed on its own; the plain nested directory above is the smaller repro of the same
walk.

## What happens

`vp lint` resolves the workspace root correctly (the inner one) and, because the inner
`vite.config.ts` declares no `lint` block, passes no `-c` to oxlint. oxlint then runs
`load_root_config`, which

1. finds `nested/vite.config.ts`,
2. gets `Ok(None)` back from the JS side ("skip" — no `lint` field), and
3. continues to the parent directory, where it loads `outer/vite.config.ts`.

Step 3 is the bug: the walk crosses a workspace boundary.

## Fix

Stop the upward root-config search at a directory that is itself a package manager
workspace root (`pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field),
after that directory itself has been checked.

The boundary is applied in Vite+ mode only. Plain oxlint keeps the unbounded,
ESLint-compatible ancestor search. Inheritance inside a workspace is unaffected: a package
directory is not a workspace root, so a package without its own config still picks up the
workspace root config — covered by a test.

## Tests

`apps/oxlint/src/config_loader.rs`:

- `root_config_search_stops_at_a_nested_pnpm_workspace_root`
- `root_config_search_stops_at_a_nested_npm_workspace_root`
- `root_config_search_crosses_a_plain_package_directory`

The first two fail without the fix (they find the outer config); the third guards the
inheritance case. `cargo test -p oxlint --lib config_loader` passes (25 tests).

They exercise the search boundary through `load_root_config_with` with plain
`.oxlintrc.json` discovery, because the Vite+ path needs the `napi` feature plus a JS
config loader. The Vite+ wiring itself (`stop_at_workspace_root = vite_plus_mode()`) is
one line and is not covered by a Rust test; the end-to-end behaviour was verified against
the released `vp` 0.3.1 binary as shown above.

## Open question for maintainers (why this is a draft)

Whether the boundary belongs in Vite+ mode only, or in plain oxlint discovery too, is a
product decision I cannot make. The same unbounded walk applies to `.oxlintrc.json`, where
the ESLint-compatible behaviour may well be intended. Happy to move the boundary, widen it,
or gate it differently.

---

AI disclosure, per the contributing guide: this patch was written with AI assistance
(Claude). The reproduction, the mechanism, and the test failures without the fix were
verified by me on a real checkout.
