### PR TITLE
fix(linter/typescript): mark `no-unnecessary-type-parameters` and `prefer-find` suggestions as implemented

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_parameters.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_parameters.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeParameters(tsgolint),
     typescript,
     suspicious,
-    pending,
+    suggestion,
     version = "1.49.0",
     short_description = "Disallow type parameters that are declared but not meaningfully used.",
 );

--- a/crates/oxc_linter/src/rules/typescript/prefer_find.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_find.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     PreferFind(tsgolint),
     typescript,
     style,
-    pending,
+    suggestion,
     version = "1.49.0",
     short_description = "Prefer `.find(...)` over `.filter(...)[0]` for retrieving a single element.",
 );


### PR DESCRIPTION
made a mistake in #24956, suggestions for these 2 rules were already implemented in tsgolint, so I should have added `suggestion`, not `pending` 