### PR TITLE
test(oxlint): add no js runtime diagnostic test

### DIFF
--- a/apps/oxlint/fixtures/cli/no_js_runtime/oxlint.config.ts
+++ b/apps/oxlint/fixtures/cli/no_js_runtime/oxlint.config.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/apps/oxlint/fixtures/cli/no_js_runtime/test.js
+++ b/apps/oxlint/fixtures/cli/no_js_runtime/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -2062,6 +2062,12 @@ export { redundant };
             .with_cwd("fixtures/cli/invalid_config_tuple_rules".into())
             .test_and_snapshot(&[]);
     }
+
+    #[test]
+    fn test_no_js_runtime() {
+        let args = &[];
+        Tester::new().with_cwd("fixtures/cli/no_js_runtime".into()).test_and_snapshot(args);
+    }
 }
 
 #[cfg(test)]

--- a/apps/oxlint/src/snapshots/fixtures__cli__no_js_runtime_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__no_js_runtime_@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/cli/no_js_runtime
+----------
+Failed to parse oxlint configuration file.
+
+  x JavaScript/TypeScript config file (<cwd>/fixtures/cli/no_js_runtime/oxlint.config.ts) found but JS runtime not available.
+  help: Run oxlint via the npm package, or use JSON config files (.oxlintrc.json or .oxlintrc.jsonc).
+
+----------
+CLI result: InvalidOptionConfig
+----------


### PR DESCRIPTION
While working on https://github.com/oxc-project/oxc/pull/26567, I was not sure if the diagnostic was really used.
Could not find a test, so added it.