### PR TITLE
fix(react-compiler): preserve BigInt literals in compiled output

### DIFF
--- a/crates/oxc_react_compiler/fixtures/bigint-literal.js
+++ b/crates/oxc_react_compiler/fixtures/bigint-literal.js
@@ -1,0 +1,27 @@
+function Component(props) {
+  const a = 1n;
+  const b = 100n;
+  const c = 0n;
+  const d = 0x1fn;
+  const msg = `Value is ${10n}`;
+  const isZero = 0n ? 'yes' : 'no';
+  const isOne = 1n ? 'yes' : 'no';
+  const eq = 10n === 10n;
+  return (
+    <div>
+      {String(a)}
+      {String(b)}
+      {String(c)}
+      {String(d)}
+      {msg}
+      {isZero}
+      {isOne}
+      {eq ? 'equal' : 'not-equal'}
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -26,7 +26,7 @@ use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;
 use oxc_str::{Ident, Str};
-use oxc_syntax::number::ToJsString;
+use oxc_syntax::number::{BigintBase, ToJsString};
 pub use raw::RawTypeCategory;
 pub use reactive::*;
 
@@ -963,6 +963,7 @@ pub enum PrimitiveValue<'a> {
     Boolean(bool),
     Number(FloatValue),
     String(Str<'a>),
+    BigInt { value: Str<'a>, raw: Option<Str<'a>>, base: BigintBase },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -3587,6 +3587,10 @@ fn lower_expression<'a>(
             value: PrimitiveValue::String(lit.value),
             span: Some(lit.span),
         }),
+        oxc::Expression::BigIntLiteral(lit) => Ok(InstructionValue::Primitive {
+            value: PrimitiveValue::BigInt { value: lit.value, raw: lit.raw, base: lit.base },
+            span: Some(lit.span),
+        }),
         oxc::Expression::RegExpLiteral(regexp) => Ok(InstructionValue::RegExpLiteral {
             pattern: regexp.regex.pattern.text,
             flags: Str::from_str_in(
@@ -4282,11 +4286,6 @@ fn lower_expression<'a>(
         ),
         oxc::Expression::AssignmentExpression(assign) => {
             lower_assignment_expression(builder, assign)
-        }
-        _ => {
-            // not-yet-ported arms bail to undefined (differential green-set grows as arms land)
-            let span = Some(expr.span());
-            Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, span })
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -331,7 +331,8 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Null
                     | PrimitiveValue::Undefined
                     | PrimitiveValue::Boolean(_)
-                    | PrimitiveValue::String(_) => {}
+                    | PrimitiveValue::String(_)
+                    | PrimitiveValue::BigInt { .. } => {}
                 }
             }
             None
@@ -375,7 +376,8 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Null
                     | PrimitiveValue::Undefined
                     | PrimitiveValue::Boolean(_)
-                    | PrimitiveValue::String(_) => {}
+                    | PrimitiveValue::String(_)
+                    | PrimitiveValue::BigInt { .. } => {}
                 }
             }
             None
@@ -546,6 +548,7 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Boolean(b) => b.to_string(),
                     PrimitiveValue::Number(n) => n.value().to_js_string(),
                     PrimitiveValue::String(s) => s.as_str().to_string(),
+                    PrimitiveValue::BigInt { value, .. } => value.as_str().to_string(),
                     // TS rejects undefined subexpression values
                     PrimitiveValue::Undefined => return None,
                 };
@@ -689,6 +692,7 @@ fn is_truthy(value: &PrimitiveValue) -> bool {
             v != 0.0 && !v.is_nan()
         }
         PrimitiveValue::String(s) => !s.as_str().is_empty(),
+        PrimitiveValue::BigInt { value, .. } => value.as_str() != "0" && !value.as_str().is_empty(),
     }
 }
 
@@ -837,6 +841,9 @@ fn js_strict_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
             av == bv
         }
         (PrimitiveValue::String(a), PrimitiveValue::String(b)) => a == b,
+        (PrimitiveValue::BigInt { value: a, .. }, PrimitiveValue::BigInt { value: b, .. }) => {
+            a == b
+        }
         // Different types => false
         _ => false,
     }
