### PR TITLE
fix(minifier): drop bound console methods

### DIFF
--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -6,6 +6,7 @@ use oxc_ecmascript::{
     side_effects::{is_typed_array_constructor, is_valid_regexp},
 };
 use oxc_semantic::IsGlobalReference;
+use oxc_span::GetSpan;
 use oxc_syntax::scope::ScopeFlags;
 
 use super::PeepholeOptimizations;
@@ -149,6 +150,12 @@ impl<'a> Traverse<'a> for Normalize {
             ctx.replace_expression(expr, new_expr);
             return;
         }
+        if ctx.options().drop_console
+            && let Expression::CallExpression(call_expr) = &mut *expr
+            && Self::replace_bound_console_method(call_expr, ctx)
+        {
+            return;
+        }
         if let Some(e) = match expr {
             Expression::Identifier(ident) => Self::try_compress_identifier(ident, ctx),
             Expression::UnaryExpression(e) if e.operator.is_void() => {
@@ -254,6 +261,45 @@ impl<'a> Normalize {
         let obj = member_expr.object();
         let Some(ident) = obj.get_identifier_reference() else { return false };
         ident.name == "console"
+    }
+
+    fn replace_bound_console_method(
+        call_expr: &mut CallExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        let Some(bind_member) = call_expr.callee.as_member_expression_mut() else {
+            return false;
+        };
+        if bind_member.static_property_name() != Some("bind") {
+            return false;
+        }
+        let bound_method = bind_member.object_mut();
+        let Some(console_member) = bound_method.as_member_expression() else {
+            return false;
+        };
+        let Some(console) = console_member.object().get_identifier_reference() else {
+            return false;
+        };
+        if console.name != "console" {
+            return false;
+        }
+
+        let span = bound_method.span();
+        let params = FormalParameters::boxed(
+            span,
+            FormalParameterKind::ArrowFormalParameters,
+            [],
+            None,
+            ctx,
+        );
+        let body = ArrowFunctionBody::new_function_body(span, [], [], ctx);
+        let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Arrow | ScopeFlags::Function);
+        let empty_function =
+            Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
+                span, false, None, params, None, body, scope_id, false, false, ctx,
+            );
+        ctx.replace_expression(bound_method, empty_function);
+        true
     }
 
     fn convert_while_to_for(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -296,7 +296,7 @@ impl<'a> Normalize {
         let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Arrow | ScopeFlags::Function);
         let empty_function =
             Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
-                span, false, None, params, None, body, scope_id, false, false, ctx,
+                span, false, None, params, None, body, scope_id, true, false, ctx,
             );
         ctx.replace_expression(bound_method, empty_function);
         true

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -64,12 +64,12 @@ fn drop_console() {
     // Keep the bind call and its arguments, while replacing the console method with a no-op.
     test_options(
         "const log = console.log.bind(console); log('hello');",
-        "(() => {}).bind(console)('hello');",
+        "/* @__NO_SIDE_EFFECTS__ */ (() => {}).bind(console)('hello');",
         &options,
     );
     test_options(
         "const error = console['error'].bind(console); error('hello');",
-        "(() => {}).bind(console)('hello');",
+        "/* @__NO_SIDE_EFFECTS__ */ (() => {}).bind(console)('hello');",
         &options,
     );
 }

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -61,6 +61,17 @@ fn drop_console() {
     // return-position `console.*` call was dropped (otherwise the call would
     // keep the IIFE alive).
     test_options("(() => { try { return console.log() } catch {} })()", "", &options);
+    // Keep the bind call and its arguments, while replacing the console method with a no-op.
+    test_options(
+        "const log = console.log.bind(console); log('hello');",
+        "(() => {}).bind(console)('hello');",
+        &options,
+    );
+    test_options(
+        "const error = console['error'].bind(console); error('hello');",
+        "(() => {}).bind(console)('hello');",
+        &options,
+    );
 }
 
 // Same leak class as `test_void_ident_does_not_leak_reference`: dropped


### PR DESCRIPTION
## Summary

- Replace the `console.<method>` receiver with a scoped empty arrow when a bound console method is retained under `compress.dropConsole`.
- Mark that replacement arrow as having no side effects, preserving the generated purity annotation for later optimization passes.
- Cover dot-property and bracket-property bound methods so the bind call and its arguments continue to be evaluated without emitting a console call.

Closes #26373

## Testing

- `cargo fmt --check`
- `cargo test -p oxc_minifier --test mod drop_console` — 2 passed.
- `cargo test -p oxc_minifier --test mod` — 703 passed, 0 failed, 33 ignored.
- `cargo clippy -p oxc_minifier --all-targets --all-features -- -D warnings`
- `cargo lintgen`
- Manually built the N-API minifier and ran the issue reproducer. The output retained `(() => {}).bind(console)`, emitted no `console.log` call, and invoked the replacement-bound function.
- `just ready` could not start because `just` and its remaining JavaScript tool prerequisites are unavailable on the remote host.

## AI disclosure

AI assistance was used for PR development.
