### PR TITLE
fix(linter/eslint/no-unused-vars): respect rest params after-used option

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -300,8 +300,10 @@ impl NoUnusedVars {
             return false;
         };
 
-        // This is the last parameter, so need to check for usages on following parameters
-        if position == params.items.len() - 1 {
+        // If this is the last parameter in `items` and there is no rest
+        // parameter, there are no following parameters to check, so this
+        // parameter is not allowed (it will be reported).
+        if position == params.items.len() - 1 && params.rest.is_none() {
             return false;
         }
 
@@ -315,6 +317,13 @@ impl NoUnusedVars {
             // no need to check if param is in a constructor, because if it's
             // not that's a parse error.
             .any(|p| p.has_modifier() || p.pattern.has_any_used_binding(ctx))
+            // A rest parameter, if present, is always the last parameter.
+            // If it has a used binding, parameters before it are allowed under
+            // `after-used` (they occur before the last used argument).
+            || params
+                .rest
+                .as_ref()
+                .is_some_and(|rest| rest.rest.argument.has_any_used_binding(ctx))
     }
 
     /// The following allowed conditions are handled:

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1159,6 +1159,12 @@ fn test_arguments() {
             "function foo(a, ...args: unknown[]) { return a } foo()",
             Some(json!([{ "args": "none" }])),
         ),
+        // https://github.com/oxc-project/oxc/issues/26562
+        // `after-used`: params before a used rest parameter are allowed
+        (
+            "function foo(unusedBeforeRest: string, ...usedRest: string[]) { console.log(usedRest); } foo('x', 'y');",
+            Some(json!([{ "args": "after-used" }])),
+        ),
     ];
     let fail = vec![
         ("function foo(a) {} foo()", None),


### PR DESCRIPTION
Fix: `no-unused-vars` with `args: after-used` incorrectly flagged normal parameters preceding a used rest parameter as unused. Rest params are stored in `FormalParameters.rest` (not `items`), so the last-param check and the following-params scan both missed them.

Closes #26562

AI-assisted; human-reviewed. Agent-Owner:sera