### PR TITLE
feat(linter): add `unicorn/no-duplicate-if-branches`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1567,6 +1567,7 @@ export interface DummyRuleMap {
   "unicorn/no-confusing-array-with"?: RuleNoConfig;
   "unicorn/no-console-spaces"?: RuleNoConfig;
   "unicorn/no-document-cookie"?: RuleNoConfig;
+  "unicorn/no-duplicate-if-branches"?: RuleNoConfig;
   "unicorn/no-empty-file"?: RuleNoConfig;
   "unicorn/no-hex-escape"?: RuleNoConfig;
   "unicorn/no-immediate-mutation"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3304,6 +3304,12 @@ impl RuleRunner for crate::rules::unicorn::no_document_cookie::NoDocumentCookie 
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_duplicate_if_branches::NoDuplicateIfBranches {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -655,6 +655,7 @@ pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMeth
 pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as UnicornNoConfusingArrayWith;
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
+pub use crate::rules::unicorn::no_duplicate_if_branches::NoDuplicateIfBranches as UnicornNoDuplicateIfBranches;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
@@ -1403,6 +1404,7 @@ pub enum RuleEnum {
     UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith),
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
+    UnicornNoDuplicateIfBranches(UnicornNoDuplicateIfBranches),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
     UnicornNoHexEscape(UnicornNoHexEscape),
     UnicornNoImmediateMutation(UnicornNoImmediateMutation),
@@ -2339,7 +2341,8 @@ const UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID: usize =
 const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
 const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_CONFUSING_ARRAY_WITH_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
-const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
+const UNICORN_NO_DUPLICATE_IF_BRANCHES_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
+const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DUPLICATE_IF_BRANCHES_ID + 1usize;
 const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
 const UNICORN_NO_IMMEDIATE_MUTATION_ID: usize = UNICORN_NO_HEX_ESCAPE_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_ARRAY_ID: usize = UNICORN_NO_IMMEDIATE_MUTATION_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3260,6 +3263,7 @@ static RULE_NAMES: [&str; 870usize] = [
     UnicornNoConfusingArrayWith::NAME,
     UnicornNoConsoleSpaces::NAME,
     UnicornNoDocumentCookie::NAME,
+    UnicornNoDuplicateIfBranches::NAME,
     UnicornNoEmptyFile::NAME,
     UnicornNoHexEscape::NAME,
     UnicornNoImmediateMutation::NAME,
@@ -4216,6 +4220,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UNICORN_NO_CONFUSING_ARRAY_WITH_ID,
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
+            Self::UnicornNoDuplicateIfBranches(_) => UNICORN_NO_DUPLICATE_IF_BRANCHES_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
             Self::UnicornNoHexEscape(_) => UNICORN_NO_HEX_ESCAPE_ID,
             Self::UnicornNoImmediateMutation(_) => UNICORN_NO_IMMEDIATE_MUTATION_ID,
@@ -5247,6 +5252,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::CATEGORY,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::CATEGORY,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::CATEGORY,
@@ -6266,6 +6272,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::FIX,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::FIX,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::FIX,
@@ -7397,6 +7404,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::documentation(),
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::documentation(),
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::documentation(),
@@ -9380,6 +9388,10 @@ impl RuleEnum {
                 .or_else(|| UnicornNoConsoleSpaces::schema(generator)),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::config_schema(generator)
                 .or_else(|| UnicornNoDocumentCookie::schema(generator)),
+            Self::UnicornNoDuplicateIfBranches(_) => {
+                UnicornNoDuplicateIfBranches::config_schema(generator)
+                    .or_else(|| UnicornNoDuplicateIfBranches::schema(generator))
+            }
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::config_schema(generator)
                 .or_else(|| UnicornNoEmptyFile::schema(generator)),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::config_schema(generator)
@@ -10940,6 +10952,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => "unicorn",
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
+            Self::UnicornNoDuplicateIfBranches(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
             Self::UnicornNoHexEscape(_) => "unicorn",
             Self::UnicornNoImmediateMutation(_) => "unicorn",
@@ -12948,6 +12961,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run(node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run(node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run(node, ctx),
@@ -13835,6 +13849,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_once(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_once(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_once(ctx),
@@ -14801,6 +14816,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15727,6 +15743,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.should_run(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
             Self::UnicornNoHexEscape(rule) => rule.should_run(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.should_run(ctx),
@@ -16819,6 +16836,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::IS_TSGOLINT_RULE,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::IS_TSGOLINT_RULE,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::IS_TSGOLINT_RULE,
@@ -17971,6 +17989,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::VERSION,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::VERSION,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::VERSION,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::VERSION,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::VERSION,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::VERSION,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::VERSION,
@@ -19042,6 +19061,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::HAS_CONFIG,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::HAS_CONFIG,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::HAS_CONFIG,
@@ -20080,6 +20100,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::INFO,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::INFO,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::INFO,
+            Self::UnicornNoDuplicateIfBranches(_) => UnicornNoDuplicateIfBranches::INFO,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::INFO,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::INFO,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::INFO,
@@ -20997,6 +21018,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.types_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
             Self::UnicornNoHexEscape(rule) => rule.types_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.types_info(),
@@ -21871,6 +21893,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
+            Self::UnicornNoDuplicateIfBranches(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
             Self::UnicornNoHexEscape(rule) => rule.run_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.run_info(),
@@ -22843,6 +22866,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith::default()),
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
+        RuleEnum::UnicornNoDuplicateIfBranches(UnicornNoDuplicateIfBranches::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),
         RuleEnum::UnicornNoHexEscape(UnicornNoHexEscape::default()),
         RuleEnum::UnicornNoImmediateMutation(UnicornNoImmediateMutation::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -591,6 +591,7 @@ pub(crate) mod unicorn {
     pub mod no_confusing_array_with;
     pub mod no_console_spaces;
     pub mod no_document_cookie;
+    pub mod no_duplicate_if_branches;
     pub mod no_empty_file;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;

--- a/crates/oxc_linter/src/rules/unicorn/no_duplicate_if_branches.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_duplicate_if_branches.rs
@@ -1,0 +1,316 @@
+use oxc_ast::{AstKind, ast::Statement};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{ContentEq, GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_duplicate_if_branches_diagnostic(branch: Span, previous_branch: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This branch has the same body as the previous branch.")
+        .with_help("Combine the conditions or remove the duplicate branch.")
+        .with_labels([
+            previous_branch.label("the previous branch is here"),
+            branch.label("this branch has the same body"),
+        ])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDuplicateIfBranches;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow duplicate adjacent branches in `if` chains.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When two adjacent branches in an `if`/`else if`/`else` chain have the same body,
+    /// the condition that chooses between them is redundant. This is usually a
+    /// copy-paste bug or an incomplete refactor.
+    ///
+    /// Only adjacent branches are compared, since non-adjacent duplicate bodies can be
+    /// legitimate fallback behavior. Comments, formatting and trailing semicolons are
+    /// ignored. Empty branches are ignored.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// if (isAdmin) {
+    ///     showDashboard();
+    ///     loadStats();
+    /// } else {
+    ///     showDashboard();
+    ///     loadStats();
+    /// }
+    ///
+    /// if (value === 'a') {
+    ///     doThing();
+    /// } else if (value === 'b') {
+    ///     doThing();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (isAdmin) {
+    ///     showDashboard();
+    ///     loadStats();
+    /// } else {
+    ///     showLogin();
+    /// }
+    ///
+    /// if (value === 'a' || value === 'b') {
+    ///     doThing();
+    /// }
+    /// ```
+    NoDuplicateIfBranches,
+    unicorn,
+    suspicious,
+    version = "next",
+    short_description = "Disallow duplicate adjacent branches in `if` chains.",
+);
+
+impl Rule for NoDuplicateIfBranches {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::IfStatement(if_stmt) = node.kind() else {
+            return;
+        };
+
+        // The whole chain is walked from its root, so an `else if` is skipped here.
+        if let AstKind::IfStatement(parent_if) = ctx.nodes().parent_kind(node.id())
+            && parent_if
+                .alternate
+                .as_ref()
+                .is_some_and(|alternate| alternate.span() == if_stmt.span)
+        {
+            return;
+        }
+
+        let mut previous = &if_stmt.consequent;
+        let mut alternate = if_stmt.alternate.as_ref();
+        while let Some(branch) = alternate {
+            let (body, next) = match branch {
+                Statement::IfStatement(else_if) => {
+                    (&else_if.consequent, else_if.alternate.as_ref())
+                }
+                _ => (branch, None),
+            };
+
+            if has_same_body(previous, body) {
+                ctx.diagnostic(no_duplicate_if_branches_diagnostic(body.span(), previous.span()));
+            }
+
+            previous = body;
+            alternate = next;
+        }
+    }
+}
+
+fn branch_statements<'a>(body: &'a Statement<'a>) -> &'a [Statement<'a>] {
+    match body {
+        Statement::BlockStatement(block) => &block.body,
+        _ => std::slice::from_ref(body),
+    }
+}
+
+// Upstream compares token streams. `ContentEq` ignores spans, so it likewise ignores
+// comments, whitespace and trailing semicolons; it additionally ignores how a literal
+// is spelled, so `'a'` and `"a"` or `0x10` and `16` compare equal.
+fn has_same_body(left: &Statement, right: &Statement) -> bool {
+    let left = branch_statements(left);
+    let right = branch_statements(right);
+
+    // A branch holding nothing but `;` has no tokens to duplicate.
+    left.iter().any(|stmt| !matches!(stmt, Statement::EmptyStatement(_)))
+        && left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| left.content_eq(right))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "if (foo) {
+                bar();
+            } else {
+                baz();
+            }",
+        "if (foo) {
+                bar();
+            }",
+        "if (foo) {
+            } else {
+            }",
+        "if (foo) {
+                ;
+            } else {
+                ;
+            }",
+        "if (foo) {
+            } else {
+                ;
+            }",
+        "if (foo) {
+                // TODO
+            } else {
+                // TODO
+            }",
+        "if (foo) {
+                bar();
+            } else if (baz) {
+                qux();
+            } else {
+                quux();
+            }",
+        "if (foo) {
+                bar();
+            } else if (baz) {
+                bar(1);
+            }",
+        "if (format === 'json') {
+                parseJson();
+            } else if (format === 'yaml') {
+                parseYaml();
+            } else {
+                parseJson();
+            }",
+        "if (foo) {
+                foo.bar();
+            } else {
+                foo['bar']();
+            }",
+        "class Unicorn {
+                #value;
+                method() {
+                    if (foo) {
+                        this.#value;
+                    } else {
+                        this.value;
+                    }
+                }
+            }",
+        "if (foo) {
+                a++;
+                b;
+            } else {
+                a;
+                ++b;
+            }",
+        "if (foo) {
+                if (bar) {
+                    baz();
+                }
+            } else if (qux) {
+                baz();
+            }",
+        "function unicorn() {
+                if (foo) {
+                    return;
+                }
+                if (bar) {
+                    return;
+                }
+            }",
+    ];
+
+    let fail = vec![
+        "if (isAdmin) {
+                showDashboard();
+                loadStats();
+            } else {
+                showDashboard();
+                loadStats();
+            }",
+        "if (foo) {
+                bar();
+            } else if (baz) {
+                bar();
+            }",
+        "if (foo) {
+                bar();
+            } else if (baz) {
+                bar();
+            } else {
+                bar();
+            }",
+        "if (foo) {
+                bar();
+            } else if (baz) {
+                qux();
+            } else {
+                qux();
+            }",
+        "function unicorn() {
+                if (foo)
+                    return bar();
+                else
+                    return bar();
+            }",
+        "if (foo)
+                bar();
+            else {
+                bar();
+            }",
+        "if (foo)
+                bar();
+            else
+                bar()",
+        "if (foo) {
+                // Comment does not make the branch different.
+                bar();
+            } else {
+                bar();
+            }",
+        "if (foo) {
+                bar(
+                    baz
+                );
+            } else {
+                bar(baz);
+            }",
+        "function unicorn() {
+                if (foo) {
+                    return bar();
+                } else {
+                    return bar()
+                }
+            }",
+        "function unicorn() {
+                if (foo) {
+                    do {
+                        bar();
+                    } while (baz);
+                } else {
+                    do {
+                        bar();
+                    } while (baz)
+                }
+            }",
+        "if (foo) {
+                const bar = value as string;
+                baz(bar);
+            } else {
+                const bar = value as string;
+                baz(bar);
+            }", // {"parser": parsers.typescript},
+        "if (foo) {
+                const bar = value satisfies string;
+                baz(bar!);
+            } else {
+                const bar = value satisfies string;
+                baz(bar!);
+            }", // {"parser": parsers.typescript}
+        // Upstream compares tokens, so it treats this as valid. `ContentEq` ignores
+        // literal spelling, so it is reported here.
+        r#"if (foo) {
+                const value = 'unicorn';
+            } else {
+                const value = "unicorn";
+            }"#,
+    ];
+
+    Tester::new(NoDuplicateIfBranches::NAME, NoDuplicateIfBranches::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_if_branches.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_if_branches.snap
@@ -1,0 +1,207 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:14]
+ 1 │ ╭──▶ if (isAdmin) {
+ 2 │ │                    showDashboard();
+ 3 │ │                    loadStats();
+ 4 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 5 │ │                    showDashboard();
+ 6 │ │                    loadStats();
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    bar();
+ 3 │ ├──▶             } else if (baz) {
+   · ╰───── the previous branch is here
+ 4 │ │                    bar();
+ 5 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    bar();
+ 3 │ ├──▶             } else if (baz) {
+   · ╰───── the previous branch is here
+ 4 │ │                    bar();
+ 5 │ ├──▶             } else {
+   · ╰───── this branch has the same body
+ 6 │                      bar();
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:3:29]
+ 2 │                      bar();
+ 3 │ ╭──▶             } else if (baz) {
+ 4 │ │                    bar();
+ 5 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 6 │ │                    bar();
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:3:29]
+ 2 │                      bar();
+ 3 │ ╭──▶             } else if (baz) {
+ 4 │ │                    qux();
+ 5 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 6 │ │                    qux();
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:3:21]
+ 2 │                 if (foo)
+ 3 │                     return bar();
+   ·                     ──────┬──────
+   ·                           ╰── the previous branch is here
+ 4 │                 else
+ 5 │                     return bar();
+   ·                     ──────┬──────
+   ·                           ╰── this branch has the same body
+ 6 │             }
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:2:17]
+ 1 │     if (foo)
+ 2 │                     bar();
+   ·                     ───┬──
+   ·                        ╰── the previous branch is here
+ 3 │ ╭─▶             else {
+ 4 │ │                   bar();
+ 5 │ ├─▶             }
+   · ╰──── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:2:17]
+ 1 │ if (foo)
+ 2 │                 bar();
+   ·                 ───┬──
+   ·                    ╰── the previous branch is here
+ 3 │             else
+ 4 │                 bar()
+   ·                 ──┬──
+   ·                   ╰── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    // Comment does not make the branch different.
+ 3 │ │                    bar();
+ 4 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 5 │ │                    bar();
+ 6 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    bar(
+ 3 │ │                        baz
+ 4 │ │                    );
+ 5 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 6 │ │                    bar(baz);
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:2:26]
+ 1 │      function unicorn() {
+ 2 │ ╭──▶                 if (foo) {
+ 3 │ │                        return bar();
+ 4 │ ├──▶                 } else {
+   · ╰───── the previous branch is here
+ 5 │ │                        return bar()
+ 6 │ ├──▶                 }
+   · ╰───── this branch has the same body
+ 7 │                  }
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+    ╭─[no_duplicate_if_branches.tsx:2:26]
+  1 │      function unicorn() {
+  2 │ ╭──▶                 if (foo) {
+  3 │ │                        do {
+  4 │ │                            bar();
+  5 │ │                        } while (baz);
+  6 │ ├──▶                 } else {
+    · ╰───── the previous branch is here
+  7 │ │                        do {
+  8 │ │                            bar();
+  9 │ │                        } while (baz)
+ 10 │ ├──▶                 }
+    · ╰───── this branch has the same body
+ 11 │                  }
+    ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    const bar = value as string;
+ 3 │ │                    baz(bar);
+ 4 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 5 │ │                    const bar = value as string;
+ 6 │ │                    baz(bar);
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    const bar = value satisfies string;
+ 3 │ │                    baz(bar!);
+ 4 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 5 │ │                    const bar = value satisfies string;
+ 6 │ │                    baz(bar!);
+ 7 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.
+
+  ⚠ unicorn(no-duplicate-if-branches): This branch has the same body as the previous branch.
+   ╭─[no_duplicate_if_branches.tsx:1:10]
+ 1 │ ╭──▶ if (foo) {
+ 2 │ │                    const value = 'unicorn';
+ 3 │ ├──▶             } else {
+   · ╰───── the previous branch is here
+ 4 │ │                    const value = "unicorn";
+ 5 │ ├──▶             }
+   · ╰───── this branch has the same body
+   ╰────
+  help: Combine the conditions or remove the duplicate branch.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9100,6 +9100,9 @@
         "unicorn/no-document-cookie": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-duplicate-if-branches": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-empty-file": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -576,6 +576,7 @@ unicorn/no-await-in-promise-methods                        |  62606
 unicorn/no-confusing-array-with                            |  62606
 unicorn/no-console-spaces                                  |  62606
 unicorn/no-document-cookie                                 |  13005
+unicorn/no-duplicate-if-branches                           |  13190
 unicorn/no-empty-file                                      |      7
 unicorn/no-hex-escape                                      |  63282
 unicorn/no-immediate-mutation                              |  24802


### PR DESCRIPTION
Part of #684. Ports [`unicorn/no-duplicate-if-branches`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-duplicate-if-branches.md) with all upstream tests.

Upstream compares ESLint token streams, which oxc has no API for, so this compares branch statements with `ContentEq` (as `oxc/branches-sharing-code` does). Two consequences: literal spelling is ignored, so `'a'`/`"a"` and `0x10`/`16` are reported where upstream is silent (that upstream "valid" case is moved to the fail list with a comment), and a `/* @__PURE__ */` annotation makes a call differ, so that pair is not reported.

AI assistance was used to write this PR; every line has been reviewed and the rule was run against the real `oxlint` binary.
