### PR TITLE
fix(linter/typescript/prefer-for-of): handle computed collections

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -147,7 +147,7 @@ impl Rule for PreferForOf {
             return;
         }
 
-        let (array_name, array_expr) = {
+        let array_expr = {
             let Some(mem_expr) = test_expr.right.as_member_expression() else {
                 return;
             };
@@ -157,18 +157,13 @@ impl Rule for PreferForOf {
             }
 
             let array_expr = mem_expr.object();
-            let array_name = match mem_expr.object() {
-                Expression::Identifier(id) => id.name.as_str(),
-                expr @ match_member_expression!(Expression) => {
-                    match expr.to_member_expression().static_property_name() {
-                        Some(array_name) => array_name,
-                        None => return,
-                    }
-                }
-                _ => return,
-            };
+            if !matches!(array_expr, Expression::Identifier(_))
+                && !matches!(array_expr, match_member_expression!(Expression))
+            {
+                return;
+            }
 
-            (array_name, array_expr)
+            array_expr
         };
 
         let Some(update_expr) = &for_stmt.update else {
@@ -180,11 +175,16 @@ impl Rule for PreferForOf {
 
         let nodes = ctx.nodes();
         let body_span = for_stmt.body.span();
+        let array_span = array_expr.span();
 
         if ctx.semantic().symbol_references(var_symbol_id).any(|reference| {
             let ref_id = reference.node_id();
 
             let symbol_span = nodes.get_node(ref_id).kind().span();
+            // A for-of loop evaluates its collection only once, so it cannot depend on the index.
+            if array_span.contains_inclusive(symbol_span) {
+                return true;
+            }
             if !body_span.contains_inclusive(symbol_span) {
                 return false;
             }
@@ -198,7 +198,7 @@ impl Rule for PreferForOf {
             }
 
             // Check if arr[i] usage prevents for-of conversion
-            if prevents_for_of_array_access(parent, grand_parent, array_name, nodes) {
+            if prevents_for_of_array_access(parent, grand_parent, nodes) {
                 return true;
             }
 
@@ -230,21 +230,8 @@ fn prevents_for_of_conversion_direct_usage(grand_parent: &AstNode, parent: &AstN
 fn prevents_for_of_array_access(
     parent: &AstNode,
     grand_parent: &AstNode,
-    array_name: &str,
     nodes: &oxc_semantic::AstNodes,
 ) -> bool {
-    let Some(mem_expr) = parent.kind().as_member_expression_kind() else {
-        return false;
-    };
-
-    let Expression::Identifier(id) = mem_expr.object() else {
-        return false;
-    };
-
-    if id.name.as_str() != array_name {
-        return false;
-    }
-
     // Check for direct assignment: arr[i] = value
     if let AstKind::AssignmentExpression(assign_expr) = grand_parent.kind()
         && assign_expr.left.span() == parent.span()
@@ -382,6 +369,20 @@ fn test() {
          for (let i = 0; i < obj1.a.b.length; i++) {
              console.log(obj2.a.b[i]); // Different object
          }",
+        "for (let i = 0; i < this.values[key].length; i++) { console.log(this.values[other][i]); }",
+        "for (let i = 0; i < this.values[key].length; i++) { console.log(other.values[key][i]); }",
+        "for (let i = 0; i < this.values[key].length; i++) { console.log(i); }",
+        "for (let i = 0; i < this.values[key].length; i++) { this.values[key][i] = 0; }",
+        "for (let i = 0; i < this.values[key].length; i++) { this.values[key][i]++; }",
+        "for (let i = 0; i < this.values[key].length; i++) { delete this.values[key][i]; }",
+        "for (let i = 0; i < this.values[key].length; i++) { [this.values[key][i]] = [0]; }",
+        "for (let i = 0; i < this.values[key].length; i++) { [...this.values[key][i]] = []; }",
+        "class Example { #values = []; print(key) { for (let i = 0; i < this[key].length; i++) { console.log(this.#values[i]); } } }",
+        "class Example { #values = []; print(key) { for (let i = 0; i < this.#values.length; i++) { console.log(this[key][i]); } } }",
+        "class Example { #values = []; #other = []; print() { for (let i = 0; i < this.#values.length; i++) { console.log(this.#other[i]); } } }",
+        "for (let i = 0; i < arrays[i].length; i++) {}",
+        "for (let i = 0; i < arrays[i + 1].length; i++) { console.log('item'); }",
+        "for (let i = 0; i < arrays[i].values.length; i++) {}",
     ];
 
     let fail = vec![
@@ -422,6 +423,18 @@ fn test() {
          for (let i = 0; i < obj.a.b.length; i++) {
              console.log(obj.a.b[i]); // Same nested array
          }",
+        "class Example {
+            private readonly values: Record<string, number[]> = {};
+
+            print(key: string) {
+                for (let index = 0; index < this.values[key].length; index++) {
+                    console.log(this.values[key][index]);
+                }
+            }
+        }",
+        "for (let i = 0; i < values[key].length; i++) { console.log(values[key][i]); }",
+        "for (let i = 0; i < this.values[key].length; i++) { [obj[this.values[key][i]]] = [0]; }",
+        "class Example { #values = []; print() { for (let i = 0; i < this.#values.length; i++) { console.log(this.#values[i]); } } }",
     ];
 
     Tester::new(PreferForOf::NAME, PreferForOf::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_for_of.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_for_of.snap
@@ -204,3 +204,33 @@ source: crates/oxc_linter/src/tester.rs
  3 │              console.log(obj.a.b[i]); // Same nested array
    ╰────
   help: Consider using a `for...of` loop for this simple iteration.
+
+  ⚠ typescript(prefer-for-of): Expected a `for...of` loop instead of a `for` loop with this simple iteration.
+   ╭─[prefer_for_of.tsx:5:22]
+ 4 │             print(key: string) {
+ 5 │                 for (let index = 0; index < this.values[key].length; index++) {
+   ·                      ───────────────────────────────────────────────────────
+ 6 │                     console.log(this.values[key][index]);
+   ╰────
+  help: Consider using a `for...of` loop for this simple iteration.
+
+  ⚠ typescript(prefer-for-of): Expected a `for...of` loop instead of a `for` loop with this simple iteration.
+   ╭─[prefer_for_of.tsx:1:6]
+ 1 │ for (let i = 0; i < values[key].length; i++) { console.log(values[key][i]); }
+   ·      ──────────────────────────────────────
+   ╰────
+  help: Consider using a `for...of` loop for this simple iteration.
+
+  ⚠ typescript(prefer-for-of): Expected a `for...of` loop instead of a `for` loop with this simple iteration.
+   ╭─[prefer_for_of.tsx:1:6]
+ 1 │ for (let i = 0; i < this.values[key].length; i++) { [obj[this.values[key][i]]] = [0]; }
+   ·      ───────────────────────────────────────────
+   ╰────
+  help: Consider using a `for...of` loop for this simple iteration.
+
+  ⚠ typescript(prefer-for-of): Expected a `for...of` loop instead of a `for` loop with this simple iteration.
+   ╭─[prefer_for_of.tsx:1:46]
+ 1 │ class Example { #values = []; print() { for (let i = 0; i < this.#values.length; i++) { console.log(this.#values[i]); } } }
+   ·                                              ───────────────────────────────────────
+   ╰────
+  help: Consider using a `for...of` loop for this simple iteration.

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -375,16 +375,18 @@ pub fn is_same_member_expression(
         (Some(_), None) | (None, Some(_)) => {
             return false;
         }
-        (None, None) => {
-            if let (
+        (None, None) => match (left, right) {
+            (
                 MemberExpression::PrivateFieldExpression(left),
                 MemberExpression::PrivateFieldExpression(right),
-            ) = (left, right)
-            {
+            ) => {
                 return left.field.name == right.field.name
                     && is_same_expression(&left.object, &right.object, ctx);
             }
-        }
+            (MemberExpression::PrivateFieldExpression(_), _)
+            | (_, MemberExpression::PrivateFieldExpression(_)) => return false,
+            _ => {}
+        },
     }
 
     if let (


### PR DESCRIPTION
Report `prefer-for-of` for loops over computed collections such as `this.values[key]`, matching typescript-eslint. Compare the full collection expression and retain the checks that exclude element writes and uses of different collections.

Also distinguish private fields from computed properties in the shared expression comparison, so `this.#values` cannot match `this[key]`. Adds regression coverage for computed collections, mutations, and private fields.

Fixes #26565
