### PR TITLE
fix(linter/eslint/no-unused-vars): preserve ambient implicit exports

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -119,7 +119,6 @@ fn has_explicit_exports(block: &TSModuleBlock) -> bool {
             stmt,
             Statement::ExportAllDeclaration(_)
                 | Statement::ExportDefaultDeclaration(_)
-                | Statement::ExportDeclaration(_)
                 | Statement::ExportNamedDeclaration(_)
                 | Statement::ExportFromDeclaration(_)
                 | Statement::TSExportAssignment(_)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -2257,3 +2257,66 @@ fn test_autofixer_imports() {
         .expect_fix(fix)
         .test();
 }
+
+#[test]
+fn test_ambient_export_modifiers() {
+    let pass = vec![
+        (
+            r#"
+            export {};
+            declare module 'some-package' {
+                interface ImplicitlyExportedInterface { addedProperty?: string; }
+                export interface ExplicitlyExportedInterface { otherProperty?: string; }
+            }
+            "#,
+            None,
+        ),
+        (
+            r#"
+            export {};
+            declare module 'some-package' {
+                interface ImplicitlyExportedInterface { addedProperty?: string; }
+            }
+            "#,
+            None,
+        ),
+        (
+            r#"
+            export {};
+            declare namespace NS {
+                interface ImplicitlyExportedInterface { addedProperty?: string; }
+                export interface ExplicitlyExportedInterface { otherProperty?: string; }
+            }
+            "#,
+            None,
+        ),
+    ];
+    let fail = vec![
+        (
+            r#"
+            export {};
+            declare module 'some-package' {
+                interface ImplicitlyExportedInterface { addedProperty?: string; }
+                export {};
+            }
+            "#,
+            None,
+        ),
+        (
+            r#"
+            export {};
+            declare module 'some-package' {
+                interface ImplicitlyExportedInterface { addedProperty?: string; }
+                export = Assigned;
+            }
+            declare const Assigned: unknown;
+            "#,
+            None,
+        ),
+        ("interface LocalUnused {}", None),
+    ];
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
+        .intentionally_allow_no_fix_tests()
+        .change_rule_path_extension("ts")
+        .test();
+}


### PR DESCRIPTION
## Summary

An export-modified declaration such as `export interface` incorrectly disabled implicit exports for other declarations in an ambient module or namespace. `no-unused-vars` then reported an implicitly exported interface as unused.

Exclude export-modified declarations from the explicit-export check, matching TypeScript's ambient export context. Explicit export statements such as `export {}` and `export =` retain their existing behavior.

Fixes #26563.

## Validation

- Native issue reproduction: one false-positive diagnostic before the fix, zero afterward; six control cases preserved.
- `oxc_linter` library suite: 1,261 passed, 1 ignored.
- Workspace tests, all-target checks, lint, formatting, lint generation, documentation, and AST generation passed across the recorded runs. Type-aware tests used the required `tsgolint` runtime; AST generation used the matching JavaScript dependencies.

[Weco baseline and candidate trajectory](https://dashboard.weco.ai/share/bjRocD7aMy4GsduISkK71lC0-iGfGQr0).

AI assistance was used for implementation and review.
