### PR TITLE
fix(react-compiler): preserve outer lexical captures in outlined functions

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2852,9 +2852,9 @@ fn ox_transform_program<'a>(
     //     original function (Babel `insertAfter`), however deeply nested it is.
     //   - (Arrow)FunctionExpression originals: appended at the end of the program
     //     body (Babel `pushContainer('body', ...)`), since inserting as a sibling
-    //     would corrupt the parent expression. For a nested original this can hoist
-    //     the outlined function past bindings it references — upstream has the same
-    //     behavior, so we reproduce it rather than diverge.
+    //     would corrupt the parent expression. Candidates whose HIR references
+    //     an outer lexical binding are kept inline for these roots, so this
+    //     placement cannot hoist them past the binding they reference.
     let mut appended_outlined_decls: Vec<Statement<'a>> = Vec::new();
 
     // Substitute every non-gated compiled function into its original in a single

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -132,6 +132,12 @@ pub struct Environment<'a> {
     // Output mode (Client, Ssr, Lint)
     pub output_mode: OutputMode,
 
+    // Whether the original function can receive outlined siblings without
+    // escaping its lexical scope. Function declarations are inserted after
+    // their source declaration; expression and arrow roots are appended to
+    // the program body.
+    pub allow_outer_lexical_outlining: bool,
+
     // Pre-resolved import local names for instrumentation/hook guards/memo cache.
     // Set by the program-level code before compilation.
     pub instrument_fn_name: Option<Ident<'a>>,
@@ -248,6 +254,7 @@ impl<'a> Environment<'a> {
             skip_compilation: false,
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
+            allow_outer_lexical_outlining: false,
             instrument_fn_name: None,
             instrument_gating_name: None,
             hook_guard_name: None,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -196,6 +196,9 @@ pub struct HirFunction<'a> {
     pub params: ArenaVec<'a, ParamPattern>,
     pub returns: Place,
     pub context: ArenaVec<'a, Place>,
+    /// Whether this function references a binding in an enclosing function
+    /// outside the compiled-function boundary.
+    pub has_outer_lexical_reference: bool,
     pub body: HIR<'a>,
     pub instructions: ArenaVec<'a, Instruction<'a>>,
     pub generator: bool,
@@ -1558,6 +1561,7 @@ impl<'a> CloneIn<'a> for HirFunction<'a> {
             params: self.params.clone_in_impl(sem, alloc),
             returns: self.returns,
             context: self.context.clone_in_impl(sem, alloc),
+            has_outer_lexical_reference: self.has_outer_lexical_reference,
             body: self.body.clone_in_impl(sem, alloc),
             instructions: self.instructions.clone_in_impl(sem, alloc),
             generator: self.generator,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -541,6 +541,15 @@ pub fn lower<'a>(
     // Note: `id` param may include inferred names (e.g., from `const Foo = () => {}`),
     // but the HIR function's `id` field should only include the function's own AST id
     // (FunctionDeclaration.id or FunctionExpression.id, NOT arrow functions).
+    // Outlined declarations are inserted as siblings of a declaration root,
+    // so references to bindings in the containing lexical scope remain valid.
+    // Arrow and function-expression roots are appended to the program body and
+    // must keep any such function inline.
+    env.allow_outer_lexical_outlining = match func {
+        FunctionNode::Function(f) => f.is_declaration(),
+        FunctionNode::Arrow(_) => false,
+    };
+
     let (params, body, generator, is_async, span, ast_id, ast_id_span) = match func {
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("component function has a body");
@@ -812,6 +821,7 @@ fn lower_inner<'a>(
     );
 
     // Build the HIR
+    let has_outer_lexical_reference = builder.has_outer_lexical_reference();
     let (hir_body, instructions, used_names, child_bindings) = builder.build()?;
     let instructions = ArenaVec::from_iter_in(instructions, &env.allocator);
 
@@ -831,6 +841,7 @@ fn lower_inner<'a>(
             params: hir_params,
             returns,
             context,
+            has_outer_lexical_reference,
             body: hir_body,
             instructions,
             generator,
@@ -3175,6 +3186,9 @@ fn lower_function<'a>(
         ident_spans,
     )?;
 
+    if hir_func.has_outer_lexical_reference {
+        builder.note_outer_lexical_reference();
+    }
     builder.merge_used_names(child_used_names);
     builder.merge_bindings(child_bindings);
 
@@ -3237,6 +3251,9 @@ fn lower_function_declaration<'a>(
         ident_spans,
     )?;
 
+    if hir_func.has_outer_lexical_reference {
+        builder.note_outer_lexical_reference();
+    }
     builder.merge_used_names(child_used_names);
     builder.merge_bindings(child_bindings);
 
@@ -3406,6 +3423,9 @@ fn lower_function_for_object_method<'a>(
         ident_spans,
     )?;
 