@@ -858,6 +865,9 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
             av == bv
         }
         (PrimitiveValue::String(a), PrimitiveValue::String(b)) => a == b,
+        (PrimitiveValue::BigInt { value: a, .. }, PrimitiveValue::BigInt { value: b, .. }) => {
+            a == b
+        }
         // Cross-type coercions for primitives
         (PrimitiveValue::Number(n), PrimitiveValue::String(s))
         | (PrimitiveValue::String(s), PrimitiveValue::Number(n)) => {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -3616,6 +3616,15 @@ fn ox_codegen_primitive_value<'a>(
         PrimitiveValue::String(s) => {
             oxc_ast::ast::Expression::new_string_literal(span, ox_str(ast, s.as_str()), None, ast)
         }
+        PrimitiveValue::BigInt { value, raw, base } => {
+            oxc_ast::ast::Expression::new_big_int_literal(
+                span,
+                ox_str(ast, value.as_str()),
+                raw.as_ref().map(|r| oxc_str::Str::from(ox_str(ast, r.as_str()))),
+                *base,
+                ast,
+            )
+        }
         PrimitiveValue::Null => oxc_ast::ast::Expression::new_null_literal(span, ast),
         PrimitiveValue::Undefined => {
             oxc_ast::ast::Expression::new_identifier(span, "undefined", ast)

--- a/crates/oxc_react_compiler/tests/snapshots/bigint-literal.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/bigint-literal.snap
@@ -1,0 +1,22 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/bigint-literal.js
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(1);
+	const isZero = 0n ? "yes" : "no";
+	const isOne = 1n ? "yes" : "no";
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <div>{String(1n)}{String(100n)}{String(0n)}{String(31n)}{"Value is 10"}{isZero}{isOne}{true ? "equal" : "not-equal"}</div>;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{}]
+};


### PR DESCRIPTION
### Summary

Fixes #26161.

In `crates/oxc_react_compiler`, `lower_expression` did not match `oxc::Expression::BigIntLiteral`. Because of the missing arm, BigInt literals (such as `1n`, `100n`, `0n`) fell through to the unported fallback arm and were lowered to `InstructionValue::Primitive { value: PrimitiveValue::Undefined, span }`. As a result, code like `<div>{String(1n)}</div>` was incorrectly transformed to `<div>{String(undefined)}</div>`.

### Changes

1. **`react_compiler_hir`**:
   - Added `PrimitiveValue::BigInt { value: Str<'a>, raw: Option<Str<'a>>, base: BigintBase }`.
   - Derives `Debug, Clone, Copy, PartialEq, Eq, Hash`.

2. **`react_compiler_lowering/build_hir.rs`**:
   - Added `oxc::Expression::BigIntLiteral(lit)` match arm in `lower_expression`, lowering AST BigInt literals to `PrimitiveValue::BigInt`.
   - Removed unreachable `_ =>` wildcard arm from `lower_expression` so that `match expr` is now completely exhaustive across all `oxc::Expression` AST variants.

3. **`react_compiler_reactive_scopes/codegen_reactive_function.rs`**:
   - Added `PrimitiveValue::BigInt` arm in `ox_codegen_primitive_value`, reconstructing `oxc_ast::ast::Expression::new_big_int_literal` preserving value, raw representation, and base.

4. **`react_compiler_optimization/constant_propagation.rs`**:
   - Handled BigInt truthiness in `is_truthy` (`value.as_str() != "0" && !value.as_str().is_empty()`).
   - Added BigInt equality in `js_strict_equal` and `js_abstract_equal`.
   - Supported BigInt interpolation in template literal constant propagation.
   - Handled BigInt in property load/store pattern matches.

5. **Tests**:
   - Added `crates/oxc_react_compiler/fixtures/bigint-literal.js` and verified golden snapshot in `bigint-literal.snap`.

### Verification

- `cargo fmt --check` passes cleanly.
- `cargo clippy -p oxc_react_compiler -- -D warnings` passes with 0 warnings.
- `cargo test -p oxc_react_compiler` passes all 44 unit, snapshot, and transform tests.
