### PR TITLE
refactor(lexer): rename `prev_is_regex` to `not_operator_position`

### DIFF
--- a/crates/oxc_lexer/src/pipeline/carve/common.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/common.rs
@@ -9,7 +9,7 @@ use crate::{
 use super::super::{
     BCOM, LCOM, REGEX, STR,
     bitmap::{bm_clear, bm_clear_range, bm_get, bm_next0, bm_set},
-    disambiguate::prev_is_regex,
+    disambiguate::not_operator_position,
     scan::{scan_block_comment, scan_line_comment, scan_quoted, scan_regex, scan_tmpl_text},
 };
 
@@ -101,7 +101,7 @@ pub(super) unsafe fn lex_slash(
         lex_line_comment(src, srcs, n, st, kind, s, lanes)
     } else if d == b'*' {
         lex_block_comment(src, srcs, n, st, kind, s, lanes)
-    } else if prev_is_regex(t, src, st, kind, word, digit, n, s, ts, lanes.module) {
+    } else if not_operator_position(t, src, st, kind, word, digit, n, s, ts, lanes.module) {
         lex_regex(src, srcs, n, st, kind, word, s, lanes)
     } else if s + 1 < n && *src.add(s + 1) == b'=' {
         // `/=`: absorb the `=`.

--- a/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/carve/jsx/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use super::super::{
     HASHBANG, JEND, JSX_LT, JTEXT, STR, TMPL_HEAD, TMPL_MIDDLE, TMPL_NOSUB, TMPL_TAIL,
     bitmap::{bm_clear, bm_clear_range, bm_set},
-    disambiguate::{bm_prev_sig, prev_is_regex},
+    disambiguate::{bm_prev_sig, not_operator_position},
     find::{
         find_jsx_tag, find_jsx_text, find_line_terminator, find_opener, find_opener_jsx5,
         find_opener_jsx7, find_opener6, find1, find2,
@@ -198,7 +198,7 @@ pub(super) unsafe fn carve_jsx(
                         } else if c1 == b'=' || is_digit(c1) {
                             // `<=` / `a<5`: leave for coalesce.
                             i = s + 1;
-                        } else if prev_is_regex(
+                        } else if not_operator_position(
                             t,
                             src,
                             st,

--- a/crates/oxc_lexer/src/pipeline/disambiguate/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/disambiguate/mod.rs
@@ -358,7 +358,7 @@ unsafe fn lt_in_range(src: *const u8, a: usize, b: usize) -> bool {
 }
 
 /// Is the token at `pos` in operand (expression-only) position? Strict
-/// whitelist; anything else returns false. Deliberately not `prev_is_regex`:
+/// whitelist; anything else returns false. Deliberately not `not_operator_position`:
 /// a regex may follow `;`/`:`/`else`, but a `{` there is a block, so reusing
 /// it would be unsound. Complement of acorn's `braceIsBlock`.
 #[inline]
@@ -4993,7 +4993,32 @@ unsafe fn type_args_head_before(
     bk >= OP_KIND_BASE && matches!(*src.add(bw), b')' | b']')
 }
 
-pub(super) unsafe fn prev_is_regex(
+/// Check if `p` is a position where an operator cannot go.
+///
+/// Operator position is directly after a complete value, e.g. after `a`, `f(x)`, or `a[0]`.
+/// Anywhere else, an operator can't go, and something must start instead:
+///
+/// - An expression e.g. `x = /re/`, `x = <Foo />`.
+/// - A statement e.g. `if (c) /re/.test(s)`, `if (c) <Foo />`.
+/// - In TypeScript, a type e.g. `let f: <T>(x: T) => T`.
+///
+/// Returns `true` if `p` is not in operator position, `false` if it is.
+///
+/// Callers use this to decide:
+///
+/// - `/` starts a regex if `true`, or is a division operator (`/` or `/=`) if `false`.
+/// - `<` may start a JSX element if `true`, or is a less-than operator if `false`.
+///   In TS, a `<` in operator position can also open type arguments e.g. `f<T>()`.
+///
+/// This is a looser test than [`operand_position`], which checks whether *only*
+/// an expression can start at a position.
+///
+/// The two differ where a statement can start, e.g. after `;` or `else`, or at the start of the file.
+/// A `/` there starts a regex, so this function returns `true`.
+/// But a `{` there opens a block, not an object literal, so `operand_position` returns `false`.
+///
+/// [`operand_position`]: operand_position
+pub(super) unsafe fn not_operator_position(
     t: &Tables,
     src: *const u8,
     st: *const u64,

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -57,7 +57,7 @@ pub(crate) const PRIV_IDENT_ESC: u8 = TokenKind::PrivateIdentEscaped as u8;
 pub(crate) const EOF: u8 = TokenKind::Eof as u8;
 
 // JSX coarse kinds, written only by `carve_jsx`. `JEND`/`JSX_LT` read as
-// values in `prev_is_regex` (after a completed element, `/` is division).
+// values in `not_operator_position` (after a completed element, `/` is division).
 pub(crate) const JTEXT: u8 = TokenKind::JsxText as u8;
 pub(crate) const JEND: u8 = TokenKind::JsxTagEnd as u8;
 pub(crate) const JSX_LT: u8 = TokenKind::JsxLt as u8;


### PR DESCRIPTION
Pure refactor. Just renaming.

`prev_is_regex` is used for 2 different purposes:

1. Deciding if a `/` is a division operator or start of a regex.
2. Deciding if a `<` in a JSX/TSX file could start a JSX element, or is a less-than operator.

The name `prev_is_regex` accurately describes the first, but not the 2nd.

Both purposes rest on the same question: is this position directly after a complete value, where an operator would go? So rename it to `not_operator_position`.

Note that this is subtlely different from another existing function `operand_position` (oper*and* not oper*ator*) - the difference is explained in the doc comments on both functions.

Naming is hard, and the negative name is not ideal.

All my changes to `oxc_lexer` at this stage are pure refactor in the strictest sense, and I want to keep to that principle. `operator_position` would be a better name, but that'd switch the "polarity" of the return value (`true` where current `prev_is_regex` returns `false`, and vice-versa) which could affect branch layout. So `not_operator_position` is a "best I can do for now" solution. There's a lot of other things in the crate which could be more clearly named, so renaming this one again is left to a later batch of work.

One thing I think is for sure: `prev_is_regex` was _not_ the right name, so even if the new name isn't perfect, IMO it's an improvement.