+    if hir_func.has_outer_lexical_reference {
+        builder.note_outer_lexical_reference();
+    }
     builder.merge_used_names(child_used_names);
     builder.merge_bindings(child_bindings);
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -154,6 +154,10 @@ pub struct HirBuilder<'a, 'b> {
     context_identifiers: rustc_hash::FxHashSet<SymbolId>,
     /// Index mapping identifier byte offsets to source locations and JSX status.
     identifier_spans: &'b IdentifierLocIndex,
+    /// Whether this function references a binding in an enclosing function
+    /// outside the compiled-function boundary. Such a function cannot be
+    /// safely outlined to module scope.
+    has_outer_lexical_reference: bool,
 }
 
 impl<'a, 'b> HirBuilder<'a, 'b> {
@@ -201,6 +205,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             component_scope,
             context_identifiers,
             identifier_spans,
+            has_outer_lexical_reference: false,
         }
     }
 
@@ -274,6 +279,18 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Returns the 'a reference to avoid conflicts with mutable borrows on self.
     pub fn identifier_spans(&self) -> &'b IdentifierLocIndex {
         self.identifier_spans
+    }
+
+    /// Mark this function as depending on an enclosing lexical binding that is
+    /// outside the compiled-function boundary.
+    pub fn note_outer_lexical_reference(&mut self) {
+        self.has_outer_lexical_reference = true;
+    }
+
+    /// Whether this function depends on an enclosing lexical binding outside
+    /// the compiled-function boundary.
+    pub fn has_outer_lexical_reference(&self) -> bool {
+        self.has_outer_lexical_reference
     }
 
     /// Access the bindings map.
@@ -799,6 +816,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                 None => VariableBinding::ModuleLocal { name },
             })
         } else if !self.is_scope_within_compiled_function(symbol_scope) {
+            self.has_outer_lexical_reference = true;
             Ok(VariableBinding::ModuleLocal { name })
         } else {
             let binding_kind = crate::react_compiler_lowering::convert_binding_kind(

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -57,6 +57,8 @@ pub fn outline_functions<'a>(
                     // 2. Anonymous (no explicit id on the inner function)
                     // 3. Not an fbt operand
                     if inner_func.context.is_empty()
+                        && (!inner_func.has_outer_lexical_reference
+                            || env.allow_outer_lexical_outlining)
                         && inner_func.id.is_none()
                         && !fbt_operands.contains(&lvalue_id)
                     {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -459,6 +459,7 @@ fn emit_outlined_fn<'a>(
         params: ArenaVec::from_array_in([ParamPattern::Place(props_obj)], &env.allocator),
         returns: returns_place,
         context: ArenaVec::new_in(&env.allocator),
+        has_outer_lexical_reference: false,
         body: HIR { entry: BlockId::ENTRY, blocks },
         instructions: instr_table,
         generator: false,

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -472,6 +472,7 @@ pub fn placeholder_function<'a>(alloc: &'a Allocator) -> HirFunction<'a> {
             span: None,
         },
         context: ArenaVec::new_in(&alloc),
+        has_outer_lexical_reference: false,
         body: HIR { entry: BlockId::ENTRY, blocks: OrderedMap::default() },
         instructions: ArenaVec::new_in(&alloc),
         generator: false,

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -137,6 +137,91 @@ function createBridge(options, fallback) {
 }
 
 #[test]
+fn keeps_named_factory_capture_lexical_and_outlines_safe_callback() {
+    let source = r#"
+import { useEffect } from "react";
+import { notify } from "./notify";
+
+function createBridge(options) {
+  function useBridge() {
+    useEffect(() => options?.onReady?.(), []);
+    useEffect(() => notify(window.location.href), []);
+  }
+  return useBridge;
+}
+"#;
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(result.changed, "the nested hook declaration should compile: {:?}", result.diagnostics);
+    assert!(!result.diagnostics.has_errors(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+    let semantic = SemanticBuilder::new().build(&program).semantic;
+    assert!(
+        !semantic.scoping().root_unresolved_references().contains_key("options"),
+        "the factory capture must resolve lexically rather than become a root global:\n{output}"
+    );
+
+    assert!(
+        output.contains("options?.onReady?.()"),
+        "the declaration-root callback must retain its factory capture:
+{output}"
+    );
+    assert!(
+        output.contains("useEffect(_temp"),
+        "the capture-free callback should remain safely outlineable:
+{output}"
+    );
+    assert!(
+        output.contains("function _temp()") && output.contains("notify(window.location.href)"),
+        "the safe outlined callback body must be preserved:
+{output}"
+    );
+}
+
+#[test]
+fn keeps_nested_function_expression_capture_inline() {
+    let source = r#"
+import { useEffect } from "react";
+
+function createBridge(options) {
+  const useBridge = function () {
+    useEffect(() => options?.onReady?.(), []);
+  };
+  return useBridge;
+}
+"#;
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(
+        result.changed,
+        "the nested function expression should compile: {:?}",
+        result.diagnostics
+    );
+    assert!(!result.diagnostics.has_errors(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+    let semantic = SemanticBuilder::new().build(&program).semantic;
+    assert!(
+        !semantic.scoping().root_unresolved_references().contains_key("options"),
+        "the factory capture must resolve lexically rather than become a root global:\n{output}"
+    );
+
+    assert!(
+        output.contains("options?.onReady?.()"),
+        "the function-expression callback must retain its factory capture:
+{output}"
+    );
+    assert!(
+        !output.contains("function _temp()"),
+        "the captured callback must stay inline instead of becoming a program-scope binding:
+{output}"
+    );
+}
+
+#[test]
 fn still_outlines_module_and_global_callback_dependencies() {
     let source = r#"
 import { useEffect } from "react";

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -98,6 +98,120 @@ function Component({ onChange, onInput }) {\n\
 }
 
 #[test]
+fn keeps_outer_capture_inline_for_arrow_factory() {
+    let source = r#"
+import { useEffect } from "react";
+
+function createBridge(options, fallback) {
+  const alias = options;
+  const useBridge = () => {
+    useEffect(() => {
+      const sendReadyMessages = () =>
+        options?.onReady?.() ?? alias?.onReady?.() ?? fallback?.onReady?.();
+      sendReadyMessages();
+    }, []);
+  };
+  return { useBridge };
+}
+"#;
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(result.changed, "the hook factory should compile: {:?}", result.diagnostics);
+    assert!(!result.diagnostics.has_errors(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+
+    assert!(
+        output.contains("options?.onReady?.()")
+            && output.contains("alias?.onReady?.()")
+            && output.contains("fallback?.onReady?.()"),
+        "the callback must retain all direct, aliased, and multiple factory captures:
+{output}"
+    );
+    assert!(
+        !output.contains("function _temp()"),
+        "the capturing callback must not be outlined past the arrow hook:
+{output}"
+    );
+}
+
+#[test]
+fn still_outlines_module_and_global_callback_dependencies() {
+    let source = r#"
+import { useEffect } from "react";
+import { notify } from "./notify";
+
+const useBridge = function () {
+  useEffect(() => {
+    notify(window.location.href);
+  }, []);
+};
+"#;
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(result.changed, "the function expression should compile: {:?}", result.diagnostics);
+    assert!(!result.diagnostics.has_errors(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+
+    assert!(
+        output.contains("useEffect(_temp"),
+        "a callback using only module/global bindings should remain outlineable:
+{output}"
+    );
+    assert!(
+        output.contains("function _temp()"),
+        "expected the outline declaration for the capture-free callback:
+{output}"
+    );
+    assert!(
+        output.contains("notify(window.location.href)"),
+        "callback body was lost:
+{output}"
+    );
+}
+
+#[test]
+fn keeps_outer_capture_inline_through_object_method() {
+    let source = r#"
+import { useEffect } from "react";
+
+function createBridge(options) {
+  const useBridge = () => {
+    const bridge = {
+      subscribe() {
+        return () => options?.onReady?.();
+      },
+    };
+    useEffect(() => bridge.subscribe()(), []);
+    return bridge;
+  };
+  return useBridge;
+}
+"#;
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(result.changed, "the hook factory should compile: {:?}", result.diagnostics);
+    assert!(!result.diagnostics.has_errors(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+
+    assert!(
+        output.contains("options?.onReady?.()"),
+        "the object-method callback must retain its factory capture:
+{output}"
+    );
+    assert!(
+        !output.contains("function _temp()"),
+        "the object-method callback must not be outlined past the arrow root:
+{output}"
+    );
+}
+
+#[test]
 fn preserves_manual_memoization_guarantees() {
     let source = "\
 import { useCallback, useMemo } from 'react';


### PR DESCRIPTION
Fixes #26519.

When function outlining is enabled, a callback returned by a factory can be moved to module scope even though it reads the factory's options. The generated application then raises `ReferenceError: options is not defined` before reaching `CHART_READY`.

This change tracks references outside the outlined function's lexical scope and keeps the affected callback inline when outlining would move it beyond the factory's scope. Safe module/global cases and function-declaration outlining remain available.

Validation:

- On the current base, the enabled browser arm reproduces the `options is not defined` failure while the disabled arm reaches `CHART_READY`.
- On the candidate, both enabled and disabled browser arms exit successfully, return HTTP 200, reach `CHART_READY`, and report no page errors. The frozen fixture files remain unchanged.
- The focused transform suite passes 30 tests with 0 failures. The full Rust test stage passes 4,874 tests with 0 failures and 162 ignored.
- The repository's required readiness checks pass on the clean candidate, including formatting, lint generation, workspace checks, documentation, and AST generation. The optional `cargo shear` check was unavailable and is not claimed as run.

AI tools were used for implementation and evaluation preparation, with Luna authoring the change and Astra coordinating the evaluation. The code and results were separately reviewed against the repository source and validation receipts.

This is a correctness fix; no performance improvement is claimed.

[Evaluation trajectory](https://dashboard.weco.ai/share/FzKcv7ky8QeJM28LP30RuFXFrEPJrKI-)

